### PR TITLE
Ignore multi-clause conditions when optimizing

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -50,8 +50,8 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.4.0")]
-[assembly: AssemblyFileVersion("1.5.4.0")]
-[assembly: AssemblyInformationalVersion("26 Jan 2019")]
+[assembly: AssemblyVersion("1.5.5.0")]
+[assembly: AssemblyFileVersion("1.5.5.0")]
+[assembly: AssemblyInformationalVersion("26 Feb 2019")]
 
 [assembly: InternalsVisibleTo("RATools.Test")]

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -366,13 +366,14 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x001234) != 3 && byte(0x001234) == 2", "byte(0x001234) == 2")] // =2 is implicitly !=3
         [TestCase("byte(0x001234) == 3 && byte(0x001234) != 2", "byte(0x001234) == 3")] // =3 is implicitly !=2
         [TestCase("byte(0x001234) == 3 && byte(0x001234) == 3", "byte(0x001234) == 3")] // redundant
-        [TestCase("byte(0x001234) == 3 && byte(0x001234) == 2", "")] // cannot both be true
-        [TestCase("byte(0x001234) > 3 && byte(0x001234) < 2", "")] // cannot both be true
-        [TestCase("byte(0x001234) > 2 && byte(0x001234) < 2", "")] // cannot both be true
-        [TestCase("byte(0x001234) < 2 && byte(0x001234) > 2", "")] // cannot both be true
-        [TestCase("byte(0x001234) < 2 && byte(0x001234) > 3", "")] // cannot both be true
-        [TestCase("byte(0x001234) >= 3 && byte(0x001234) <= 2", "")] // cannot both be true
-        [TestCase("byte(0x001234) <= 2 && byte(0x001234) >= 3", "")] // cannot both be true
+        [TestCase("byte(0x001234) > 3 && byte(0x001234) < 2", "0 == 1")] // cannot both be true
+        [TestCase("byte(0x001234) > 2 && byte(0x001234) < 2", "0 == 1")] // cannot both be true
+        [TestCase("byte(0x001234) < 2 && byte(0x001234) > 2", "0 == 1")] // cannot both be true
+        [TestCase("byte(0x001234) < 2 && byte(0x001234) > 3", "0 == 1")] // cannot both be true
+        [TestCase("byte(0x001234) >= 3 && byte(0x001234) <= 2", "0 == 1")] // cannot both be true
+        [TestCase("byte(0x001234) <= 2 && byte(0x001234) >= 3", "0 == 1")] // cannot both be true
+        [TestCase("byte(0x001234) == 3 && byte(0x001234) == 2", "0 == 1")] // cannot both be true
+        [TestCase("byte(0x001234) - prev(byte(0x001234)) == 1 && byte(0x001234) == 2", "(byte(0x001234) - prev(byte(0x001234))) == 1 && byte(0x001234) == 2")] // conflict with part of a SubSource clause should not be treated as wholly conflicting
         [TestCase("byte(0x001234) <= 2 && byte(0x001234) >= 2", "byte(0x001234) == 2")] // only overlap is the one value
         [TestCase("byte(0x001234) >= 2 && byte(0x001234) <= 2", "byte(0x001234) == 2")] // only overlap is the one value
         [TestCase("once(byte(0x001234) == 2) && once(byte(0x001234) == 3)", "once(byte(0x001234) == 2) && once(byte(0x001234) == 3)")] // cannot both be true at the same time, but can each be true once

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v1.5.5 - TBD
+* ignore multi-clause conditions when optimizing
+
 v1.5.4 - 26 Jan 2019
 * support for quoted strings in local achievements
 * support for matching the difference between values at two addresses: "byte(0x1234) - byte(0x3456) == 6"


### PR DESCRIPTION
Prevents an issue where a clause within a multi-clause condition would conflict with another clause outside the multi-clause condition, eliminating both.