### PR TITLE
Adjust UI for upgrade to .NET 4.0

### DIFF
--- a/Views/GameViewer.xaml
+++ b/Views/GameViewer.xaml
@@ -9,7 +9,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <DataTemplate x:Key="editorRowTemplate">
-        <Grid HorizontalAlignment="Left" Width="{Binding ActualWidth, ElementName=maxAchievementRowWidth}">
+        <Grid HorizontalAlignment="Left" Width="{Binding ActualWidth, ElementName=maxAchievementRowWidth}" Height="13" Margin="-2,0,0,0">
             <Grid.Resources>
                 <ContextMenu x:Key="updateLocalContextMenu" DataContext="{Binding PlacementTarget, RelativeSource={RelativeSource Self}}">
                     <MenuItem Header="Update Local" Command="{Binding DataContext.UpdateLocalCommand}" />
@@ -36,7 +36,7 @@
                 </Style>
             </Grid.Style>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="10" />
+                <ColumnDefinition Width="8" />
                 <ColumnDefinition Width="14" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="30" />
@@ -44,7 +44,7 @@
 
             <!-- Modified -->
             <TextBlock FontSize="10" VerticalAlignment="Center" Foreground="Gray" 
-                       ToolTip="{Binding ModificationMessage}">
+                       ToolTip="{Binding ModificationMessage}" Margin="-2,-2,0,0">
                 <TextBlock.Style>
                     <Style TargetType="{x:Type TextBlock}">
                         <Style.Triggers>
@@ -52,7 +52,7 @@
                                 <Setter Property="Text" Value="&#x25CB;" />
                             </DataTrigger>
                             <DataTrigger Binding="{Binding CompareState}" Value="LocalDiffers">
-                                <Setter Property="Text" Value="&#x23FA;" />
+                                <Setter Property="Text" Value="&#x2BC3;" />
                             </DataTrigger>
                             <DataTrigger Binding="{Binding CompareState}" Value="PublishedDiffers">
                                 <Setter Property="Text" Value="&#x25D0;" />
@@ -63,7 +63,7 @@
             </TextBlock>
 
             <!-- Image -->
-            <ContentPresenter Grid.Column="1" Content="{Binding}" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <ContentPresenter Grid.Column="1" Content="{Binding}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,-1,0,-1">
                 <ContentPresenter.Resources>
                     <DataTemplate DataType="{x:Type vm:GeneratedAchievementViewModel}">
                         <Image Width="12" Height="12" Source="/RATools;component/Resources/achievement.png" ToolTip="Achievement" />
@@ -81,7 +81,7 @@
             </ContentPresenter>
 
             <!-- Name -->
-            <TextBlock Grid.Column="2" Margin="2,0,2,0" HorizontalAlignment="Stretch"
+            <TextBlock Grid.Column="2" Margin="2,-3,2,0" HorizontalAlignment="Stretch"
                        Text="{Binding Title}" TextTrimming="CharacterEllipsis" />
 
             <!-- Points -->

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -3,6 +3,9 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:commands="clr-namespace:Jamiras.Commands;assembly=Jamiras.Core"
         xmlns:controls="clr-namespace:Jamiras.Controls;assembly=Jamiras.Core"
+        SnapsToDevicePixels="True"
+        UseLayoutRounding="True"
+        RenderOptions.BitmapScalingMode="HighQuality"
         Title="{Binding Game.Title, StringFormat='RA Tools - {0}', FallbackValue='RA Tools - No Game Loaded'}" Height="768" Width="1024">
     <Window.Resources>
         <ResourceDictionary>


### PR DESCRIPTION
The upgrade to .NET 4.0 had some unintended side effects to the UI. The modified marker gained a box, the icons lost their anti-aliasing, and the spacing between items increased.

old UI:
![image](https://user-images.githubusercontent.com/32680403/53430210-4f0db500-39ab-11e9-8b6e-f5c82ad126e7.png)

after upgrading to .NET 4.0:
![image](https://user-images.githubusercontent.com/32680403/53430228-56cd5980-39ab-11e9-8ae0-c22027797025.png)

with these changes:
![image](https://user-images.githubusercontent.com/32680403/53430244-5d5bd100-39ab-11e9-8d27-dd1ee1ad5349.png)
