### PR TITLE
disable Update Local if local directory is not known

### DIFF
--- a/ViewModels/GeneratedAchievementViewModel.cs
+++ b/ViewModels/GeneratedAchievementViewModel.cs
@@ -28,8 +28,16 @@ namespace RATools.ViewModels
             Unofficial = new AchievementViewModel(owner, "Unofficial");
             Core = new AchievementViewModel(owner, "Core");
 
-            UpdateLocalCommand = new DelegateCommand(() => UpdateLocal(owner));
-            DeleteLocalCommand = new DelegateCommand(() => DeleteLocal(owner));
+            if (String.IsNullOrEmpty(owner.RACacheDirectory))
+            {
+                UpdateLocalCommand = DisabledCommand.Instance;
+                DeleteLocalCommand = DisabledCommand.Instance;
+            }
+            else
+            {
+                UpdateLocalCommand = new DelegateCommand(() => UpdateLocal(owner));
+                DeleteLocalCommand = new DelegateCommand(() => DeleteLocal(owner));
+            }
         }
 
         private readonly GameViewModel _owner;

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -402,6 +402,13 @@ namespace RATools.ViewModels
             {
                 MessageBoxViewModel.ShowMessage("Cannot update while errors exist.");
                 game.Script.Editor.ErrorsToolWindow.IsVisible = true;
+                return;
+            }
+
+            if (String.IsNullOrEmpty(game.RACacheDirectory))
+            {
+                MessageBoxViewModel.ShowMessage("Could not identify local directory.");
+                return;
             }
 
             var dialog = new UpdateLocalViewModel(game);

--- a/ViewModels/RichPresenceViewModel.cs
+++ b/ViewModels/RichPresenceViewModel.cs
@@ -19,8 +19,14 @@ namespace RATools.ViewModels
             var genLines = _richPresence.Trim().Length > 0 ? _richPresence.Replace("\r\n", "\n").Split('\n') : new string[0];
             string[] localLines = new string[0];
 
-            if (!String.IsNullOrEmpty(owner.RACacheDirectory))
+            if (String.IsNullOrEmpty(owner.RACacheDirectory))
             {
+                UpdateLocalCommand = DisabledCommand.Instance;
+            }
+            else
+            {
+                UpdateLocalCommand = new DelegateCommand(UpdateLocal);
+
                 _richFile = Path.Combine(owner.RACacheDirectory, owner.GameId + "-Rich.txt");
                 if (File.Exists(_richFile))
                 {
@@ -186,7 +192,6 @@ namespace RATools.ViewModels
                 RichPresenceLength = _richPresence.Length;
                 ModificationMessage = _hasLocal ? "Local value differs from generated value" : "Local value does not exist";
                 CompareState = GeneratedCompareState.LocalDiffers;
-                UpdateLocalCommand = new DelegateCommand(UpdateLocal);
                 CanUpdate = true;
             }
             else


### PR DESCRIPTION
The local directory is found by locating the `XXX-Notes.json` file. If the "Could not locate notes file" messagebox is shown, the "Update Local" right-click options will be disabled, and attempting to use the menu option or the shortcut key will show an error message.