### PR TITLE
support non-zero local achievement IDs (supports #29)

### DIFF
--- a/Parser/LocalAchievements.cs
+++ b/Parser/LocalAchievements.cs
@@ -188,7 +188,7 @@ namespace RATools.Parser
 
                 foreach (var achievement in _achievements)
                 {
-                    writer.Write(0); // id always 0 in local file
+                    writer.Write(achievement.Id);
                     writer.Write(':');
 
                     var requirements = AchievementBuilder.SerializeRequirements(achievement);

--- a/ViewModels/GeneratedAchievementViewModel.cs
+++ b/ViewModels/GeneratedAchievementViewModel.cs
@@ -22,7 +22,10 @@ namespace RATools.ViewModels
 
             Generated = new AchievementViewModel(owner, "Generated");
             if (generatedAchievement != null)
+            {
                 Generated.LoadAchievement(generatedAchievement);
+                Id = Generated.Id;
+            }
 
             Local = new AchievementViewModel(owner, "Local");
             Unofficial = new AchievementViewModel(owner, "Unofficial");


### PR DESCRIPTION
If an `achievement()` call specifies an `id`, that will now be carried along with the generated achievement definition, both internally and when written to the local XXX-User.txt file. This allows the toolkit to merge the achievement generated by the `achievement()` call into an already published achievement, and improves support for modifying published achievements within the editor.

Additionally, it prevents unintentional duplication when both the title and description of a published achievement are modified by the `achievement()` call. Without the ID, title, or description to link the published achievement to the generated one, a new achievement was being added to the list.