### PR TITLE
Evaluate trigger before generating trigger code

### DIFF
--- a/Data/Field.cs
+++ b/Data/Field.cs
@@ -307,7 +307,13 @@ namespace RATools.Data
                 return false;
 
             var that = (Field)obj;
-            return that.Type == Type && that.Size == Size && that.Value == Value;
+            if (that.Type != Type || that.Value != Value)
+                return false;
+
+            if (Type == FieldType.Value)
+                return true;
+
+            return that.Size == Size;
         }
 
         /// <summary>

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -306,8 +306,10 @@ namespace RATools.Parser
             {
                 case ExpressionType.Assignment:
                     var assignment = (AssignmentExpression)expression;
+                    var assignmentScope = new InterpreterScope(scope) { Context = assignment };
+
                     ExpressionBase result;
-                    if (!assignment.Value.ReplaceVariables(scope, out result))
+                    if (!assignment.Value.ReplaceVariables(assignmentScope, out result))
                     {
                         Error = result as ParseErrorExpression;
                         return false;
@@ -350,7 +352,8 @@ namespace RATools.Parser
         private bool EvaluateReturn(ReturnExpression expression, InterpreterScope scope)
         {
             ExpressionBase result;
-            if (!expression.Value.ReplaceVariables(scope, out result))
+            var returnScope = new InterpreterScope(scope) { Context = new AssignmentExpression(new VariableExpression("@return"), expression.Value) };
+            if (!expression.Value.ReplaceVariables(returnScope, out result))
             {
                 Error = result as ParseErrorExpression;
                 return false;
@@ -359,8 +362,10 @@ namespace RATools.Parser
             var functionCall = result as FunctionCallExpression;
             if (functionCall != null)
             {
-                if (!CallFunction(functionCall, scope))
+                if (!CallFunction(functionCall, returnScope))
                     return false;
+
+                scope.ReturnValue = returnScope.ReturnValue;
             }
             else
             {
@@ -483,10 +488,10 @@ namespace RATools.Parser
         private bool CallFunction(FunctionCallExpression expression, InterpreterScope scope)
         {
             ExpressionBase result;
-            bool success = scope.IsReplacingVariables ? expression.ReplaceVariables(scope, out result) : expression.Invoke(scope, out result);
+            bool success = (scope.GetInterpreterContext<AssignmentExpression>() != null) ? expression.ReplaceVariables(scope, out result) : expression.Invoke(scope, out result);
             if (!success)
             {
-                if (scope.GetContext<FunctionCallExpression>() != null)
+                if (scope.GetInterpreterContext<FunctionCallExpression>() != null)
                 {
                     var error = result as ParseErrorExpression;
                     result = new ParseErrorExpression(expression.FunctionName.Name + " call failed: " + error.Message, expression.FunctionName) { InnerError = error };

--- a/Parser/Functions/AlwaysFalseFunction.cs
+++ b/Parser/Functions/AlwaysFalseFunction.cs
@@ -12,6 +12,9 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
+            if (!IsInTriggerClause(scope, out result))
+                return false;
+
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[0]);
             return true;
         }

--- a/Parser/Functions/AlwaysFalseFunction.cs
+++ b/Parser/Functions/AlwaysFalseFunction.cs
@@ -3,26 +3,23 @@ using RATools.Parser.Internal;
 
 namespace RATools.Parser.Functions
 {
-    internal class AlwaysFalseFunction : FunctionDefinitionExpression
+    internal class AlwaysFalseFunction : TriggerBuilderContext.FunctionDefinition
     {
         public AlwaysFalseFunction()
             : base("always_false")
         {
         }
 
-        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            var context = scope.GetContext<TriggerBuilderContext>();
-            if (context == null)
-            {
-                result = new ParseErrorExpression(Name.Name + " has no meaning outside of a trigger clause");
-                return false;
-            }
-
-            context.Trigger.Add(CreateAlwaysFalseRequirement());
-
-            result = null;
+            result = new FunctionCallExpression(Name.Name, new ExpressionBase[0]);
             return true;
+        }
+
+        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        {
+            context.Trigger.Add(CreateAlwaysFalseRequirement());
+            return null;
         }
 
         public static Requirement CreateAlwaysFalseRequirement()

--- a/Parser/Functions/AlwaysTrueFunction.cs
+++ b/Parser/Functions/AlwaysTrueFunction.cs
@@ -12,6 +12,9 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
+            if (!IsInTriggerClause(scope, out result))
+                return false;
+
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[0]);
             return true;
         }

--- a/Parser/Functions/AlwaysTrueFunction.cs
+++ b/Parser/Functions/AlwaysTrueFunction.cs
@@ -3,26 +3,23 @@ using RATools.Parser.Internal;
 
 namespace RATools.Parser.Functions
 {
-    internal class AlwaysTrueFunction : FunctionDefinitionExpression
+    internal class AlwaysTrueFunction : TriggerBuilderContext.FunctionDefinition
     {
         public AlwaysTrueFunction()
             : base("always_true")
         {
         }
 
-        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            var context = scope.GetContext<TriggerBuilderContext>();
-            if (context == null)
-            {
-                result = new ParseErrorExpression(Name.Name + " has no meaning outside of a trigger clause");
-                return false;
-            }
-
-            context.Trigger.Add(CreateAlwaysTrueRequirement());
-
-            result = null;
+            result = new FunctionCallExpression(Name.Name, new ExpressionBase[0]);
             return true;
+        }
+
+        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        {
+            context.Trigger.Add(CreateAlwaysTrueRequirement());
+            return null;
         }
 
         public static Requirement CreateAlwaysTrueRequirement()

--- a/Parser/Functions/ComparisonModificationFunction.cs
+++ b/Parser/Functions/ComparisonModificationFunction.cs
@@ -15,6 +15,9 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
+            if (!IsInTriggerClause(scope, out result))
+                return false;
+
             var comparison = GetParameter(scope, "comparison", out result);
             if (comparison == null)
                 return false;

--- a/Parser/Functions/ComparisonModificationFunction.cs
+++ b/Parser/Functions/ComparisonModificationFunction.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace RATools.Parser.Functions
 {
-    internal abstract class ComparisonModificationFunction : FunctionDefinitionExpression
+    internal abstract class ComparisonModificationFunction : TriggerBuilderContext.FunctionDefinition
     {
         public ComparisonModificationFunction(string name)
             : base(name)
@@ -13,59 +13,60 @@ namespace RATools.Parser.Functions
             Parameters.Add(new VariableDefinitionExpression("comparison"));
         }
 
-        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            var context = scope.GetContext<TriggerBuilderContext>();
-            if (context == null)
-            {
-                result = new ParseErrorExpression(Name.Name + " has no meaning outside of a trigger clause");
-                return false;
-            }
-
             var comparison = GetParameter(scope, "comparison", out result);
             if (comparison == null)
                 return false;
 
+            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { comparison });
+            return true;
+        }
+
+        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        {
+            var comparison = functionCall.Parameters.First();
+            return BuildTriggerCondition(context, scope, comparison);
+        }
+
+        protected ParseErrorExpression BuildTriggerCondition(TriggerBuilderContext context, InterpreterScope scope, ExpressionBase condition)
+        { 
             var builder = new ScriptInterpreterAchievementBuilder();
-            if (!TriggerBuilderContext.ProcessAchievementConditions(builder, comparison, scope, out result))
-                return false;
+            ExpressionBase result;
+            if (!TriggerBuilderContext.ProcessAchievementConditions(builder, condition, scope, out result))
+                return (ParseErrorExpression)result;
 
             if (builder.AlternateRequirements.Count > 0)
-            {
-                result = new ParseErrorExpression(Name.Name + " does not support ||'d conditions", comparison);
-                return false;
-            }
+                return new ParseErrorExpression(Name.Name + " does not support ||'d conditions", condition);
 
-            if (!ValidateSingleCondition(comparison, builder.CoreRequirements, out result))
-                return false;
+            ParseErrorExpression error = ValidateSingleCondition(builder.CoreRequirements);
+            if (error != null)
+                return new ParseErrorExpression(error, condition);
 
-            ModifyRequirements(builder);
+            error = ModifyRequirements(builder);
+            if (error != null)
+                return error;
 
             foreach (var requirement in builder.CoreRequirements)
                 context.Trigger.Add(requirement);
 
-            return true;
+            return null;
         }
 
-        protected bool ValidateSingleCondition(ExpressionBase comparison, ICollection<Requirement> requirements, out ExpressionBase result)
+        protected ParseErrorExpression ValidateSingleCondition(ICollection<Requirement> requirements)
         {
             if (requirements.Count == 0 ||
                 requirements.Last().Operator == RequirementOperator.None)
             {
-                result = new ParseErrorExpression("comparison did not evaluate to a valid comparison", comparison);
-                return false;
+                return new ParseErrorExpression("comparison did not evaluate to a valid comparison");
             }
 
             if (requirements.Count(r => r.Operator != RequirementOperator.None) != 1)
-            {
-                result = new ParseErrorExpression(Name.Name + " does not support &&'d conditions", comparison);
-                return false;
-            }
+                return new ParseErrorExpression(Name.Name + " does not support &&'d conditions");
 
-            result = null;
-            return true;
+            return null;
         }
 
-        protected abstract void ModifyRequirements(ScriptInterpreterAchievementBuilder builder);
+        protected abstract ParseErrorExpression ModifyRequirements(AchievementBuilder builder);
     }
 }

--- a/Parser/Functions/FlagConditionFunction.cs
+++ b/Parser/Functions/FlagConditionFunction.cs
@@ -1,4 +1,5 @@
 ﻿using RATools.Data;
+using RATools.Parser.Internal;
 using System.Linq;
 
 namespace RATools.Parser.Functions
@@ -13,9 +14,10 @@ namespace RATools.Parser.Functions
 
         private readonly RequirementType _type;
 
-        protected override void ModifyRequirements(ScriptInterpreterAchievementBuilder builder)
+        protected override ParseErrorExpression ModifyRequirements(AchievementBuilder builder)
         {
             builder.CoreRequirements.Last().Type = _type;
+            return null;
         }
     }
 }

--- a/Parser/Functions/MemoryAccessorFunction.cs
+++ b/Parser/Functions/MemoryAccessorFunction.cs
@@ -18,6 +18,9 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
+            if (!IsInTriggerClause(scope, out result))
+                return false;
+
             var address = GetIntegerParameter(scope, "address", out result);
             if (address == null)
                 return false;

--- a/Parser/Functions/OnceFunction.cs
+++ b/Parser/Functions/OnceFunction.cs
@@ -12,6 +12,9 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
+            if (!IsInTriggerClause(scope, out result))
+                return false;
+
             var comparison = GetParameter(scope, "comparison", out result);
             if (comparison == null)
                 return false;

--- a/Parser/Functions/OnceFunction.cs
+++ b/Parser/Functions/OnceFunction.cs
@@ -1,4 +1,5 @@
 ﻿using RATools.Parser.Internal;
+using System.Linq;
 
 namespace RATools.Parser.Functions
 {
@@ -9,9 +10,20 @@ namespace RATools.Parser.Functions
         {
         }
 
-        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            return Evaluate(scope, 1, out result);
+            var comparison = GetParameter(scope, "comparison", out result);
+            if (comparison == null)
+                return false;
+
+            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { comparison });
+            return true;
+        }
+
+        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        {
+            var comparison = functionCall.Parameters.First();
+            return BuildTriggerConditions(context, scope, comparison, 1);
         }
     }
 }

--- a/Parser/Functions/PrevFunction.cs
+++ b/Parser/Functions/PrevFunction.cs
@@ -1,9 +1,10 @@
 ﻿using RATools.Data;
 using RATools.Parser.Internal;
+using System.Linq;
 
 namespace RATools.Parser.Functions
 {
-    internal class PrevFunction : FunctionDefinitionExpression
+    internal class PrevFunction : TriggerBuilderContext.FunctionDefinition
     {
         public PrevFunction()
             : base("prev")
@@ -11,24 +12,26 @@ namespace RATools.Parser.Functions
             Parameters.Add(new VariableDefinitionExpression("accessor"));
         }
 
-        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            var context = scope.GetContext<TriggerBuilderContext>();
-            if (context == null)
-            {
-                result = new ParseErrorExpression(Name.Name + " has no meaning outside of a trigger clause");
-                return false;
-            }
-
-            Field accessor = GetMemoryAccessorParameter(scope, "accessor", out result);
-            if (accessor.Type == FieldType.None)
+            var accessor = GetMemoryAccessorParameter(scope, "accessor", out result);
+            if (accessor == null)
                 return false;
 
-            var requirement = new Requirement();
-            requirement.Left = new Field { Size = accessor.Size, Type = FieldType.PreviousValue, Value = accessor.Value };
-            context.Trigger.Add(requirement);
-
+            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { accessor });
             return true;
+        }
+
+        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        {
+            var accessor = (FunctionCallExpression)functionCall.Parameters.First();
+            var error = context.CallFunction(accessor, scope);
+            if (error != null)
+                return error;
+
+            var left = context.LastRequirement.Left;
+            context.LastRequirement.Left = new Field { Size = left.Size, Type = FieldType.PreviousValue, Value = left.Value };
+            return null;
         }
     }
 }

--- a/Parser/Functions/PrevFunction.cs
+++ b/Parser/Functions/PrevFunction.cs
@@ -14,6 +14,9 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
+            if (!IsInTriggerClause(scope, out result))
+                return false;
+
             var accessor = GetMemoryAccessorParameter(scope, "accessor", out result);
             if (accessor == null)
                 return false;

--- a/Parser/Functions/RangeFunction.cs
+++ b/Parser/Functions/RangeFunction.cs
@@ -61,7 +61,7 @@ namespace RATools.Parser.Functions
                     array.Entries.Add(new IntegerConstantExpression(i));
             }
 
-            scope.ReturnValue = array;
+            result = array;
             return true;
         }
     }

--- a/Parser/Functions/RepeatedFunction.cs
+++ b/Parser/Functions/RepeatedFunction.cs
@@ -20,65 +20,70 @@ namespace RATools.Parser.Functions
         {
         }
 
-        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
             var count = GetIntegerParameter(scope, "count", out result);
             if (count == null)
                 return false;
 
-            return Evaluate(scope, (ushort)count.Value, out result);
-        }
+            var comparison = GetParameter(scope, "comparison", out result);
+            if (comparison == null)
+                return false;
 
-        protected bool Evaluate(InterpreterScope scope, ushort count, out ExpressionBase result)
-        { 
-            var logicalComparison = GetParameter(scope, "comparison", out result) as ConditionalExpression;
-            if (logicalComparison != null && logicalComparison.Operation == ConditionalOperation.Or)
-            {
-                if (!EvaluateAddHits(scope, logicalComparison, out result))
-                    return false;
-            }
-            else
-            {
-                if (!base.Evaluate(scope, out result))
-                    return false;
-            }
-
-            var context = scope.GetContext<TriggerBuilderContext>();
-            context.LastRequirement.HitCount = count;
+            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { count, comparison });
             return true;
         }
 
-        protected override void ModifyRequirements(ScriptInterpreterAchievementBuilder builder)
+        protected override ParseErrorExpression ModifyRequirements(AchievementBuilder builder)
         {
-            // we want to set the HitCount on the last requirement, but don't know what to set it to. will modify back in Evaluate
+            // not actually called because we override BuildTrigger, but required because its abstract in the base class
+            return null;
         }
 
-        private bool EvaluateAddHits(InterpreterScope scope, ConditionalExpression condition, out ExpressionBase result)
+        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
-            var context = scope.GetContext<TriggerBuilderContext>();
-            if (context == null)
-            {
-                result = new ParseErrorExpression(Name.Name + " has no meaning outside of a trigger clause");
-                return false;
-            }
+            var count = (IntegerConstantExpression)functionCall.Parameters.First();
+            var comparison = functionCall.Parameters.ElementAt(1);
+
+            return BuildTriggerConditions(context, scope, comparison, count.Value);
+        }
+
+        protected ParseErrorExpression BuildTriggerConditions(TriggerBuilderContext context, InterpreterScope scope, ExpressionBase comparison, int count)
+        {
+            ParseErrorExpression error;
+
+            var logicalComparison = comparison as ConditionalExpression;
+            if (logicalComparison != null && logicalComparison.Operation == ConditionalOperation.Or)
+                error = EvaluateAddHits(context, scope, logicalComparison);
+            else
+                error = BuildTriggerCondition(context, scope, comparison);
+
+            if (error != null)
+                return error;
+
+            context.LastRequirement.HitCount = (ushort)count;
+            return null;
+        }
+
+        private ParseErrorExpression EvaluateAddHits(TriggerBuilderContext context, InterpreterScope scope, ConditionalExpression condition)
+        {
+            ExpressionBase result;
 
             var builder = new ScriptInterpreterAchievementBuilder();
             builder.CoreRequirements.Add(new Requirement()); // empty core requirement required for optimize call, we'll ignore it
             if (!TriggerBuilderContext.ProcessAchievementConditions(builder, condition, scope, out result))
-                return false;
+                return (ParseErrorExpression)result;
 
             var requirements = new List<Requirement>();
             foreach (var altGroup in builder.AlternateRequirements)
             {
-                if (!ValidateSingleCondition(condition, altGroup, out result))
-                    return false;
+                var error = ValidateSingleCondition(altGroup);
+                if (error != null)
+                    return error;
 
                 var requirement = altGroup.First();
                 if (requirement.Type != RequirementType.None)
-                {
-                    result = new ParseErrorExpression("modifier not allowed in multi-condition repeated clause");
-                    return false;
-                }
+                    return new ParseErrorExpression("modifier not allowed in multi-condition repeated clause");
 
                 requirements.Add(requirement);
             }
@@ -120,7 +125,7 @@ namespace RATools.Parser.Functions
             foreach (var requirement in requirements)
                 context.Trigger.Add(requirement);
 
-            return true;
+            return null;
         }
     }
 }

--- a/Parser/Functions/RepeatedFunction.cs
+++ b/Parser/Functions/RepeatedFunction.cs
@@ -22,6 +22,9 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
+            if (!IsInTriggerClause(scope, out result))
+                return false;
+
             var count = GetIntegerParameter(scope, "count", out result);
             if (count == null)
                 return false;

--- a/Parser/Functions/RichPresenceDisplayFunction.cs
+++ b/Parser/Functions/RichPresenceDisplayFunction.cs
@@ -31,10 +31,12 @@ namespace RATools.Parser.Functions
             scope = new InterpreterScope(scope);
             scope.Context = new RichPresenceDisplayContext { RichPresence = context.RichPresence };
 
-            if (!ProcessRichPresenceDisplay(stringExpression, scope, out result))
+            string displayString;
+            result = ProcessRichPresenceDisplay(stringExpression, scope, out displayString);
+            if (result != null)
                 return false;
 
-            if (!SetDisplayString(context.RichPresence, ((StringConstantExpression)result).Value, scope, out result))
+            if (!SetDisplayString(context.RichPresence, displayString, scope, out result))
                 return false;
 
             return true;
@@ -50,21 +52,24 @@ namespace RATools.Parser.Functions
             return true;
         }
 
-        private bool ProcessRichPresenceDisplay(StringConstantExpression displayString, InterpreterScope scope, out ExpressionBase result)
+        private ParseErrorExpression ProcessRichPresenceDisplay(StringConstantExpression stringExpression, InterpreterScope scope, out string displayString)
         {
-            result = null;
+            displayString = null;
 
+            ExpressionBase result;
             var varargs = GetParameter(scope, "varargs", out result) as ArrayExpression;
             if (varargs == null)
             {
-                if (result == null)
-                    result = new ParseErrorExpression("unexpected varargs", displayString);
-                return false;
+                var error = result as ParseErrorExpression;
+                if (error == null)
+                    error = new ParseErrorExpression("unexpected varargs", stringExpression);
+                return error;
             }
 
-            var builder = ((RichPresenceDisplayContext)scope.Context).DisplayString;
+            var context = scope.GetContext<RichPresenceDisplayContext>();
+            var builder = context.DisplayString;
 
-            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(displayString.Value));
+            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(stringExpression.Value));
             while (tokenizer.NextChar != '\0')
             {
                 var token = tokenizer.ReadTo('{');
@@ -78,35 +83,37 @@ namespace RATools.Parser.Functions
                 var index = tokenizer.ReadNumber();
                 if (tokenizer.NextChar != '}')
                 {
-                    result = new ParseErrorExpression("Invalid positional token",
-                                                      displayString.Line, displayString.Column + positionalTokenColumn,
-                                                      displayString.Line, displayString.Column + tokenizer.Column - 1);
-                    return false;
+                    return new ParseErrorExpression("Invalid positional token", 
+                                                    stringExpression.Line, stringExpression.Column + positionalTokenColumn,
+                                                    stringExpression.Line, stringExpression.Column + tokenizer.Column - 1);
                 }
                 tokenizer.Advance();
 
                 var parameterIndex = Int32.Parse(index.ToString());
                 if (parameterIndex >= varargs.Entries.Count)
                 {
-                    result = new ParseErrorExpression("Invalid parameter index: " + parameterIndex, 
-                                                      displayString.Line, displayString.Column + positionalTokenColumn,
-                                                      displayString.Line, displayString.Column + tokenizer.Column - 1);
-                    return false;
+                    return new ParseErrorExpression("Invalid parameter index: " + parameterIndex,
+                                                    stringExpression.Line, stringExpression.Column + positionalTokenColumn,
+                                                    stringExpression.Line, stringExpression.Column + tokenizer.Column - 1);
                 }
 
-                var richPresenceFunction = varargs.Entries[parameterIndex] as FunctionCallExpression;
-                if (richPresenceFunction == null || !richPresenceFunction.FunctionName.Name.StartsWith("rich_presence_"))
-                {
-                    result = new ParseErrorExpression("Parameter must be a rich_presence_ function", richPresenceFunction);
-                    return false;
-                }
+                var functionCall = varargs.Entries[parameterIndex] as FunctionCallExpression;
 
-                if (!richPresenceFunction.Evaluate(scope, out result, false))
-                    return false;
+                var functionDefinition = scope.GetFunction(functionCall.FunctionName.Name);
+                if (functionDefinition == null)
+                    return new ParseErrorExpression("Unknown function: " + functionCall.FunctionName.Name);
+
+                var richPresenceFunction = functionDefinition as FunctionDefinition;
+                if (richPresenceFunction == null)
+                    return new ParseErrorExpression(functionCall.FunctionName.Name + " cannot be called as a rich_presence_display parameter", functionCall);
+
+                var error = richPresenceFunction.BuildMacro(context, scope, functionCall);
+                if (error != null)
+                    return new ParseErrorExpression(error, functionCall);
             }
 
-            result = new StringConstantExpression(builder.ToString());
-            return true;
+            displayString = builder.ToString();
+            return null;
         }
 
         internal class RichPresenceDisplayContext
@@ -118,6 +125,22 @@ namespace RATools.Parser.Functions
 
             public RichPresenceBuilder RichPresence { get; set; }
             public StringBuilder DisplayString { get; private set; }
+        }
+
+        internal abstract class FunctionDefinition : FunctionDefinitionExpression
+        {
+            public FunctionDefinition(string name)
+                : base(name)
+            {
+            }
+
+            public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+            {
+                result = new ParseErrorExpression(Name.Name + " has no meaning outside of a rich_presence_display call");
+                return false;
+            }
+
+            public abstract ParseErrorExpression BuildMacro(RichPresenceDisplayContext context, InterpreterScope scope, FunctionCallExpression functionCall);
         }
     }
 }

--- a/Parser/Functions/RichPresenceDisplayFunction.cs
+++ b/Parser/Functions/RichPresenceDisplayFunction.cs
@@ -134,6 +134,28 @@ namespace RATools.Parser.Functions
             {
             }
 
+            protected bool IsInRichPresenceDisplayClause(InterpreterScope scope, out ExpressionBase result)
+            {
+                var richPresence = scope.GetContext<RichPresenceDisplayContext>(); // explicitly in rich_presence_display clause
+                if (richPresence == null)
+                {
+                    var assignment = scope.GetInterpreterContext<AssignmentExpression>(); // in generic assignment clause - may be used byte rich_presence_display - will determine later
+                    if (assignment == null)
+                    {
+                        result = new ParseErrorExpression(Name.Name + " has no meaning outside of a rich_presence_display call");
+                        return false;
+                    }
+                }
+
+                result = null;
+                return true;
+            }
+
+            public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+            {
+                return IsInRichPresenceDisplayClause(scope, out result);
+            }
+
             public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
             {
                 result = new ParseErrorExpression(Name.Name + " has no meaning outside of a rich_presence_display call");

--- a/Parser/Functions/RichPresenceLookupFunction.cs
+++ b/Parser/Functions/RichPresenceLookupFunction.cs
@@ -15,6 +15,9 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
+            if (!IsInRichPresenceDisplayClause(scope, out result))
+                return false;
+
             var name = GetStringParameter(scope, "name", out result);
             if (name == null)
                 return false;

--- a/Parser/Functions/RichPresenceValueFunction.cs
+++ b/Parser/Functions/RichPresenceValueFunction.cs
@@ -18,6 +18,9 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
+            if (!IsInRichPresenceDisplayClause(scope, out result))
+                return false;
+
             var name = GetStringParameter(scope, "name", out result);
             if (name == null)
                 return false;

--- a/Parser/Functions/RichPresenceValueFunction.cs
+++ b/Parser/Functions/RichPresenceValueFunction.cs
@@ -1,9 +1,10 @@
 ﻿using RATools.Data;
 using RATools.Parser.Internal;
+using System.Linq;
 
 namespace RATools.Parser.Functions
 {
-    internal class RichPresenceValueFunction : FunctionDefinitionExpression
+    internal class RichPresenceValueFunction : RichPresenceDisplayFunction.FunctionDefinition
     {
         public RichPresenceValueFunction()
             : base("rich_presence_value")
@@ -15,15 +16,8 @@ namespace RATools.Parser.Functions
             DefaultParameters["format"] = new StringConstantExpression("value");
         }
 
-        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            var context = scope.GetContext<RichPresenceDisplayFunction.RichPresenceDisplayContext>();
-            if (context == null)
-            {
-                result = new ParseErrorExpression(Name.Name + " has no meaning outside of a rich_presence_display call");
-                return false;
-            }
-
             var name = GetStringParameter(scope, "name", out result);
             if (name == null)
                 return false;
@@ -43,9 +37,21 @@ namespace RATools.Parser.Functions
             if (expression == null)
                 return false;
 
+            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { name, expression, format });
+            return true;
+        }
+
+        public override ParseErrorExpression BuildMacro(RichPresenceDisplayFunction.RichPresenceDisplayContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        {
+            var name = (StringConstantExpression)functionCall.Parameters.First();
+            var expression = functionCall.Parameters.ElementAt(1);
+            var format = (StringConstantExpression)functionCall.Parameters.ElementAt(2);
+            var valueFormat = Leaderboard.ParseFormat(format.Value);
+
+            ExpressionBase result;
             var value = TriggerBuilderContext.GetValueString(expression, scope, out result);
             if (value == null)
-                return false;
+                return (ParseErrorExpression)result;
 
             context.RichPresence.AddValueField(name.Value, valueFormat);
 
@@ -54,7 +60,7 @@ namespace RATools.Parser.Functions
             context.DisplayString.Append('(');
             context.DisplayString.Append(value);
             context.DisplayString.Append(')');
-            return true;
+            return null;
         }
     }
 }

--- a/Parser/Internal/ArrayExpression.cs
+++ b/Parser/Internal/ArrayExpression.cs
@@ -52,11 +52,15 @@ namespace RATools.Parser.Internal
                 return true;
             }
 
+            var arrayScope = new InterpreterScope(scope);
+
+            int index = 0;
             var entries = new List<ExpressionBase>();
             foreach (var entry in Entries)
             {
                 ExpressionBase value;
-                if (!entry.ReplaceVariables(scope, out value))
+                arrayScope.Context = new AssignmentExpression(new VariableExpression("[" + (index++) + "]"), entry);
+                if (!entry.ReplaceVariables(arrayScope, out value))
                 {
                     result = value;
                     return false;

--- a/Parser/Internal/AssignmentExpression.cs
+++ b/Parser/Internal/AssignmentExpression.cs
@@ -53,8 +53,9 @@ namespace RATools.Parser.Internal
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
+            var expressionScope = new InterpreterScope(scope) { Context = this };
             ExpressionBase value;
-            if (!Value.ReplaceVariables(scope, out value))
+            if (!Value.ReplaceVariables(expressionScope, out value))
             {
                 result = value;
                 return false;

--- a/Parser/Internal/ComparisonExpression.cs
+++ b/Parser/Internal/ComparisonExpression.cs
@@ -69,8 +69,7 @@ namespace RATools.Parser.Internal
             }
 
             var comparison = new ComparisonExpression(left, Operation, right);
-            comparison.Line = Line;
-            comparison.Column = Column;
+            CopyLocation(comparison);
             result = comparison;
             return true;
         }

--- a/Parser/Internal/DictionaryExpression.cs
+++ b/Parser/Internal/DictionaryExpression.cs
@@ -108,7 +108,7 @@ namespace RATools.Parser.Internal
                 if (key.Type == ExpressionType.FunctionCall)
                 {
                     var expression = (FunctionCallExpression)key;
-                    if (!expression.Evaluate(scope, out value, true))
+                    if (!expression.ReplaceVariables(scope, out value))
                     {
                         result = value;
                         return false;

--- a/Parser/Internal/DictionaryExpression.cs
+++ b/Parser/Internal/DictionaryExpression.cs
@@ -99,16 +99,20 @@ namespace RATools.Parser.Internal
                 return true;
             }
 
+            var dictScope = new InterpreterScope(scope);
+
             var entries = new List<DictionaryEntry>();
             foreach (var entry in Entries)
             {
                 ExpressionBase key, value;
                 key = entry.Key;
 
+                dictScope.Context = new AssignmentExpression(new VariableExpression("@key"), key);
+
                 if (key.Type == ExpressionType.FunctionCall)
                 {
                     var expression = (FunctionCallExpression)key;
-                    if (!expression.ReplaceVariables(scope, out value))
+                    if (!expression.ReplaceVariables(dictScope, out value))
                     {
                         result = value;
                         return false;
@@ -117,19 +121,28 @@ namespace RATools.Parser.Internal
                     key = value;
                 }
 
-                if (!key.ReplaceVariables(scope, out key))
+                if (!key.ReplaceVariables(dictScope, out key))
                 {
                     result = key;
                     return false;
                 }
 
-                if (key.Type != ExpressionType.StringConstant && key.Type != ExpressionType.IntegerConstant)
+                switch (key.Type)
                 {
-                    result = new ParseErrorExpression("Dictionary key must evaluate to a constant", key);
-                    return false;
+                    case ExpressionType.StringConstant:
+                        dictScope.Context = new AssignmentExpression(new VariableExpression("[" + ((StringConstantExpression)key).Value + "]"), entry.Value);
+                        break;
+
+                    case ExpressionType.IntegerConstant:
+                        dictScope.Context = new AssignmentExpression(new VariableExpression("[" + ((IntegerConstantExpression)key).Value.ToString() + "]"), entry.Value);
+                        break;
+
+                    default:
+                        result = new ParseErrorExpression("Dictionary key must evaluate to a constant", key);
+                        return false;
                 }
 
-                if (!entry.Value.ReplaceVariables(scope, out value))
+                if (!entry.Value.ReplaceVariables(dictScope, out value))
                 {
                     result = value;
                     return false;

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -42,6 +42,20 @@ namespace RATools.Parser.Internal
         public int EndColumn { get; protected set; }
 
         /// <summary>
+        /// Copies the location of this expression into another expression.
+        /// </summary>
+        protected void CopyLocation(ExpressionBase source)
+        {
+            if (Line != 0)
+            {
+                source.Line = Line;
+                source.Column = Column;
+                source.EndLine = EndLine;
+                source.EndColumn = EndColumn;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets whether this is a logical unit.
         /// </summary>
         /// <remarks>

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -44,7 +44,7 @@ namespace RATools.Parser.Internal
         /// <summary>
         /// Copies the location of this expression into another expression.
         /// </summary>
-        protected void CopyLocation(ExpressionBase source)
+        internal void CopyLocation(ExpressionBase source)
         {
             if (Line != 0)
             {

--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -63,25 +63,36 @@ namespace RATools.Parser.Internal
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            var parameters = new List<ExpressionBase>();
-            foreach (var parameter in Parameters)
+            var functionDefinition = scope.GetFunction(FunctionName.Name);
+            if (functionDefinition == null)
             {
-                ExpressionBase value;
-                if (!parameter.ReplaceVariables(scope, out value))
-                {
-                    result = value;
-                    return false;
-                }
-
-                parameters.Add(value);
+                result = new ParseErrorExpression("Unknown function: " + FunctionName.Name, FunctionName);
+                return false;
             }
 
-            var functionCall = new FunctionCallExpression(FunctionName, parameters);
-            functionCall.Line = Line;
-            functionCall.Column = Column;
-            functionCall.EndLine = EndLine;
-            functionCall.EndColumn = EndColumn;
-            result = functionCall;
+            var functionScope = GetParameters(functionDefinition, scope, out result);
+            if (functionScope == null)
+                return false;
+
+            if (functionScope.Depth >= 100)
+            {
+                result = new ParseErrorExpression("Maximum recursion depth exceeded", this);
+                return false;
+            }
+
+            functionScope.Context = this;
+            if (!functionDefinition.ReplaceVariables(functionScope, out result))
+                return false;
+
+            var functionCall = result as FunctionCallExpression;
+            if (functionCall != null && functionCall.Line == 0)
+            {
+                functionCall.Line = Line;
+                functionCall.Column = Column;
+                functionCall.EndLine = EndLine;
+                functionCall.EndColumn = EndColumn;
+            }
+
             return true;
         }
 
@@ -91,50 +102,52 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the function result.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if invocation was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
         /// </returns>
-        public bool Evaluate(InterpreterScope scope, out ExpressionBase result, bool resultRequired)
+        public bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
-            var function = scope.GetFunction(FunctionName.Name);
-            if (function == null)
+            var functionDefinition = scope.GetFunction(FunctionName.Name);
+            if (functionDefinition == null)
             {
                 result = new ParseErrorExpression("Unknown function: " + FunctionName.Name, FunctionName);
                 return false;
             }
 
-            var functionScope = GetParameters(function, scope, out result);
+            var functionScope = GetParameters(functionDefinition, scope, out result);
             if (functionScope == null)
                 return false;
 
+            if (functionScope.Depth >= 100)
+            {
+                result = new ParseErrorExpression("Maximum recursion depth exceeded", this);
+                return false;
+            }
+
             functionScope.Context = this;
-
-            if (!function.Evaluate(functionScope, out result))
-            {
-                if (result.Line == 0)
-                {
-                    result = new ParseErrorExpression(result, FunctionName);
-                }
-                else
-                {
-                    var parseError = (ParseErrorExpression)result;
-                    var sourceError = parseError.InnermostError;
-                    result = new ParseErrorExpression("Function call failed: " + (sourceError != null ? sourceError.Message : parseError.Message), FunctionName)
-                    {
-                        InnerError = parseError
-                    };
-                }
-
+            if (!functionDefinition.Evaluate(functionScope, out result))
                 return false;
-            }
 
-            if (resultRequired && functionScope.ReturnValue == null)
-            {
-                result = new ParseErrorExpression(function.Name.Name + " did not return a value", FunctionName);
-                return false;
-            }
-
-            result = functionScope.ReturnValue;
+            scope.ReturnValue = result;
             return true;
+        }
+
+        /// <summary>
+        /// Gets the return value from calling a function.
+        /// </summary>
+        /// <param name="scope">The scope object containing variable values.</param>
+        /// <param name="result">[out] The new expression containing the function result.</param>
+        /// <returns>
+        ///   <c>true</c> if invocation was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        /// </returns>
+        public bool Invoke(InterpreterScope scope, out ExpressionBase result)
+        {
+            if (Evaluate(scope, out result))
+                return true;
+
+            if (result.Line == 0)
+                result = new ParseErrorExpression(result, FunctionName);
+
+            return false;
         }
 
         /// <summary>

--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -194,6 +194,8 @@ namespace RATools.Parser.Internal
                         return null;
                     }
 
+                    assignedParameter.Value.CopyLocation(value);
+
                     parameterScope.DefineVariable(new VariableDefinitionExpression(assignedParameter.Variable), value);
                     namedParameters = true;
                 }
@@ -220,6 +222,8 @@ namespace RATools.Parser.Internal
                         error = new ParseErrorExpression(value, parameter);
                         return null;
                     }
+
+                    parameter.CopyLocation(value);
 
                     if (index < parameterCount)
                     {

--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -84,15 +84,7 @@ namespace RATools.Parser.Internal
             if (!functionDefinition.ReplaceVariables(functionScope, out result))
                 return false;
 
-            var functionCall = result as FunctionCallExpression;
-            if (functionCall != null && functionCall.Line == 0)
-            {
-                functionCall.Line = Line;
-                functionCall.Column = Column;
-                functionCall.EndLine = EndLine;
-                functionCall.EndColumn = EndColumn;
-            }
-
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Internal/FunctionDefinitionExpression.cs
+++ b/Parser/Internal/FunctionDefinitionExpression.cs
@@ -201,7 +201,6 @@ namespace RATools.Parser.Internal
         /// <returns><c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result"/> will likely be a <see cref="ParseErrorExpression"/>.</returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            scope = new InterpreterScope(scope) { IsReplacingVariables = true };
             if (!Evaluate(scope, out result))
                 return false;
 
@@ -230,13 +229,14 @@ namespace RATools.Parser.Internal
         public virtual bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
             var interpreter = new AchievementScriptInterpreter();
-            if (!interpreter.Evaluate(Expressions, scope))
+            var interpreterScope = new InterpreterScope(scope) { Context = interpreter };
+            if (!interpreter.Evaluate(Expressions, interpreterScope))
             {
                 result = interpreter.Error;
                 return false;
             }
 
-            result = scope.ReturnValue;
+            result = interpreterScope.ReturnValue;
             return true;
         }
 

--- a/Parser/Internal/IndexedVariableExpression.cs
+++ b/Parser/Internal/IndexedVariableExpression.cs
@@ -62,7 +62,7 @@ namespace RATools.Parser.Internal
             if (Index.Type == ExpressionType.FunctionCall)
             {
                 var expression = (FunctionCallExpression)Index;
-                if (!expression.Evaluate(scope, out index, true))
+                if (!expression.ReplaceVariables(scope, out index))
                 {
                     result = index;
                     return null;

--- a/Parser/Internal/InterpreterScope.cs
+++ b/Parser/Internal/InterpreterScope.cs
@@ -16,7 +16,6 @@ namespace RATools.Parser.Internal
         {
             _parent = parent;
             Depth = parent.Depth + 1;
-            IsReplacingVariables = parent.IsReplacingVariables;
         }
 
         private readonly TinyDictionary<string, FunctionDefinitionExpression> _functions;
@@ -135,12 +134,7 @@ namespace RATools.Parser.Internal
         /// Gets whether or not the processor has encountered an early exit statement (return, break)
         /// </summary>
         public bool IsComplete { get; internal set; }
-
-        /// <summary>
-        /// Gets whether function calls should be evaluated or invoked.
-        /// </summary>
-        public bool IsReplacingVariables { get; internal set; }
-
+ 
         /// <summary>
         /// Gets the value to return when leaving the scope.
         /// </summary>
@@ -157,6 +151,25 @@ namespace RATools.Parser.Internal
                 var context = scope.Context as T;
                 if (context != null)
                     return context;
+
+                scope = scope._parent;
+            } while (scope != null);
+
+            return null;
+        }
+
+        internal T GetInterpreterContext<T>()
+            where T : class
+        {
+            var scope = this;
+            do
+            {
+                var context = scope.Context as T;
+                if (context != null)
+                    return context;
+
+                if (scope.Context is AchievementScriptInterpreter)
+                    break;
 
                 scope = scope._parent;
             } while (scope != null);

--- a/Parser/Internal/InterpreterScope.cs
+++ b/Parser/Internal/InterpreterScope.cs
@@ -16,6 +16,7 @@ namespace RATools.Parser.Internal
         {
             _parent = parent;
             Depth = parent.Depth + 1;
+            IsReplacingVariables = parent.IsReplacingVariables;
         }
 
         private readonly TinyDictionary<string, FunctionDefinitionExpression> _functions;
@@ -134,6 +135,11 @@ namespace RATools.Parser.Internal
         /// Gets whether or not the processor has encountered an early exit statement (return, break)
         /// </summary>
         public bool IsComplete { get; internal set; }
+
+        /// <summary>
+        /// Gets whether function calls should be evaluated or invoked.
+        /// </summary>
+        public bool IsReplacingVariables { get; internal set; }
 
         /// <summary>
         /// Gets the value to return when leaving the scope.

--- a/Parser/TriggerBuilderContext.cs
+++ b/Parser/TriggerBuilderContext.cs
@@ -142,6 +142,28 @@ namespace RATools.Parser
             {
             }
 
+            protected bool IsInTriggerClause(InterpreterScope scope, out ExpressionBase result)
+            {
+                var triggerContext = scope.GetContext<TriggerBuilderContext>();
+                if (triggerContext == null) // explicitly in trigger clause
+                {
+                    var assignment = scope.GetInterpreterContext<AssignmentExpression>();
+                    if (assignment == null) // in generic assignment clause - may be used in a trigger - will determine later
+                    {
+                        result = new ParseErrorExpression(Name.Name + " has no meaning outside of a trigger clause");
+                        return false;
+                    }
+                }
+
+                result = null;
+                return true;
+            }
+
+            public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+            {
+                return IsInTriggerClause(scope, out result);
+            }
+
             public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
             {
                 result = new ParseErrorExpression(Name.Name + " has no meaning outside of a trigger clause");

--- a/Tests/Data/FieldTests.cs
+++ b/Tests/Data/FieldTests.cs
@@ -171,5 +171,17 @@ namespace RATools.Tests.Data
             Assert.That(field1 != field2);
             Assert.That(!field1.Equals(field2));
         }
+
+        [Test]
+        public void TestEqualsDifferentSizeValue()
+        {
+            // Size should be ignored when comparing two Value fields, all Value fields are 32-bit in the runtime
+            var field1 = new Field { Size = FieldSize.Byte, Type = FieldType.Value, Value = 8 };
+            var field2 = new Field { Size = FieldSize.Word, Type = FieldType.Value, Value = 8 };
+
+            Assert.That(field1, Is.EqualTo(field2));
+            Assert.That(field1 == field2);
+            Assert.That(field1.Equals(field2));
+        }
     }
 }

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -634,7 +634,7 @@ namespace RATools.Test.Parser
         {
             var parser = Parse("function foo() => byte(1)\n" +
                                "achievement(\"Title\", \"Description\", 5, once(foo()))\n", false);
-            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("2:48 comparison did not evaluate to a valid comparison"));
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("2:45 comparison did not evaluate to a valid comparison"));
         }
     }
 }

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -396,7 +396,7 @@ namespace RATools.Test.Parser
         public void TestPrevMalformed()
         {
             var parser = Parse("achievement(\"T\", \"D\", 5, prev(byte(0x1234) == 1))", false);
-            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:26 accessor did not evaluate to a memory accessor"));
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:31 accessor did not evaluate to a memory accessor"));
         }
 
         [Test]
@@ -412,7 +412,7 @@ namespace RATools.Test.Parser
         public void TestOnceMalformed()
         {
             var parser = Parse("achievement(\"T\", \"D\", 5, once(byte(0x1234)) == 1)", false);
-            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:26 comparison did not evaluate to a valid comparison"));
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:31 comparison did not evaluate to a valid comparison"));
         }
 
         [Test]

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -689,5 +689,13 @@ namespace RATools.Test.Parser
                                "achievement(\"Title\", \"Description\", 5, once(foo()))\n", false);
             Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("2:45 comparison did not evaluate to a valid comparison"));
         }
+
+        [Test]
+        public void TestErrorInFunctionParameterLocation()
+        {
+            var parser = Parse("tens = word(0x1234) * 10\n" +
+                               "achievement(\"Title\", \"Description\", 5, prev(tens) == 100)\n", false);
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("2:45 accessor did not evaluate to a memory accessor"));
+        }
     }
 }

--- a/Tests/Parser/Functions/OnceFunctionTests.cs
+++ b/Tests/Parser/Functions/OnceFunctionTests.cs
@@ -32,11 +32,11 @@ namespace RATools.Test.Parser.Functions
 
             ExpressionBase error;
             var scope = funcCall.GetParameters(funcDef, AchievementScriptInterpreter.GetGlobalScope(), out error);
+            var context = new TriggerBuilderContext { Trigger = requirements };
+            scope.Context = context;
 
             ExpressionBase evaluated;
             Assert.That(funcDef.ReplaceVariables(scope, out evaluated), Is.True);
-
-            var context = new TriggerBuilderContext { Trigger = requirements };
 
             if (expectedError == null)
             {

--- a/Tests/Parser/Functions/OnceFunctionTests.cs
+++ b/Tests/Parser/Functions/OnceFunctionTests.cs
@@ -32,17 +32,21 @@ namespace RATools.Test.Parser.Functions
 
             ExpressionBase error;
             var scope = funcCall.GetParameters(funcDef, AchievementScriptInterpreter.GetGlobalScope(), out error);
-            scope.Context = new TriggerBuilderContext { Trigger = requirements };
+
+            ExpressionBase evaluated;
+            Assert.That(funcDef.ReplaceVariables(scope, out evaluated), Is.True);
+
+            var context = new TriggerBuilderContext { Trigger = requirements };
 
             if (expectedError == null)
             {
-                Assert.That(funcDef.Evaluate(scope, out error), Is.True);
+                Assert.That(funcDef.BuildTrigger(context, scope, funcCall), Is.Null);
             }
             else
             {
-                Assert.That(funcDef.Evaluate(scope, out error), Is.False);
-                Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
-                Assert.That(((ParseErrorExpression)error).Message, Is.EqualTo(expectedError));
+                var parseError = funcDef.BuildTrigger(context, scope, funcCall);
+                Assert.That(parseError, Is.Not.Null);
+                Assert.That(parseError.Message, Is.EqualTo(expectedError));
             }
 
             return requirements;

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -33,11 +33,11 @@ namespace RATools.Test.Parser.Functions
 
             ExpressionBase error;
             var scope = funcCall.GetParameters(funcDef, AchievementScriptInterpreter.GetGlobalScope(), out error);
+            var context = new TriggerBuilderContext { Trigger = requirements };
+            scope.Context = context;
 
             ExpressionBase evaluated;
             Assert.That(funcDef.ReplaceVariables(scope, out evaluated), Is.True);
-
-            var context = new TriggerBuilderContext { Trigger = requirements };
 
             if (expectedError == null)
             {

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -33,17 +33,21 @@ namespace RATools.Test.Parser.Functions
 
             ExpressionBase error;
             var scope = funcCall.GetParameters(funcDef, AchievementScriptInterpreter.GetGlobalScope(), out error);
-            scope.Context = new TriggerBuilderContext { Trigger = requirements };
+
+            ExpressionBase evaluated;
+            Assert.That(funcDef.ReplaceVariables(scope, out evaluated), Is.True);
+
+            var context = new TriggerBuilderContext { Trigger = requirements };
 
             if (expectedError == null)
             {
-                Assert.That(funcDef.Evaluate(scope, out error), Is.True);
+                Assert.That(funcDef.BuildTrigger(context, scope, funcCall), Is.Null);
             }
             else
             {
-                Assert.That(funcDef.Evaluate(scope, out error), Is.False);
-                Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
-                Assert.That(((ParseErrorExpression)error).Message, Is.EqualTo(expectedError));
+                var parseError = funcDef.BuildTrigger(context, scope, funcCall);
+                Assert.That(parseError, Is.Not.Null);
+                Assert.That(parseError.Message, Is.EqualTo(expectedError));
             }
 
             return requirements;

--- a/Tests/Parser/Internal/ArrayExpressionTests.cs
+++ b/Tests/Parser/Internal/ArrayExpressionTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using RATools.Parser;
 using RATools.Parser.Internal;
 using System.Text;
 
@@ -49,11 +50,29 @@ namespace RATools.Test.Parser.Internal
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
             Assert.That(result, Is.InstanceOf<ArrayExpression>());
-            var dictResult = (ArrayExpression)result;
-            Assert.That(dictResult.Entries.Count, Is.EqualTo(3));
-            Assert.That(dictResult.Entries[0], Is.EqualTo(value1));
-            Assert.That(dictResult.Entries[1], Is.EqualTo(value2));
-            Assert.That(dictResult.Entries[2], Is.EqualTo(value3));
+            var arrayResult = (ArrayExpression)result;
+            Assert.That(arrayResult.Entries.Count, Is.EqualTo(3));
+            Assert.That(arrayResult.Entries[0], Is.EqualTo(value1));
+            Assert.That(arrayResult.Entries[1], Is.EqualTo(value2));
+            Assert.That(arrayResult.Entries[2], Is.EqualTo(value3));
+        }
+
+        [Test]
+        public void TestReplaceVariablesMemoryAccessor()
+        {
+            var value = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(1) });
+            var expr = new ArrayExpression();
+            expr.Entries.Add(value);
+
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
+
+            Assert.That(result, Is.InstanceOf<ArrayExpression>());
+            var arrayResult = (ArrayExpression)result;
+            Assert.That(arrayResult.Entries.Count, Is.EqualTo(1));
+            Assert.That(arrayResult.Entries[0].ToString(), Is.EqualTo(value.ToString()));
         }
     }
 }

--- a/Tests/Parser/Internal/DictionaryExpressionTests.cs
+++ b/Tests/Parser/Internal/DictionaryExpressionTests.cs
@@ -1,5 +1,6 @@
 ﻿using Jamiras.Components;
 using NUnit.Framework;
+using RATools.Parser;
 using RATools.Parser.Internal;
 using System.Text;
 
@@ -12,7 +13,8 @@ namespace RATools.Test.Parser.Internal
         public void TestAppendString()
         {
             var expr = new DictionaryExpression();
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry {
+            expr.Entries.Add(new DictionaryExpression.DictionaryEntry
+            {
                 Key = new VariableExpression("a"),
                 Value = new IntegerConstantExpression(1)
             });
@@ -223,6 +225,25 @@ namespace RATools.Test.Parser.Internal
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
             Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
             Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("1 already exists in dictionary"));
+        }
+
+        [Test]
+        public void TestReplaceVariablesMemoryAccessor()
+        {
+            var key = new IntegerConstantExpression(6);
+            var value = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(1) });
+            var expr = new DictionaryExpression();
+            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = key, Value = value });
+
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
+
+            Assert.That(result, Is.InstanceOf<DictionaryExpression>());
+            var arrayResult = (DictionaryExpression)result;
+            Assert.That(arrayResult.Entries.Count, Is.EqualTo(1));
+            Assert.That(arrayResult.Entries[0].Value.ToString(), Is.EqualTo(value.ToString()));
         }
     }
 }

--- a/Views/GameViewer.xaml
+++ b/Views/GameViewer.xaml
@@ -85,7 +85,7 @@
                        Text="{Binding Title}" TextTrimming="CharacterEllipsis" />
 
             <!-- Points -->
-            <TextBlock Grid.Column="3" Text="{Binding Points}" Margin="2,0,2,0" HorizontalAlignment="Right">
+            <TextBlock Grid.Column="3" Text="{Binding Points}" Margin="2,-2,2,0" HorizontalAlignment="Right">
                 <TextBlock.Style>
                     <Style TargetType="{x:Type TextBlock}">
                         <Style.Triggers>


### PR DESCRIPTION
Fixes #27 

Because trigger code was being generated while evaluating the functions called by an achievement trigger, it was possible to create "weird" code that functioned (see #27 for more details).

This code changes the logic to fully evaluate the function call into a single expression, then process that expression to generate the code. As a result, the standalone function in the example provided in #27 now generates the following error:

![image](https://user-images.githubusercontent.com/32680403/55168609-b77dbc80-5138-11e9-9d93-a9beb9c3189d.png)

This is a rather significant change to function processing. I've tested all of my scripts, and none of them generate any new errors. Along with the unit tests, I believe the changes are correct.
