### PR TITLE
better error message when attempting to multiply within a trigger clause

### DIFF
--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -598,6 +598,16 @@ namespace RATools.Parser
                             else
                                 alwaysTrue.Add(requirement);
                             break;
+
+                        case RequirementOperator.Equal:
+                            if (requirement.Right.Value > max)
+                                alwaysFalse.Add(requirement);
+                            break;
+
+                        case RequirementOperator.NotEqual:
+                            if (requirement.Right.Value > max)
+                                alwaysTrue.Add(requirement);
+                            break;
                     }
                 }
             }

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -256,12 +256,7 @@ namespace RATools.Parser
             {
                 var error = Error;
                 if (error != null)
-                {
-                    while (error.InnerError != null)
-                        error = error.InnerError;
-
                     expressionGroup.Errors.Add(error);
-                }
 
                 return false;
             }

--- a/Parser/Functions/AchievementFunction.cs
+++ b/Parser/Functions/AchievementFunction.cs
@@ -59,7 +59,11 @@ namespace RATools.Parser.Functions
                 return false;
 
             if (!TriggerBuilderContext.ProcessAchievementConditions(achievement, trigger, scope, out result))
+            {
+                var error = (ParseErrorExpression)result;
+                result = new ParseErrorExpression(error.Message, trigger) { InnerError = error };
                 return false;
+            }
 
             var newAchievement = achievement.ToAchievement();
             var functionCall = scope.GetOutermostContext<FunctionCallExpression>();

--- a/Parser/Internal/ExpressionGroup.cs
+++ b/Parser/Internal/ExpressionGroup.cs
@@ -30,11 +30,9 @@ namespace RATools.Parser.Internal
 
             foreach (var error in Errors)
             {
-                if (error.Line > line)
-                    break;
-
-                if (error.Line == line)
-                    expressions.Add(error);
+                var innerError = error.InnermostError ?? error;
+                if (innerError.Line == line)
+                    expressions.Add(innerError);
             }
 
             return result;

--- a/Parser/Internal/LeftRightExpressionBase.cs
+++ b/Parser/Internal/LeftRightExpressionBase.cs
@@ -34,7 +34,7 @@ namespace RATools.Parser.Internal
         /// <summary>
         /// Gets the right side of the expression.
         /// </summary>
-        public ExpressionBase Right { get; private set; }
+        public ExpressionBase Right { get; internal set; }
 
         /// <summary>
         /// Rebalances the current node and the <paramref name="newRoot"/> so <paramref name="newRoot" /> becomes the parent node.

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -320,6 +320,7 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x001234) == 1 && word(0x004567) < 65535", "byte(0x001234) == 1 && word(0x004567) != 65535")] // word cannot be greater than 255, change to not equals
         [TestCase("byte(0x001234) == 1 && dword(0x004567) < 4294967295", "byte(0x001234) == 1 && dword(0x004567) != 4294967295")] // dword cannot be greater than 4294967295, change to not equals
         [TestCase("bit0(0x001234) + bit1(0x001234) == 2", "(bit0(0x001234) + bit1(0x001234)) == 2")] // addition can exceed max size of source
+        [TestCase("byte(0x001234) == 1000", "0 == 1")] // can never be true
         [TestCase("byte(0x001234) > 256", "0 == 1")] // can never be true
         [TestCase("byte(0x001234) < 256", "1 == 1")] // always true
         [TestCase("0 < 256", "1 == 1")] // always true

--- a/Tests/Parser/Internal/MathematicExpressionTests.cs
+++ b/Tests/Parser/Internal/MathematicExpressionTests.cs
@@ -1,4 +1,7 @@
 ﻿using NUnit.Framework;
+using RATools.Data;
+using RATools.Parser;
+using RATools.Parser.Functions;
 using RATools.Parser.Internal;
 using System.Text;
 
@@ -202,6 +205,21 @@ namespace RATools.Test.Parser.Internal
         }
 
         [Test]
+        public void TestAddZero()
+        {
+            var left = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(0) });
+            var right = new IntegerConstantExpression(0);
+            var expr = new MathematicExpression(left, MathematicOperation.Add, right);
+            var scope = new InterpreterScope();
+            scope.Context = new TriggerBuilderContext();
+            scope.AddFunction(new MemoryAccessorFunction("byte", FieldSize.Byte));
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
+            Assert.That(result.ToString(), Is.EqualTo(left.ToString()));
+        }
+
+        [Test]
         public void TestAddVariables()
         {
             var value1 = new IntegerConstantExpression(1);
@@ -276,6 +294,21 @@ namespace RATools.Test.Parser.Internal
         }
 
         [Test]
+        public void TestSubtractZero()
+        {
+            var left = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(0) });
+            var right = new IntegerConstantExpression(0);
+            var expr = new MathematicExpression(left, MathematicOperation.Subtract, right);
+            var scope = new InterpreterScope();
+            scope.Context = new TriggerBuilderContext();
+            scope.AddFunction(new MemoryAccessorFunction("byte", FieldSize.Byte));
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
+            Assert.That(result.ToString(), Is.EqualTo(left.ToString()));
+        }
+
+        [Test]
         public void TestMultiply()
         {
             var left = new IntegerConstantExpression(7);
@@ -287,6 +320,36 @@ namespace RATools.Test.Parser.Internal
             Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
             Assert.That(result, Is.InstanceOf<IntegerConstantExpression>());
             Assert.That(((IntegerConstantExpression)result).Value, Is.EqualTo(21));
+        }
+
+        [Test]
+        public void TestMultiplyZero()
+        {
+            var left = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(0) });
+            var right = new IntegerConstantExpression(0);
+            var expr = new MathematicExpression(left, MathematicOperation.Multiply, right);
+            var scope = new InterpreterScope();
+            scope.Context = new TriggerBuilderContext();
+            scope.AddFunction(new MemoryAccessorFunction("byte", FieldSize.Byte));
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
+            Assert.That(result.ToString(), Is.EqualTo(right.ToString()));
+        }
+
+        [Test]
+        public void TestMultiplyOne()
+        {
+            var left = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(0) });
+            var right = new IntegerConstantExpression(1);
+            var expr = new MathematicExpression(left, MathematicOperation.Multiply, right);
+            var scope = new InterpreterScope();
+            scope.Context = new TriggerBuilderContext();
+            scope.AddFunction(new MemoryAccessorFunction("byte", FieldSize.Byte));
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
+            Assert.That(result.ToString(), Is.EqualTo(left.ToString()));
         }
 
         [Test]
@@ -304,6 +367,36 @@ namespace RATools.Test.Parser.Internal
         }
 
         [Test]
+        public void TestDivideZero()
+        {
+            var left = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(0) });
+            var right = new IntegerConstantExpression(0);
+            var expr = new MathematicExpression(left, MathematicOperation.Divide, right);
+            var scope = new InterpreterScope();
+            scope.Context = new TriggerBuilderContext();
+            scope.AddFunction(new MemoryAccessorFunction("byte", FieldSize.Byte));
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
+            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("division by zero"));
+        }
+
+        [Test]
+        public void TestDivideOne()
+        {
+            var left = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(0) });
+            var right = new IntegerConstantExpression(1);
+            var expr = new MathematicExpression(left, MathematicOperation.Divide, right);
+            var scope = new InterpreterScope();
+            scope.Context = new TriggerBuilderContext();
+            scope.AddFunction(new MemoryAccessorFunction("byte", FieldSize.Byte));
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
+            Assert.That(result.ToString(), Is.EqualTo(left.ToString()));
+        }
+
+        [Test]
         public void TestModulus()
         {
             var left = new IntegerConstantExpression(20);
@@ -315,6 +408,36 @@ namespace RATools.Test.Parser.Internal
             Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
             Assert.That(result, Is.InstanceOf<IntegerConstantExpression>());
             Assert.That(((IntegerConstantExpression)result).Value, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestModulusZero()
+        {
+            var left = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(0) });
+            var right = new IntegerConstantExpression(0);
+            var expr = new MathematicExpression(left, MathematicOperation.Modulus, right);
+            var scope = new InterpreterScope();
+            scope.Context = new TriggerBuilderContext();
+            scope.AddFunction(new MemoryAccessorFunction("byte", FieldSize.Byte));
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
+            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("division by zero"));
+        }
+
+        [Test]
+        public void TestModulusOne()
+        {
+            var left = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(0) });
+            var right = new IntegerConstantExpression(1);
+            var expr = new MathematicExpression(left, MathematicOperation.Modulus, right);
+            var scope = new InterpreterScope();
+            scope.Context = new TriggerBuilderContext();
+            scope.AddFunction(new MemoryAccessorFunction("byte", FieldSize.Byte));
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
+            Assert.That(result.ToString(), Is.EqualTo(new IntegerConstantExpression(0).ToString()));
         }
     }
 }

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Parser\Internal\ComparisonExpressionTests.cs" />
     <Compile Include="Parser\Internal\AssignmentExpressionTests.cs" />
     <Compile Include="Parser\LocalAchievementsTests.cs" />
+    <Compile Include="Parser\RegressionTests.cs" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(SolutionFileName)' == 'RATools + Core.sln'">

--- a/ViewModels/EditorViewModel.cs
+++ b/ViewModels/EditorViewModel.cs
@@ -71,7 +71,8 @@ namespace RATools.ViewModels
                             innerError = innerError.InnerError;
                         } while (innerError.InnerError != null);
 
-                        message += String.Format(" (called from {0}:{1})", error.Line, error.Column);
+                        if (error.Line != innerError.Line || error.Column != innerError.Column)
+                            message += String.Format(" (called from {0}:{1})", error.Line, error.Column);
                     }
 
                     ErrorsToolWindow.References.Add(new CodeReferenceViewModel

--- a/ViewModels/EditorViewModel.cs
+++ b/ViewModels/EditorViewModel.cs
@@ -61,9 +61,18 @@ namespace RATools.ViewModels
                 ErrorsToolWindow.References.Clear();
                 foreach (var error in _parsedContent.Errors)
                 {
+                    string message = error.Message;
+
                     var innerError = error;
-                    while (innerError.InnerError != null)
-                        innerError = innerError.InnerError;
+                    if (innerError.InnerError != null)
+                    {
+                        do
+                        {
+                            innerError = innerError.InnerError;
+                        } while (innerError.InnerError != null);
+
+                        message += String.Format(" (called from {0}:{1})", error.Line, error.Column);
+                    }
 
                     ErrorsToolWindow.References.Add(new CodeReferenceViewModel
                     {
@@ -71,7 +80,7 @@ namespace RATools.ViewModels
                         StartColumn = innerError.Column,
                         EndLine = innerError.EndLine,
                         EndColumn = innerError.EndColumn,
-                        Message = innerError.Message
+                        Message = message
                     });
                 }
             });


### PR DESCRIPTION
fixes last issue reported in #51:
```
function score() => byte(0x8E) + byte(0x8F) * 100

achievement
(
    title = "Nice Score", 
    description = "Reach a score of 1234567 points",
    points = 10,
    trigger = score() >= 1234567
)
```
The code was incorrectly dividing 1234567 by 100 in an attempt to normalize the score() function, leading to a weird string of AddSources. However, with the "byte(0x8E)+" in there, it's not correct to divide both sides by 100. This situation is now detected, and reported as "Cannot normalize expression to eliminate multiplication".


