### PR TITLE
convert never(A||B) to never(A)&&never(B)

### DIFF
--- a/Parser/Functions/FlagConditionFunction.cs
+++ b/Parser/Functions/FlagConditionFunction.cs
@@ -14,6 +14,32 @@ namespace RATools.Parser.Functions
 
         private readonly RequirementType _type;
 
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            var comparison = GetParameter(scope, "comparison", out result);
+            if (comparison == null)
+                return false;
+
+            var condition = comparison as ConditionalExpression;
+            if (condition != null && condition.Operation == ConditionalOperation.Or)
+            {
+                ExpressionBase left = new FunctionCallExpression(Name.Name, new ExpressionBase[] { condition.Left });
+                if (!left.ReplaceVariables(scope, out result))
+                    return false;
+                left = result;
+
+                ExpressionBase right = new FunctionCallExpression(Name.Name, new ExpressionBase[] { condition.Right });
+                if (!right.ReplaceVariables(scope, out result))
+                    return false;
+                right = result;
+
+                result = new ConditionalExpression(left, ConditionalOperation.And, right);
+                return true;
+            }
+
+            return base.ReplaceVariables(scope, out result);
+        }
+
         protected override ParseErrorExpression ModifyRequirements(AchievementBuilder builder)
         {
             builder.CoreRequirements.Last().Type = _type;

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -434,12 +434,32 @@ namespace RATools.Test.Parser
         }
 
         [Test]
+        public void TestNeverWithOrs()
+        {
+            var parser = Parse("achievement(\"T\", \"D\", 5, once(byte(0x2345) == 0) && never(byte(0x1234) == 0 || byte(0x1234) == 2 || byte(0x1234) == 5)");
+            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
+
+            var achievement = parser.Achievements.First();
+            Assert.That(GetRequirements(achievement), Is.EqualTo("once(byte(0x002345) == 0) && never(byte(0x001234) == 0) && never(byte(0x001234) == 2) && never(byte(0x001234) == 5)"));
+        }
+
+        [Test]
         public void TestUnless()
         {
             var parser = Parse("achievement(\"T\", \"D\", 5, once(byte(0x4567) == 1) && unless(byte(0x1234) == 1))");
             Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
             var achievement = parser.Achievements.First();
             Assert.That(GetRequirements(achievement), Is.EqualTo("once(byte(0x004567) == 1) && unless(byte(0x001234) == 1)"));
+        }
+
+        [Test]
+        public void TestUnlessWithOrs()
+        {
+            var parser = Parse("achievement(\"T\", \"D\", 5, once(byte(0x2345) == 0) && unless(byte(0x1234) == 0 || byte(0x1234) == 2 || byte(0x1234) == 5)");
+            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
+
+            var achievement = parser.Achievements.First();
+            Assert.That(GetRequirements(achievement), Is.EqualTo("once(byte(0x002345) == 0) && unless(byte(0x001234) == 0) && unless(byte(0x001234) == 2) && unless(byte(0x001234) == 5)"));
         }
 
         [Test]


### PR DESCRIPTION
implements #53 

also converts `unless(A || B)` to `unless(A) && unless(B)`