### PR TITLE
remove always_true from core when promoting from alts

### DIFF
--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -1178,7 +1178,11 @@ namespace RATools.Parser
                     }
                 }
 
-                // and put it in the core group
+                // the the core only contains an always true statement, remove it
+                if (_core.Count == 1 && IsTrue(_core[0]))
+                    _core.Clear();
+
+                // put one copy of the repeated requirement it in the core group
                 _core.Add(requirement);
             }
         }

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -358,6 +358,8 @@ namespace RATools.Test.Parser
                   "once(byte(0x001234) == 1) && ((never((byte(0x002345) + byte(0x002346)) == 2)) || (never((byte(0x002345) + byte(0x002347)) == 2)))")] // partial AddSource cannot be promoted
         [TestCase("once(byte(0x001234) == 1) && ((never(byte(0x002345) == 1) && unless(byte(0x003456) == 3)) || (never(byte(0x002345) == 1) && unless(byte(0x003456) == 1)))",
                   "once(byte(0x001234) == 1) && ((never(byte(0x002345) == 1) && unless(byte(0x003456) == 3)) || (never(byte(0x002345) == 1) && unless(byte(0x003456) == 1)))")] // resetif cannot be promoted if pauseif is present
+        [TestCase("1 == 1 && ((byte(0x001234) == 1 && byte(0x002345) == 1) || (byte(0x001234) == 1 && byte(0x002345) == 2))",
+                  "byte(0x001234) == 1 && (byte(0x002345) == 1 || byte(0x002345) == 2)")] // core "1=1" should be removed by promotion of another condition
         // ==== RemoveDuplicates ====
         [TestCase("byte(0x001234) == 1 && byte(0x001234) == 1", "byte(0x001234) == 1")]
         [TestCase("prev(byte(0x001234)) == 1 && prev(byte(0x001234)) == 1", "prev(byte(0x001234)) == 1")]

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -697,5 +697,15 @@ namespace RATools.Test.Parser
                                "achievement(\"Title\", \"Description\", 5, prev(tens) == 100)\n", false);
             Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("2:45 accessor did not evaluate to a memory accessor"));
         }
+
+        [Test]
+        public void TestFunctionWithCommonConditionPromotedToCore()
+        {
+            var parser = Parse("function test(x) => byte(0x1234) == 1 && byte(0x2345) == x\n" +
+                               "achievement(\"Title\", \"Description\", 5, test(3) || test(4))\n");
+
+            var achievement = parser.Achievements.First();
+            Assert.That(GetRequirements(achievement), Is.EqualTo("byte(0x001234) == 1 && (byte(0x002345) == 3 || byte(0x002345) == 4)"));
+        }
     }
 }


### PR DESCRIPTION
An achievement that only had OR clauses would generate an implicit always_true core group. When optimizing, a condition that appeared in all alt groups would be promoted to core. This change removes the always_true condition when a common condition is promoted.