### PR TITLE
improve transitive math logic

### DIFF
--- a/Parser/Internal/MathematicExpression.cs
+++ b/Parser/Internal/MathematicExpression.cs
@@ -94,7 +94,7 @@ namespace RATools.Parser.Internal
             if (!Right.IsLogicalUnit)
             {
                 var mathematicRight = Right as MathematicExpression;
-                if (mathematicRight != null)
+                if (mathematicRight != null && !(Left is StringConstantExpression))
                 {
                     // multiply and divide should happen before add or subtract.
                     // at the same priority, they should happen left-to-right.

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -601,6 +601,25 @@ namespace RATools.Test.Parser
         }
 
         [Test]
+        [TestCase("byte(0x1234) + 1 - byte(0x1235) == 3", "(byte(0x001234) - byte(0x001235)) == 2")]
+        [TestCase("byte(0x1234) + 1 - byte(0x1235) != 3", "(byte(0x001234) - byte(0x001235)) != 2")]
+        [TestCase("byte(0x1234) + 1 - byte(0x1235) >= 3", "(byte(0x001234) - byte(0x001235)) >= 2")]
+        [TestCase("byte(0x1234) + 1 - byte(0x1235) >  3", "(byte(0x001234) - byte(0x001235)) > 2")]
+        [TestCase("byte(0x1234) + 1 - byte(0x1235) <= 3", "(1 + byte(0x001234) - byte(0x001235)) <= 3")]
+        [TestCase("byte(0x1234) + 1 - byte(0x1235) <  3", "(1 + byte(0x001234) - byte(0x001235)) < 3")]
+        public void TestSubSourceMemoryPreventsBalancing(string input, string expected)
+        {
+            // SubSource(mem) can cause wraparound, so if modifiers are present when doing a
+            // less than comparison, assume they're there to prevent the wraparound and don't
+            // transfer them to the right side.
+            var parser = Parse("achievement(\"T\", \"D\", 5, " + input + ")");
+            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
+
+            var achievement = parser.Achievements.First();
+            Assert.That(GetRequirements(achievement), Is.EqualTo(expected));
+        }
+
+        [Test]
         public void TestTransitiveOrClause()
         {
             var parser = Parse("achievement(\"T\", \"D\", 5, (byte(0x1234) == 1 || byte(0x2345) == 2) && byte(0x3456) == 3");

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -611,6 +611,16 @@ namespace RATools.Test.Parser
         }
 
         [Test]
+        public void TestTransitiveMath()
+        {
+            var parser = Parse("function f(n) => byte(n) + 1\n" +
+                               "achievement(\"T\", \"D\", 5, f(0x1234) - f(0x2345) == 3)\n");
+
+            var achievement = parser.Achievements.First();
+            Assert.That(GetRequirements(achievement), Is.EqualTo("(byte(0x001234) - byte(0x002345)) == 3"));
+        }
+
+        [Test]
         public void TestRichPresenceDisplay()
         {
             var parser = Parse("rich_presence_display(\"simple string\")");

--- a/Tests/Parser/Internal/MathematicExpressionTests.cs
+++ b/Tests/Parser/Internal/MathematicExpressionTests.cs
@@ -191,6 +191,34 @@ namespace RATools.Test.Parser.Internal
         }
 
         [Test]
+        public void TestRebalanceAddString()
+        {
+            // "A" + B - C => "A" + (B - C)
+            var str = new StringConstantExpression("ban");
+            var exprLeft = new IntegerConstantExpression(6);
+            var exprRight = new IntegerConstantExpression(2);
+            var clause = new MathematicExpression(exprLeft, MathematicOperation.Subtract, exprRight);
+            var expr = new MathematicExpression(str, MathematicOperation.Add, clause);
+
+            var result = expr.Rebalance() as MathematicExpression;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Left, Is.EqualTo(str));
+            Assert.That(result.Operation, Is.EqualTo(MathematicOperation.Add));
+            Assert.That(result.Right, Is.EqualTo(clause));
+
+            // A - B + "C" => (A - B) + "C"
+            clause = new MathematicExpression(exprRight, MathematicOperation.Add, str);
+            expr = new MathematicExpression(exprLeft, MathematicOperation.Subtract, clause);
+
+            result = expr.Rebalance() as MathematicExpression;
+            Assert.That(result, Is.Not.Null);
+            var expectedLeft = new MathematicExpression(exprLeft, MathematicOperation.Subtract, exprRight);
+            Assert.That(result.Left, Is.EqualTo(expectedLeft));
+            Assert.That(result.Operation, Is.EqualTo(MathematicOperation.Add));
+            Assert.That(result.Right, Is.EqualTo(str));
+        }
+
+        [Test]
         public void TestAdd()
         {
             var left = new IntegerConstantExpression(1);
@@ -277,6 +305,38 @@ namespace RATools.Test.Parser.Internal
             Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
             Assert.That(result, Is.InstanceOf<StringConstantExpression>());
             Assert.That(((StringConstantExpression)result).Value, Is.EqualTo("1ana"));
+        }
+
+        [Test]
+        public void TestAddStringExpression()
+        {
+            var left = new StringConstantExpression("ban");
+            var right1 = new IntegerConstantExpression(6);
+            var right2 = new IntegerConstantExpression(2);
+            var right = new MathematicExpression(right1, MathematicOperation.Subtract, right2);
+            var expr = new MathematicExpression(left, MathematicOperation.Add, right);
+            var scope = new InterpreterScope();
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
+            Assert.That(result, Is.InstanceOf<StringConstantExpression>());
+            Assert.That(((StringConstantExpression)result).Value, Is.EqualTo("ban4"));
+        }
+
+        [Test]
+        public void TestAddExpressionString()
+        {
+            var left1 = new IntegerConstantExpression(6);
+            var left2 = new IntegerConstantExpression(2);
+            var left = new MathematicExpression(left1, MathematicOperation.Subtract, left2);
+            var right = new StringConstantExpression("ana");
+            var expr = new MathematicExpression(left, MathematicOperation.Add, right);
+            var scope = new InterpreterScope();
+
+            ExpressionBase result;
+            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
+            Assert.That(result, Is.InstanceOf<StringConstantExpression>());
+            Assert.That(((StringConstantExpression)result).Value, Is.EqualTo("4ana"));
         }
 
         [Test]


### PR DESCRIPTION
* fixes subtraction of complex expressions (see #54)
* better handling of psuedo-implementation of abs:
  `abs(A - B) <= 1` => `A + 1 - B <= 2`
  Because the result is a unsigned int, the `+1` is required to prevent the -1 result from evaluating as higher than 1. The simplification code previously merged it into the 2, resulting in `A - B <= 1`, which won't handle the case where `B = A+1`. Now the subtraction of an unknown value is detected, along with the less than comparison, and the translation does not occur, leaving `A + 1 - B <= 2`