### PR TITLE
select/deselect all for Update Local dialog

### DIFF
--- a/ViewModels/GeneratedAchievementViewModel.cs
+++ b/ViewModels/GeneratedAchievementViewModel.cs
@@ -379,9 +379,6 @@ namespace RATools.ViewModels
             owner.UpdateLocal(null, Local.Achievement);
 
             Local = new AchievementViewModel(owner, "Local");
-            if (Generated.Achievement != null)
-                Local.LoadAchievement(Generated.Achievement);
-
             OnPropertyChanged(() => Local);
             UpdateModified();
         }

--- a/ViewModels/UpdateLocalViewModel.cs
+++ b/ViewModels/UpdateLocalViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Jamiras.DataModels;
+﻿using Jamiras.Commands;
+using Jamiras.DataModels;
 using Jamiras.ViewModels;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -45,6 +46,56 @@ namespace RATools.ViewModels
             }
 
             DialogResult = DialogResult.Ok;
+        }
+
+        public CommandBase ToggleSelectedForUpdateCommand
+        {
+            get { return new DelegateCommand(ExecuteToggleSelectedForUpdateCommand); }
+        }
+
+        private void ExecuteToggleSelectedForUpdateCommand()
+        {
+            if (_achievements.Any(a => !a.IsUpdated && a.CanUpdate))
+            {
+                foreach (var a in _achievements)
+                {
+                    if (a.CanUpdate)
+                        a.IsUpdated = true;
+                }
+            }
+            else
+            {
+                foreach (var a in _achievements)
+                {
+                    if (a.CanUpdate)
+                        a.IsUpdated = false;
+                }
+            }
+        }
+
+        public CommandBase ToggleSelectedForDeleteCommand
+        {
+            get { return new DelegateCommand(ExecuteToggleSelectedForDeleteCommand); }
+        }
+
+        private void ExecuteToggleSelectedForDeleteCommand()
+        {
+            if (_achievements.Any(a => !a.IsDeleted && a.CanDelete))
+            {
+                foreach (var a in _achievements)
+                {
+                    if (a.CanDelete)
+                        a.IsDeleted = true;
+                }
+            }
+            else
+            {
+                foreach (var a in _achievements)
+                {
+                    if (a.CanDelete)
+                        a.IsDeleted = false;
+                }
+            }
         }
 
         /// <summary>

--- a/Views/UpdateLocalDialog.xaml
+++ b/Views/UpdateLocalDialog.xaml
@@ -17,9 +17,18 @@
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <TextBlock FontSize="10" Margin="6,0,0,0" Text="Achievement" />
-        <TextBlock Grid.Column="1" FontSize="10" Text="Update" HorizontalAlignment="Center" />
-        <TextBlock Grid.Column="2" FontSize="10" Text="Delete" HorizontalAlignment="Center" />
-        <ListView Grid.Row="1" Grid.ColumnSpan="4" ItemsSource="{Binding Achievements}" Margin="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+        <TextBlock Grid.Column="1" FontSize="10" HorizontalAlignment="Center">
+            <Hyperlink Command="{Binding ToggleSelectedForUpdateCommand}">
+                <TextBlock Text="Update" />
+            </Hyperlink>
+        </TextBlock>
+        <TextBlock Grid.Column="2" FontSize="10" HorizontalAlignment="Center">
+            <Hyperlink Command="{Binding ToggleSelectedForDeleteCommand}">
+                <TextBlock Text="Delete" />
+            </Hyperlink>
+        </TextBlock>
+        <ListView Grid.Row="1" Grid.ColumnSpan="4" ItemsSource="{Binding Achievements}"
+                  Margin="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Grid>


### PR DESCRIPTION
Turns the "Update" and "Delete" column headers into hyperlinks. Clicking on them will "select all" if any items can be selected, or "deselect all" if all items are already selected.