### PR TITLE
add prior() function

### DIFF
--- a/Data/Field.cs
+++ b/Data/Field.cs
@@ -95,10 +95,12 @@ namespace RATools.Data
 
             if (Type == FieldType.PreviousValue)
                 builder.Append("prev(");
+            else if (Type == FieldType.PriorValue)
+                builder.Append("prior(");
 
             AppendMemoryReference(builder, Value, Size);
 
-            if (Type == FieldType.PreviousValue)
+            if (Type == FieldType.PreviousValue || Type == FieldType.PriorValue)
                 builder.Append(')');
         }
 
@@ -145,6 +147,26 @@ namespace RATools.Data
         }
 
         /// <summary>
+        /// Gets whether or not the field references memory.
+        /// </summary>
+        public bool IsMemoryReference
+        {
+            get
+            {
+                switch (Type)
+                {
+                    case FieldType.MemoryAddress:
+                    case FieldType.PreviousValue:
+                    case FieldType.PriorValue:
+                        return true;
+
+                    default:
+                        return false;
+                }
+            }
+        }
+
+        /// <summary>
         /// Appends the serialized field to the <paramref name="builder"/>
         /// </summary>
         /// <remarks>
@@ -160,6 +182,8 @@ namespace RATools.Data
 
             if (Type == FieldType.PreviousValue)
                 builder.Append('d');
+            else if (Type == FieldType.PriorValue)
+                builder.Append('p');
 
             builder.Append("0x");
 
@@ -194,6 +218,11 @@ namespace RATools.Data
             if (tokenizer.NextChar == 'd')
             {
                 fieldType = FieldType.PreviousValue;
+                tokenizer.Advance();
+            }
+            else if (tokenizer.NextChar == 'p')
+            {
+                fieldType = FieldType.PriorValue;
                 tokenizer.Advance();
             }
 
@@ -384,6 +413,11 @@ namespace RATools.Data
         /// The previous value at a memory address.
         /// </summary>
         PreviousValue = 2, // Delta
+
+        /// <summary>
+        /// The last differing value at a memory address.
+        /// </summary>
+        PriorValue = 4, // Prior
     }
 
     /// <summary>

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -78,7 +78,8 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new MemoryAccessorFunction("dword", FieldSize.DWord));
                 _globalScope.AddFunction(new BitFunction());
 
-                _globalScope.AddFunction(new PrevFunction());
+                _globalScope.AddFunction(new PrevPriorFunction("prev", FieldType.PreviousValue));
+                _globalScope.AddFunction(new PrevPriorFunction("prior", FieldType.PriorValue));
 
                 _globalScope.AddFunction(new OnceFunction());
                 _globalScope.AddFunction(new RepeatedFunction());

--- a/Parser/Functions/PrevPriorFunction.cs
+++ b/Parser/Functions/PrevPriorFunction.cs
@@ -4,13 +4,17 @@ using System.Linq;
 
 namespace RATools.Parser.Functions
 {
-    internal class PrevFunction : TriggerBuilderContext.FunctionDefinition
+    internal class PrevPriorFunction : TriggerBuilderContext.FunctionDefinition
     {
-        public PrevFunction()
-            : base("prev")
+        public PrevPriorFunction(string name, FieldType fieldType)
+            : base(name)
         {
+            _fieldType = fieldType;
+
             Parameters.Add(new VariableDefinitionExpression("accessor"));
         }
+
+        private readonly FieldType _fieldType;
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
@@ -77,7 +81,7 @@ namespace RATools.Parser.Functions
                 return error;
 
             var left = context.LastRequirement.Left;
-            context.LastRequirement.Left = new Field { Size = left.Size, Type = FieldType.PreviousValue, Value = left.Value };
+            context.LastRequirement.Left = new Field { Size = left.Size, Type = _fieldType, Value = left.Value };
             return null;
         }
     }

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -69,7 +69,7 @@
     <Compile Include="Parser\Functions\RichPresenceConditionalDisplayFunction.cs" />
     <Compile Include="Parser\Functions\RichPresenceDisplayFunction.cs" />
     <Compile Include="Parser\Functions\LeaderboardFunction.cs" />
-    <Compile Include="Parser\Functions\PrevFunction.cs" />
+    <Compile Include="Parser\Functions\PrevPriorFunction.cs" />
     <Compile Include="Parser\Functions\RepeatedFunction.cs" />
     <Compile Include="Parser\Functions\OnceFunction.cs" />
     <Compile Include="Parser\Functions\MemoryAccessorFunction.cs" />

--- a/Tests/Data/FieldTests.cs
+++ b/Tests/Data/FieldTests.cs
@@ -24,6 +24,7 @@ namespace RATools.Tests.Data
         [TestCase(FieldSize.Word, FieldType.MemoryAddress, 0x1234, "word(0x001234)")]
         [TestCase(FieldSize.DWord, FieldType.MemoryAddress, 0x1234, "dword(0x001234)")]
         [TestCase(FieldSize.Byte, FieldType.PreviousValue, 0x1234, "prev(byte(0x001234))")]
+        [TestCase(FieldSize.Byte, FieldType.PriorValue, 0x1234, "prior(byte(0x001234))")]
         [TestCase(FieldSize.Word, FieldType.Value, 0x1234, "4660")]
         [TestCase(FieldSize.Byte, FieldType.MemoryAddress, 0x123456, "byte(0x123456)")]
         public void TestToString(FieldSize fieldSize, FieldType fieldType, int value, string expected)
@@ -81,6 +82,7 @@ namespace RATools.Tests.Data
         [TestCase(FieldSize.Word, FieldType.MemoryAddress, 0x1234, "0x 001234")]
         [TestCase(FieldSize.DWord, FieldType.MemoryAddress, 0x1234, "0xX001234")]
         [TestCase(FieldSize.Byte, FieldType.PreviousValue, 0x1234, "d0xH001234")]
+        [TestCase(FieldSize.Byte, FieldType.PriorValue, 0x1234, "p0xH001234")]
         [TestCase(FieldSize.Word, FieldType.Value, 0x1234, "4660")]
         [TestCase(FieldSize.Byte, FieldType.MemoryAddress, 0x123456, "0xH123456")]
         public void TestSerialize(FieldSize fieldSize, FieldType fieldType, int value, string expected)
@@ -106,6 +108,7 @@ namespace RATools.Tests.Data
         [TestCase("0x 001234", FieldSize.Word, FieldType.MemoryAddress, 0x1234)]
         [TestCase("0xX001234", FieldSize.DWord, FieldType.MemoryAddress, 0x1234)]
         [TestCase("d0xH001234", FieldSize.Byte, FieldType.PreviousValue, 0x1234)]
+        [TestCase("p0xH001234", FieldSize.Byte, FieldType.PriorValue, 0x1234)]
         [TestCase("4660", FieldSize.None, FieldType.Value, 0x1234)]
         [TestCase("0xH123456", FieldSize.Byte, FieldType.MemoryAddress, 0x123456)]
         public void TestDeserialize(string serialized, FieldSize fieldSize, FieldType fieldType, int value)

--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -128,14 +128,14 @@ namespace RATools.ViewModels
                         if (requirement.Requirement == null)
                             continue;
 
-                        if (requirement.Requirement.Left != null && (requirement.Requirement.Left.Type == FieldType.MemoryAddress || requirement.Requirement.Left.Type == FieldType.PreviousValue))
+                        if (requirement.Requirement.Left != null && requirement.Requirement.Left.IsMemoryReference)
                         {
                             var memoryItem = AddMemoryAddress(requirement.Requirement.Left);
                             if (memoryItem != null && !dumpAchievement.MemoryAddresses.Contains(memoryItem))
                                 dumpAchievement.MemoryAddresses.Add(memoryItem);
                         }
 
-                        if (requirement.Requirement.Right != null && (requirement.Requirement.Right.Type == FieldType.MemoryAddress || requirement.Requirement.Right.Type == FieldType.PreviousValue))
+                        if (requirement.Requirement.Right != null && requirement.Requirement.Right.IsMemoryReference)
                         {
                             var memoryItem = AddMemoryAddress(requirement.Requirement.Right);
                             if (memoryItem != null && !dumpAchievement.MemoryAddresses.Contains(memoryItem))

--- a/ViewModels/RequirementViewModel.cs
+++ b/ViewModels/RequirementViewModel.cs
@@ -39,14 +39,14 @@ namespace RATools.ViewModels
                     else
                     {
                         string note;
-                        if (requirement.Left.IsMemoryReference && notes.TryGetValue((int)requirement.Left.Value, out note))
+                        if (notes.TryGetValue((int)requirement.Left.Value, out note))
                             Notes = note;
                     }
                 }
                 else if (requirement.Right.IsMemoryReference)
                 {
                     string note;
-                    if (requirement.Right.IsMemoryReference && notes.TryGetValue((int)requirement.Right.Value, out note))
+                    if (notes.TryGetValue((int)requirement.Right.Value, out note))
                         Notes = note;
                 }
             }

--- a/ViewModels/RequirementViewModel.cs
+++ b/ViewModels/RequirementViewModel.cs
@@ -17,29 +17,37 @@ namespace RATools.ViewModels
             {
                 UpdateDefinition(numberFormat);
 
-                if (!requirement.Right.IsMemoryReference ||
-                    (requirement.Left.IsMemoryReference && requirement.Left.Value == requirement.Right.Value))
+                if (requirement.Left.IsMemoryReference)
                 {
-                    string note;
-                    if (requirement.Left.IsMemoryReference && notes.TryGetValue((int)requirement.Left.Value, out note))
-                        Notes = note;
-                }
-                else
-                {
-                    var builder = new StringBuilder();
-
-                    string note;
-                    if (requirement.Left.Type != FieldType.Value && notes.TryGetValue((int)requirement.Left.Value, out note))
-                        builder.AppendFormat("0x{0:x6}:{1}", requirement.Left.Value, note);
-
-                    if (requirement.Right.Type != FieldType.Value && notes.TryGetValue((int)requirement.Right.Value, out note))
+                    if (requirement.Right.IsMemoryReference && requirement.Left.Value != requirement.Right.Value)
                     {
-                        if (builder.Length > 0)
-                            builder.AppendLine();
-                        builder.AppendFormat("0x{0:x6}:{1}", requirement.Right.Value, note);
-                    }
+                        var builder = new StringBuilder();
 
-                    Notes = builder.ToString();
+                        string note;
+                        if (notes.TryGetValue((int)requirement.Left.Value, out note))
+                            builder.AppendFormat("0x{0:x6}:{1}", requirement.Left.Value, note);
+
+                        if (notes.TryGetValue((int)requirement.Right.Value, out note))
+                        {
+                            if (builder.Length > 0)
+                                builder.AppendLine();
+                            builder.AppendFormat("0x{0:x6}:{1}", requirement.Right.Value, note);
+                        }
+
+                        Notes = builder.ToString();
+                    }
+                    else
+                    {
+                        string note;
+                        if (requirement.Left.IsMemoryReference && notes.TryGetValue((int)requirement.Left.Value, out note))
+                            Notes = note;
+                    }
+                }
+                else if (requirement.Right.IsMemoryReference)
+                {
+                    string note;
+                    if (requirement.Right.IsMemoryReference && notes.TryGetValue((int)requirement.Right.Value, out note))
+                        Notes = note;
                 }
             }
         }

--- a/ViewModels/RequirementViewModel.cs
+++ b/ViewModels/RequirementViewModel.cs
@@ -17,12 +17,11 @@ namespace RATools.ViewModels
             {
                 UpdateDefinition(numberFormat);
 
-                if (requirement.Right.Type == FieldType.Value ||
-                    requirement.Right.Type == FieldType.None ||
-                    (requirement.Right.Type == FieldType.PreviousValue && requirement.Right.Value == requirement.Left.Value))
+                if (!requirement.Right.IsMemoryReference ||
+                    (requirement.Left.IsMemoryReference && requirement.Left.Value == requirement.Right.Value))
                 {
                     string note;
-                    if (requirement.Left.Type != FieldType.Value && notes.TryGetValue((int)requirement.Left.Value, out note))
+                    if (requirement.Left.IsMemoryReference && notes.TryGetValue((int)requirement.Left.Value, out note))
                         Notes = note;
                 }
                 else


### PR DESCRIPTION
Supports new "prior" data type in 0.76 integration DLL. Syntax is the same as `prev()`