### PR TITLE
add Settings dialog

### DIFF
--- a/RATools.csproj
+++ b/RATools.csproj
@@ -91,8 +91,12 @@
     <Compile Include="ViewModels\AboutDialogViewModel.cs" />
     <Compile Include="ViewModels\EditorViewModel.cs" />
     <Compile Include="ViewModels\NewScriptDialogViewModel.cs" />
+    <Compile Include="ViewModels\OptionsDialogViewModel.cs" />
     <Compile Include="ViewModels\ScriptViewModel.cs" />
     <Compile Include="ViewModels\UpdateLocalViewModel.cs" />
+    <Compile Include="Views\OptionsDialog.xaml.cs">
+      <DependentUpon>OptionsDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\UpdateLocalDialog.xaml.cs">
       <DependentUpon>UpdateLocalDialog.xaml</DependentUpon>
     </Compile>
@@ -140,6 +144,10 @@
     <Compile Include="ViewModels\RequirementGroupViewModel.cs" />
     <Compile Include="ViewModels\RequirementViewModel.cs" />
     <Compile Include="ViewModels\RichPresenceViewModel.cs" />
+    <Page Include="Views\OptionsDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Views\ScriptViewer.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/Services/ISettings.cs
+++ b/Services/ISettings.cs
@@ -7,7 +7,7 @@ namespace RATools.Services
         /// <summary>
         /// Gets the directories to search for cached RA data.
         /// </summary>
-        IEnumerable<string> DataDirectories { get; }
+        IEnumerable<string> EmulatorDirectories { get; }
 
         /// <summary>
         /// Gets the name of the user.

--- a/Services/Settings.cs
+++ b/Services/Settings.cs
@@ -24,7 +24,7 @@ namespace RATools.Services
             var hexValues = persistance.GetValue("HexValues");
             _hexValues = (hexValues == "1");
 
-            EmulatorDirectories = new string[0];
+            EmulatorDirectories = new List<string>();
             UserName = "RATools";
 
             var file = new IniFile("RATools.ini");
@@ -37,10 +37,9 @@ namespace RATools.Services
                 {
                     EmulatorDirectories = new List<string>(emulatorDirectories.Split(';'));
                 }
-                else
+                else if (values.TryGetValue("RACacheDirectory", out emulatorDirectories))
                 {
-                    EmulatorDirectories = new List<string>();
-                    foreach (var path in values["RACacheDirectory"].Split(';'))
+                    foreach (var path in emulatorDirectories.Split(';'))
                     {
                         if (path.EndsWith("RACache\\Data", StringComparison.OrdinalIgnoreCase))
                             EmulatorDirectories.Add(path.Substring(0, path.Length - 13));
@@ -78,8 +77,16 @@ namespace RATools.Services
             }
 
             values["User"] = UserName;
-            values["ApiKey"] = ApiKey;
-            values["EmulatorDirectories"] = string.Join(";", EmulatorDirectories);
+
+            if (String.IsNullOrEmpty(ApiKey))
+                values.Remove("ApiKey");
+            else
+                values["ApiKey"] = ApiKey;
+
+            if (EmulatorDirectories.Count == 0)
+                values.Remove("EmulatorDirectories");
+            else
+                values["EmulatorDirectories"] = string.Join(";", EmulatorDirectories);
 
             values.Remove("RACacheDirectory");
 

--- a/ViewModels/AboutDialogViewModel.cs
+++ b/ViewModels/AboutDialogViewModel.cs
@@ -1,11 +1,7 @@
 ﻿using Jamiras.Commands;
-using Jamiras.Components;
 using Jamiras.ViewModels;
-using RATools.Services;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection;
 
 namespace RATools.ViewModels
@@ -17,12 +13,6 @@ namespace RATools.ViewModels
             DialogTitle = "About";
             SourceLinkCommand = new DelegateCommand(OpenSourceLink);
             CancelButtonText = null;
-
-            var directories = new List<LookupItem>();
-            foreach (var path in ServiceRepository.Instance.FindService<ISettings>().DataDirectories)
-                directories.Add(new LookupItem(Directory.Exists(path) ? 1 : 0, path));
-
-            DataDirectories = directories;
         }
 
         public string ProductVersion
@@ -72,7 +62,5 @@ namespace RATools.ViewModels
         {
             Process.Start(SourceLink);
         }
-
-        public IEnumerable<LookupItem> DataDirectories { get; private set; }
     }
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -24,6 +24,7 @@ namespace RATools.ViewModels
             SaveScriptAsCommand = DisabledCommand.Instance;
             RefreshScriptCommand = DisabledCommand.Instance;
             OpenRecentCommand = new DelegateCommand<string>(OpenFile);
+            SettingsCommand = new DelegateCommand(OpenSettings);
             ExitCommand = new DelegateCommand(Exit);
 
             UpdateLocalCommand = DisabledCommand.Instance;
@@ -262,9 +263,9 @@ namespace RATools.ViewModels
             var gameTitle = expressionGroup.Comments[0].Value.Substring(2).Trim();
             GameViewModel viewModel = null;
 
-            foreach (var directory in ServiceRepository.Instance.FindService<ISettings>().DataDirectories)
+            foreach (var directory in ServiceRepository.Instance.FindService<ISettings>().EmulatorDirectories)
             {
-                var notesFile = Path.Combine(directory, gameId + "-Notes2.txt");
+                var notesFile = Path.Combine(directory, "RACache", "Data", gameId + "-Notes2.txt");
                 if (File.Exists(notesFile))
                 {
                     logger.WriteVerbose("Found code notes in " + directory);
@@ -273,7 +274,7 @@ namespace RATools.ViewModels
                 }
                 else
                 {
-                    notesFile = Path.Combine(directory, gameId + "-Notes.json");
+                    notesFile = Path.Combine(directory, "RACache", "Data", gameId + "-Notes.json");
                     if (File.Exists(notesFile))
                     {
                         logger.WriteVerbose("Found code notes in " + directory);
@@ -286,7 +287,8 @@ namespace RATools.ViewModels
             if (viewModel == null)
             {
                 logger.WriteVerbose("Could not find code notes");
-                MessageBoxViewModel.ShowMessage("Could not locate notes file for game " + gameId);
+                MessageBoxViewModel.ShowMessage("Could not locate notes file for game " + gameId + ".\n\n" +
+                    "The game does not appear to have been recently loaded in any of the emulators specified in the Settings dialog.");
 
                 viewModel = new GameViewModel(gameId, gameTitle);
             }
@@ -386,6 +388,14 @@ namespace RATools.ViewModels
             var dialog = new NewScriptDialogViewModel();
             if (dialog.ShowDialog() == DialogResult.Ok)
                 Game = dialog.Finalize();
+        }
+
+        public CommandBase SettingsCommand { get; private set; }
+        private void OpenSettings()
+        {
+            var vm = new OptionsDialogViewModel();
+            if (vm.ShowDialog() == DialogResult.Ok)
+                vm.ApplyChanges();
         }
 
         public CommandBase UpdateLocalCommand { get; private set; }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -265,22 +265,16 @@ namespace RATools.ViewModels
 
             foreach (var directory in ServiceRepository.Instance.FindService<ISettings>().EmulatorDirectories)
             {
-                var notesFile = Path.Combine(directory, "RACache", "Data", gameId + "-Notes2.txt");
+                var dataDirectory = Path.Combine(directory, "RACache", "Data");
+
+                var notesFile = Path.Combine(dataDirectory, gameId + "-Notes.json");
+                if (!File.Exists(notesFile))
+                    notesFile = Path.Combine(dataDirectory, gameId + "-Notes2.txt");
+
                 if (File.Exists(notesFile))
                 {
-                    logger.WriteVerbose("Found code notes in " + directory);
-
-                    viewModel = new GameViewModel(gameId, gameTitle, directory.ToString());
-                }
-                else
-                {
-                    notesFile = Path.Combine(directory, "RACache", "Data", gameId + "-Notes.json");
-                    if (File.Exists(notesFile))
-                    {
-                        logger.WriteVerbose("Found code notes in " + directory);
-
-                        viewModel = new GameViewModel(gameId, gameTitle, directory.ToString());
-                    }
+                    logger.WriteVerbose("Found code notes in " + dataDirectory);
+                    viewModel = new GameViewModel(gameId, gameTitle, dataDirectory);
                 }
             }
 

--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -71,11 +71,11 @@ namespace RATools.ViewModels
         private void Search()
         {
             int gameId = GameId.Value.GetValueOrDefault();
-            foreach (var directory in ServiceRepository.Instance.FindService<ISettings>().DataDirectories)
+            foreach (var directory in ServiceRepository.Instance.FindService<ISettings>().EmulatorDirectories)
             {
-                var notesFile = Path.Combine(directory, gameId + "-Notes.json");
+                var notesFile = Path.Combine(directory, "RACache", "Data", gameId + "-Notes.json");
                 if (!File.Exists(notesFile))
-                    notesFile = Path.Combine(directory, gameId + "-Notes2.txt");
+                    notesFile = Path.Combine(directory, "RACache", "Data", gameId + "-Notes2.txt");
 
                 if (File.Exists(notesFile))
                 {

--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -84,7 +84,8 @@ namespace RATools.ViewModels
                 }
             }
 
-            MessageBoxViewModel.ShowMessage("Could not locate notes file for game " + gameId);
+            MessageBoxViewModel.ShowMessage("Could not locate notes file for game " + gameId + ".\n\n" +
+                "The game does not appear to have been recently loaded in any of the emulators specified in the Settings dialog.");
             return;
         }
 

--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -73,13 +73,15 @@ namespace RATools.ViewModels
             int gameId = GameId.Value.GetValueOrDefault();
             foreach (var directory in ServiceRepository.Instance.FindService<ISettings>().EmulatorDirectories)
             {
-                var notesFile = Path.Combine(directory, "RACache", "Data", gameId + "-Notes.json");
+                var dataDirectory = Path.Combine(directory, "RACache", "Data");
+
+                var notesFile = Path.Combine(dataDirectory, gameId + "-Notes.json");
                 if (!File.Exists(notesFile))
-                    notesFile = Path.Combine(directory, "RACache", "Data", gameId + "-Notes2.txt");
+                    notesFile = Path.Combine(dataDirectory, gameId + "-Notes2.txt");
 
                 if (File.Exists(notesFile))
                 {
-                    LoadGame(gameId, directory);
+                    LoadGame(gameId, dataDirectory);
                     return;
                 }
             }

--- a/ViewModels/OptionsDialogViewModel.cs
+++ b/ViewModels/OptionsDialogViewModel.cs
@@ -1,0 +1,103 @@
+﻿using Jamiras.Commands;
+using Jamiras.Components;
+using Jamiras.DataModels;
+using Jamiras.Services;
+using Jamiras.ViewModels;
+using Jamiras.ViewModels.Fields;
+using RATools.Services;
+using System.Collections.ObjectModel;
+using System.IO;
+
+namespace RATools.ViewModels
+{
+    public class OptionsDialogViewModel : DialogViewModelBase
+    {
+        public OptionsDialogViewModel()
+            : this(ServiceRepository.Instance.FindService<ISettings>(),
+                   ServiceRepository.Instance.FindService<IFileSystemService>())
+        {
+        }
+
+        public OptionsDialogViewModel(ISettings settings, IFileSystemService fileSystemService)
+        {
+            _settings = settings;
+            _fileSystemService = fileSystemService;
+
+            UserName = new TextFieldViewModel("UserName", 80);
+            UserName.Text = settings.UserName;
+
+            Directories = new ObservableCollection<DirectoryViewModel>();
+            foreach (var path in settings.EmulatorDirectories)
+            {
+                var directoryViewModel = new DirectoryViewModel { Path = path };
+
+                var cachePath = Path.Combine(path, "RACache", "Data");
+                directoryViewModel.IsValid = fileSystemService.DirectoryExists(cachePath);
+
+                Directories.Add(directoryViewModel);
+            }
+
+            DialogTitle = "Settings";
+
+            AddDirectoryCommand = new DelegateCommand(AddDirectory);
+            RemoveDirectoryCommand = new DelegateCommand(RemoveDirectory);
+        }
+
+        private readonly ISettings _settings;
+        private readonly IFileSystemService _fileSystemService;
+
+        public TextFieldViewModel UserName { get; private set; }
+
+        public class DirectoryViewModel
+        {
+            public string Path { get; set; }
+            public bool IsValid { get; set; }
+        }
+
+        public ObservableCollection<DirectoryViewModel> Directories { get; private set; }
+
+        public static readonly ModelProperty SelectedDirectoryProperty = ModelProperty.Register(typeof(OptionsDialogViewModel), "SelectedDirectory", typeof(DirectoryViewModel), null);
+
+        public DirectoryViewModel SelectedDirectory
+        {
+            get { return (DirectoryViewModel)GetValue(SelectedDirectoryProperty); }
+            set { SetValue(SelectedDirectoryProperty, value); }
+        }
+
+        public void ApplyChanges()
+        {
+            var settings = (Settings)_settings;
+            settings.UserName = UserName.Text;
+
+            settings.EmulatorDirectories.Clear();
+            foreach (var directoryViewModel in Directories)
+                settings.EmulatorDirectories.Add(directoryViewModel.Path);
+
+            settings.Save();
+        }
+
+        public CommandBase AddDirectoryCommand { get; private set; }
+        private void AddDirectory()
+        {
+            var vm = new FileDialogViewModel();
+
+            if (vm.ShowSelectFolderDialog() == DialogResult.Ok)
+            {
+                var directoryViewModel = new DirectoryViewModel { Path = vm.FileNames[0] };
+
+                var cachePath = Path.Combine(vm.FileNames[0], "RACache", "Data");
+                directoryViewModel.IsValid = _fileSystemService.DirectoryExists(cachePath);
+
+                Directories.Add(directoryViewModel);
+            }
+        }
+
+        public CommandBase RemoveDirectoryCommand { get; private set; }
+        private void RemoveDirectory()
+        {
+            var selectedDirectory = SelectedDirectory;
+            if (selectedDirectory != null)
+                Directories.Remove(selectedDirectory);
+        }
+    }
+}

--- a/Views/AboutDialog.xaml
+++ b/Views/AboutDialog.xaml
@@ -3,7 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:RATools.Views"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.Resources>
@@ -17,7 +16,6 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
         <Grid.ColumnDefinitions>
@@ -37,37 +35,5 @@
                 <TextBlock Text="{Binding SourceLink}" />
             </Hyperlink>
         </TextBlock>
-
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Margin="0,4,0,0">
-            <Border BorderThickness="1" Height="1" BorderBrush="LightGray" />
-            <TextBlock Text="Data Directories" FontSize="10" Foreground="Gray"/>
-            <ItemsControl ItemsSource="{Binding DataDirectories}">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="16" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock HorizontalAlignment="Center" FontSize="10">
-                                <TextBlock.Style>
-                                    <Style TargetType="{x:Type TextBlock}">
-                                        <Setter Property="Foreground" Value="#00D040" />
-                                        <Setter Property="Text" Value="&#10003;" />
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding Id}" Value="0">
-                                                <Setter Property="Foreground" Value="#E04040" />
-                                                <Setter Property="Text" Value="&#10008;" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
-                            <TextBlock Grid.Column="1" Text="{Binding Label}" FontSize="10" Foreground="Gray" Margin="0,0,4,0"/>
-                        </Grid>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </StackPanel>
     </Grid>
 </UserControl>

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -22,7 +22,7 @@
                 <MenuItem Header="_Save Script" Command="{Binding SaveScriptCommand}" 
                           controls:CommandBinding.InputGesture="Ctrl+S" />
                 <MenuItem Header="Save Script _As" Command="{Binding SaveScriptAsCommand}" />
-                <MenuItem Header="_Revert" Command="{Binding RefreshScriptCommand}" 
+                <MenuItem Header="Re_vert" Command="{Binding RefreshScriptCommand}" 
                           controls:CommandBinding.InputGesture="F5" />
                 <Separator />
                 <MenuItem Header="_Recent" ItemsSource="{Binding RecentFiles}">
@@ -33,7 +33,9 @@
                     </MenuItem.ItemTemplate>
                 </MenuItem>
                 <Separator />
-                <MenuItem Header="_Exit" Command="{Binding ExitCommand}" InputGestureText="Alt+F4" />
+                <MenuItem Header="S_ettings..." Command="{Binding SettingsCommand}" />
+                <Separator />
+                <MenuItem Header="E_xit" Command="{Binding ExitCommand}" InputGestureText="Alt+F4" />
             </MenuItem>
             <MenuItem Header="_Edit">
                 <MenuItem Header="_Goto Line" Command="{Binding Game.SelectedEditor.Editor.GotoLineCommand, FallbackValue={x:Static commands:DisabledCommand.Instance}}" InputGestureText="Ctrl+G" />

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace RATools.Views
             windowSettingsRepository.RestoreSettings(this);
 
             dialogService.RegisterDialogHandler(typeof(NewScriptDialogViewModel), vm => new NewScriptDialog());
+            dialogService.RegisterDialogHandler(typeof(OptionsDialogViewModel), vm => new OkCancelView(new OptionsDialog()));
             dialogService.RegisterDialogHandler(typeof(UpdateLocalViewModel), vm => new OkCancelView(new UpdateLocalDialog()));
             dialogService.RegisterDialogHandler(typeof(GameStatsViewModel), vm => new GameStatsDialog());
             dialogService.RegisterDialogHandler(typeof(OpenTicketsViewModel), vm => new OpenTicketsDialog());

--- a/Views/OptionsDialog.xaml
+++ b/Views/OptionsDialog.xaml
@@ -1,0 +1,86 @@
+﻿<UserControl x:Class="RATools.Views.OptionsDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:RATools"
+             mc:Ignorable="d" 
+             Width="600" Height="290">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Jamiras.Core;component/Controls/Styles/FieldStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid Margin="4">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <GroupBox Header="User Name">
+            <StackPanel>
+                <TextBlock Margin="2" FontSize="11" Text="Please enter your RetroAchievements.org user name here." />
+                <TextBox Text="{Binding UserName.Text}" Margin="2" MaxLength="{Binding UserName.MaxLength}" />
+            </StackPanel>
+        </GroupBox>
+
+        <GroupBox Grid.Row="1" Header="Emulator Directories">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <TextBlock TextWrapping="Wrap" FontSize="11" Margin="2"
+                           Text="Specifies the directories where RetroAchievements emulators are installed. Code notes are loaded from the emulator cache directories." />
+                <ListView Grid.Row="1" Margin="0,2,0,2" x:Name="directoriesList"
+                          ItemsSource="{Binding Directories}" SelectedItem="{Binding SelectedDirectory}">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="12" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10">
+                                    <TextBlock.Style>
+                                        <Style TargetType="{x:Type TextBlock}">
+                                            <Setter Property="Foreground" Value="#00D040" />
+                                            <Setter Property="Text" Value="&#10003;" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsValid}" Value="false">
+                                                    <Setter Property="Foreground" Value="#E04040" />
+                                                    <Setter Property="Text" Value="&#10008;" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <TextBlock Grid.Column="1" FontSize="11" Text="{Binding Path}" />
+                            </Grid>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+
+                <Button Grid.Row="2" HorizontalAlignment="Left" Width="80" 
+                        Content="Remove" Command="{Binding RemoveDirectoryCommand}">
+                    <Button.Style>
+                        <Style TargetType="{x:Type Button}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedDirectory}" Value="{x:Null}">
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
+
+                <Button Grid.Row="2" HorizontalAlignment="Right" Width="80" 
+                        Content="Add" Command="{Binding AddDirectoryCommand}" />
+            </Grid>
+        </GroupBox>
+    </Grid>
+</UserControl>

--- a/Views/OptionsDialog.xaml.cs
+++ b/Views/OptionsDialog.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Controls;
+
+namespace RATools.Views
+{
+    /// <summary>
+    /// Interaction logic for OptionsDialog.xaml
+    /// </summary>
+    public partial class OptionsDialog : UserControl
+    {
+        public OptionsDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Implements #77 

![image](https://user-images.githubusercontent.com/32680403/60776928-adcb0400-a0ec-11e9-82a8-38ca5cbce1be.png)

The list of directories has been removed from the About dialog and is now present here, where it can be modified. It still shows a green check or red X to indicate whether or not the directory is valid.

Additionally, the paths no longer require `RACache\Data` (#76). The new ini field (without `RACache\Data`) is `EmulatorDirectories`. `RACacheDirectory` will be converted on load and replaced when saved.