### PR TITLE
fix generating achievement from string with no core group

### DIFF
--- a/Data/Requirement.cs
+++ b/Data/Requirement.cs
@@ -52,32 +52,44 @@ namespace RATools.Data
         internal void AppendString(StringBuilder builder, NumberFormat numberFormat, 
             string addSources = null, string subSources = null, string addHits = null, string andNext = null)
         {
-            if (HitCount == 1)
-                builder.Append("once(");
-            else if (HitCount > 0)
-                builder.AppendFormat("repeated({0}, ", HitCount);
-
             switch (Type)
             {
                 case RequirementType.ResetIf:
                     builder.Append("never(");
-                    AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
                     builder.Append(')');
                     break;
 
                 case RequirementType.PauseIf:
                     builder.Append("unless(");
-                    AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
                     builder.Append(')');
                     break;
 
                 default:
-                    AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
                     break;
             }
+        }
 
-            if (HitCount != 0)
+        private void AppendRepeatedCondition(StringBuilder builder, NumberFormat numberFormat,
+            string addSources, string subSources, string addHits, string andNext)
+        {
+            if (HitCount == 0)
+            {
+                AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+            }
+            else
+            {
+                if (HitCount == 1)
+                    builder.Append("once(");
+                else
+                    builder.AppendFormat("repeated({0}, ", HitCount);
+
+                AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+
                 builder.Append(')');
+            }
         }
 
         internal void AppendCondition(StringBuilder builder, NumberFormat numberFormat, 

--- a/Data/Requirement.cs
+++ b/Data/Requirement.cs
@@ -157,6 +157,76 @@ namespace RATools.Data
         }
 
         /// <summary>
+        /// Determines if the requirement always evaluates true or false.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if the requirement is always true, <c>false</c> if it's always false, or 
+        /// <c>null</c> if the result cannot be determined at this time.
+        /// </returns>
+        public bool? Evaluate()
+        {
+            if (Left.Type != Right.Type)
+                return null;
+
+            bool result = false;
+
+            if (Left.Type != FieldType.Value)
+            {
+                // memory reference - can only be equal or not equal to same memory reference
+                if (Left.Value != Right.Value)
+                    return null;
+
+                // same memory reference in the same frame is always equal
+                switch (Operator)
+                {
+                    case RequirementOperator.Equal:
+                    case RequirementOperator.GreaterThanOrEqual:
+                    case RequirementOperator.LessThanOrEqual:
+                        result = true;
+                        break;
+
+                    default:
+                        result = false;
+                        break;
+                }
+            }
+            else
+            {
+                // comparing constants
+                switch (Operator)
+                {
+                    case RequirementOperator.Equal:
+                        result = (Left.Value == Right.Value);
+                        break;
+                    case RequirementOperator.NotEqual:
+                        result = (Left.Value != Right.Value);
+                        break;
+                    case RequirementOperator.LessThan:
+                        result = (Left.Value < Right.Value);
+                        break;
+                    case RequirementOperator.LessThanOrEqual:
+                        result = (Left.Value <= Right.Value);
+                        break;
+                    case RequirementOperator.GreaterThan:
+                        result = (Left.Value > Right.Value);
+                        break;
+                    case RequirementOperator.GreaterThanOrEqual:
+                        result = (Left.Value >= Right.Value);
+                        break;
+                    default:
+                        result = false;
+                        break;
+                }
+            }
+
+            // even if the condition is always true, if there's a target hit count, it won't be true initially.
+            if (result && HitCount > 1)
+                return null;
+
+            return result;
+        }
+
+        /// <summary>
         /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
         /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>

--- a/Data/Requirement.cs
+++ b/Data/Requirement.cs
@@ -170,10 +170,10 @@ namespace RATools.Data
 
             bool result = false;
 
-            if (Left.Type != FieldType.Value)
+            if (Left.IsMemoryReference)
             {
                 // memory reference - can only be equal or not equal to same memory reference
-                if (Left.Value != Right.Value)
+                if (Left.Value != Right.Value || Left.Size != Right.Size)
                     return null;
 
                 // same memory reference in the same frame is always equal

--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -541,9 +541,10 @@ namespace RATools.Parser
 
                 if (requirement.Left.Type == FieldType.Value)
                 {
-                    if (requirement.Evaluate() == true)
+                    var result = requirement.Evaluate();
+                    if (result == true)
                         alwaysTrue.Add(requirementEx);
-                    else
+                    else if (result == false)
                         alwaysFalse.Add(requirementEx);
 
                     continue;

--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -90,12 +90,6 @@ namespace RATools.Parser
         {
             var core = _core.ToArray();
 
-            // if core is empty and any alts exist, add an always_true condition to the core for compatibility
-            // with legacy RetroArch parsing. duplicates functionality in SerializeRequirements so the 
-            // condition will appear in the editor
-            if (core.Length == 0 && _alts.Any())
-                core = new Requirement[] { AlwaysTrueFunction.CreateAlwaysTrueRequirement() };
-
             var achievement = new Achievement { Title = Title, Description = Description, Points = Points, CoreRequirements = core, Id = Id, BadgeName = BadgeName };
             var alts = new Requirement[_alts.Count][];
             for (int i = 0; i < _alts.Count; i++)
@@ -339,7 +333,7 @@ namespace RATools.Parser
             NumberFormat numberFormat, int wrapWidth, int indent = 14)
         {
             bool needsAmpersand = false;
-            int width = wrapWidth;
+            int width = wrapWidth - indent;
 
             var enumerator = group.GetEnumerator();
             while (enumerator.MoveNext())
@@ -430,14 +424,14 @@ namespace RATools.Parser
                     builder.AppendLine();
                     builder.Append(' ', indent);
                     definition.Remove(0, index);
-                    width = wrapWidth;
+                    width = wrapWidth - indent;
                 }
 
                 if (width - definition.Length < 0)
                 {
                     builder.AppendLine();
                     builder.Append(' ', indent);
-                    width = wrapWidth;
+                    width = wrapWidth - indent;
                 }
 
                 width -= definition.Length;

--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -112,53 +112,56 @@ namespace RATools.Parser
             var current = _core;
             do
             {
-                var requirement = new Requirement();
-
-                if (tokenizer.Match("R:"))
-                    requirement.Type = RequirementType.ResetIf;
-                else if (tokenizer.Match("P:"))
-                    requirement.Type = RequirementType.PauseIf;
-                else if (tokenizer.Match("A:"))
-                    requirement.Type = RequirementType.AddSource;
-                else if (tokenizer.Match("B:"))
-                    requirement.Type = RequirementType.SubSource;
-                else if (tokenizer.Match("C:"))
-                    requirement.Type = RequirementType.AddHits;
-                else if (tokenizer.Match("N:"))
-                    requirement.Type = RequirementType.AndNext;
-
-                requirement.Left = Field.Deserialize(tokenizer);
-
-                requirement.Operator = ReadOperator(tokenizer);
-                requirement.Right = Field.Deserialize(tokenizer);
-
-                switch (requirement.Type)
+                if (tokenizer.NextChar != 'S')
                 {
-                    case RequirementType.AddSource:
-                    case RequirementType.SubSource:
-                        requirement.Operator = RequirementOperator.None;
-                        requirement.Right = new Field();
-                        break;
+                    var requirement = new Requirement();
 
-                    default:
-                        if (requirement.Right.Size == FieldSize.None)
-                            requirement.Right = new Field { Type = requirement.Right.Type, Size = requirement.Left.Size, Value = requirement.Right.Value };
-                        break;
-                }
+                    if (tokenizer.Match("R:"))
+                        requirement.Type = RequirementType.ResetIf;
+                    else if (tokenizer.Match("P:"))
+                        requirement.Type = RequirementType.PauseIf;
+                    else if (tokenizer.Match("A:"))
+                        requirement.Type = RequirementType.AddSource;
+                    else if (tokenizer.Match("B:"))
+                        requirement.Type = RequirementType.SubSource;
+                    else if (tokenizer.Match("C:"))
+                        requirement.Type = RequirementType.AddHits;
+                    else if (tokenizer.Match("N:"))
+                        requirement.Type = RequirementType.AndNext;
 
-                current.Add(requirement);
+                    requirement.Left = Field.Deserialize(tokenizer);
 
-                if (tokenizer.NextChar == '.')
-                {
-                    tokenizer.Advance(); // first period
-                    requirement.HitCount = (ushort)ReadNumber(tokenizer);
-                    tokenizer.Advance(); // second period
-                }
-                else if (tokenizer.NextChar == '(') // old format
-                {
-                    tokenizer.Advance(); // '('
-                    requirement.HitCount = (ushort)ReadNumber(tokenizer);
-                    tokenizer.Advance(); // ')'
+                    requirement.Operator = ReadOperator(tokenizer);
+                    requirement.Right = Field.Deserialize(tokenizer);
+
+                    switch (requirement.Type)
+                    {
+                        case RequirementType.AddSource:
+                        case RequirementType.SubSource:
+                            requirement.Operator = RequirementOperator.None;
+                            requirement.Right = new Field();
+                            break;
+
+                        default:
+                            if (requirement.Right.Size == FieldSize.None)
+                                requirement.Right = new Field { Type = requirement.Right.Type, Size = requirement.Left.Size, Value = requirement.Right.Value };
+                            break;
+                    }
+
+                    if (tokenizer.NextChar == '.')
+                    {
+                        tokenizer.Advance(); // first period
+                        requirement.HitCount = (ushort)ReadNumber(tokenizer);
+                        tokenizer.Advance(); // second period
+                    }
+                    else if (tokenizer.NextChar == '(') // old format
+                    {
+                        tokenizer.Advance(); // '('
+                        requirement.HitCount = (ushort)ReadNumber(tokenizer);
+                        tokenizer.Advance(); // ')'
+                    }
+
+                    current.Add(requirement);
                 }
 
                 switch (tokenizer.NextChar)
@@ -332,9 +335,11 @@ namespace RATools.Parser
             }
         }
 
-        static void AppendDebugStringGroup(StringBuilder builder, ICollection<Requirement> group)
+        public static void AppendStringGroup(StringBuilder builder, IEnumerable<Requirement> group, 
+            NumberFormat numberFormat, int wrapWidth, int indent = 14)
         {
             bool needsAmpersand = false;
+            int width = wrapWidth;
 
             var enumerator = group.GetEnumerator();
             while (enumerator.MoveNext())
@@ -351,22 +356,22 @@ namespace RATools.Parser
                     switch (requirement.Type)
                     {
                         case RequirementType.AddSource:
-                            requirement.Left.AppendString(addSources, NumberFormat.Decimal);
+                            requirement.Left.AppendString(addSources, numberFormat);
                             addSources.Append(" + ");
                             break;
 
                         case RequirementType.SubSource:
                             subSources.Append(" - ");
-                            requirement.Left.AppendString(subSources, NumberFormat.Decimal);
+                            requirement.Left.AppendString(subSources, numberFormat);
                             break;
 
                         case RequirementType.AddHits:
-                            requirement.AppendString(addHits, NumberFormat.Decimal);
+                            requirement.AppendString(addHits, numberFormat);
                             addHits.Append(" || ");
                             break;
 
                         case RequirementType.AndNext:
-                            requirement.AppendString(andNext, NumberFormat.Decimal);
+                            requirement.AppendString(andNext, numberFormat);
                             andNext.Append(" && ");
                             break;
 
@@ -385,16 +390,57 @@ namespace RATools.Parser
                 } while (true);
 
                 var definition = new StringBuilder();
-                requirement.AppendString(definition, NumberFormat.Decimal,
-                    addSources.Length > 0 ? addSources.ToString() : null,
-                    subSources.Length > 0 ? subSources.ToString() : null,
-                    addHits.Length > 0 ? addHits.ToString() : null,
-                    andNext.Length > 0 ? andNext.ToString() : null);
+
+                if (addSources.Length == 0 && subSources.Length == 0 && addHits.Length == 0 && andNext.Length == 0)
+                {
+                    var result = requirement.Evaluate();
+                    if (result == true)
+                        definition.Append("always_true()");
+                    else if (result == false)
+                        definition.Append("always_false()");
+                    else
+                        requirement.AppendString(definition, numberFormat);
+                }
+                else
+                {
+                    requirement.AppendString(definition, numberFormat,
+                        addSources.Length > 0 ? addSources.ToString() : null,
+                        subSources.Length > 0 ? subSources.ToString() : null,
+                        addHits.Length > 0 ? addHits.ToString() : null,
+                        andNext.Length > 0 ? andNext.ToString() : null);
+                }
 
                 if (needsAmpersand)
+                {
                     builder.Append(" && ");
+                    width -= 4;
+                }
                 else
+                {
                     needsAmpersand = true;
+                }
+
+                while (definition.Length > wrapWidth)
+                {
+                    var index = width;
+                    while (index > 0 && definition[index] != ' ')
+                        index--;
+
+                    builder.Append(definition.ToString(), 0, index);
+                    builder.AppendLine();
+                    builder.Append(' ', indent);
+                    definition.Remove(0, index);
+                    width = wrapWidth;
+                }
+
+                if (width - definition.Length < 0)
+                {
+                    builder.AppendLine();
+                    builder.Append(' ', indent);
+                    width = wrapWidth;
+                }
+
+                width -= definition.Length;
 
                 builder.Append(definition.ToString());
             }
@@ -408,7 +454,7 @@ namespace RATools.Parser
             get
             {
                 var builder = new StringBuilder();
-                AppendDebugStringGroup(builder, CoreRequirements);
+                AppendStringGroup(builder, CoreRequirements, NumberFormat.Decimal, Int32.MaxValue);
 
                 if (AlternateRequirements.Count > 0)
                 {
@@ -420,7 +466,7 @@ namespace RATools.Parser
                         if (altGroup.Count > 1)
                             builder.Append('(');
 
-                        AppendDebugStringGroup(builder, altGroup);
+                        AppendStringGroup(builder, altGroup, NumberFormat.Decimal, Int32.MaxValue);
 
                         if (altGroup.Count > 1)
                             builder.Append(')');
@@ -501,7 +547,7 @@ namespace RATools.Parser
 
                 if (requirement.Left.Type == FieldType.Value)
                 {
-                    if (Evaluate(requirement))
+                    if (requirement.Evaluate() == true)
                         alwaysTrue.Add(requirementEx);
                     else
                         alwaysFalse.Add(requirementEx);
@@ -1012,43 +1058,6 @@ namespace RATools.Parser
             return false;
         }
 
-        protected static bool Evaluate(Requirement requirement)
-        {
-            switch (requirement.Operator)
-            {
-                case RequirementOperator.Equal:
-                    return (requirement.Left.Value == requirement.Right.Value);
-                case RequirementOperator.NotEqual:
-                    return (requirement.Left.Value != requirement.Right.Value);
-                case RequirementOperator.LessThan:
-                    return (requirement.Left.Value < requirement.Right.Value);
-                case RequirementOperator.LessThanOrEqual:
-                    return (requirement.Left.Value <= requirement.Right.Value);
-                case RequirementOperator.GreaterThan:
-                    return (requirement.Left.Value > requirement.Right.Value);
-                case RequirementOperator.GreaterThanOrEqual:
-                    return (requirement.Left.Value >= requirement.Right.Value);
-                default:
-                    return false;
-            }
-        }
-
-        private static bool IsTrue(Requirement requirement)
-        {
-            if (requirement.Left.Type == FieldType.Value && requirement.Right.Type == FieldType.Value)
-                return Evaluate(requirement);
-
-            return false;
-        }
-
-        private static bool IsFalse(Requirement requirement)
-        {
-            if (requirement.Left.Type == FieldType.Value && requirement.Right.Type == FieldType.Value)
-                return !Evaluate(requirement);
-
-            return false;
-        }
-
         private static void MergeDuplicateAlts(List<List<RequirementEx>> groups)
         {
             // if two alt groups are exactly identical, or can otherwise be represented by merging their
@@ -1106,7 +1115,8 @@ namespace RATools.Parser
                 {
                     if (groups[j].Count == 1 && groups[j][0].Requirements.Count == 1)
                     {
-                        if (IsFalse(groups[j][0].Requirements[0]))
+                        var result = groups[j][0].Requirements[0].Evaluate();
+                        if (result == false)
                         {
                             // an always_false alt group is used for two cases:
                             // 1) building an alt group list (safe to remove)
@@ -1114,7 +1124,7 @@ namespace RATools.Parser
                             if (groups.Count > 3)
                                 groups.RemoveAt(j);
                         }
-                        else if (IsTrue(groups[j][0].Requirements[0]))
+                        else if (result == true)
                         {
                             // an always_true alt group supercedes all other alt groups.
                             // if we see one, keep track of that and we'll process it later.
@@ -1128,7 +1138,7 @@ namespace RATools.Parser
                 {
                     for (int j = groups.Count - 1; j >= 1; j--)
                     {
-                        if (groups[j].Count == 1 && groups[j][0].Requirements.Count == 1 && IsTrue(groups[j][0].Requirements[0]))
+                        if (groups[j].Count == 1 && groups[j][0].Requirements.Count == 1 && groups[j][0].Requirements[0].Evaluate() == true)
                             continue;
 
                         bool hasPauseIf = false;
@@ -1304,7 +1314,7 @@ namespace RATools.Parser
                         if (group[j] == coreGroup[i])
                         {
                             // always_true has special meaning and shouldn't be eliminated if present in the core group
-                            if (group[j].Requirements.Count > 1 || !IsTrue(group[j].Requirements[0]))
+                            if (group[j].Requirements.Count > 1 || group[j].Requirements[0].Evaluate() != true)
                                 group.RemoveAt(j);
                         }
                     }
@@ -1745,7 +1755,7 @@ namespace RATools.Parser
 
             // if the core group contains an always_true statement in addition to any other promoted statements, 
             // remove the always_true statement
-            if (groups[0].Count > 1 && groups[0][0].Requirements.Count == 1 && IsTrue(groups[0][0].Requirements[0]))
+            if (groups[0].Count > 1 && groups[0][0].Requirements.Count == 1 && groups[0][0].Requirements[0].Evaluate() == true)
                 groups[0].RemoveAt(0);
 
             // convert back to flattened expressions

--- a/Parser/Functions/ComparisonModificationFunction.cs
+++ b/Parser/Functions/ComparisonModificationFunction.cs
@@ -69,14 +69,30 @@ namespace RATools.Parser.Functions
         protected ParseErrorExpression ValidateSingleCondition(ICollection<Requirement> requirements)
         {
             if (requirements.Count == 0 ||
-                requirements.Last().Operator == RequirementOperator.None ||
-                requirements.Last().Type != RequirementType.None)
+                requirements.Last().Operator == RequirementOperator.None)
             {
                 return new ParseErrorExpression("comparison did not evaluate to a valid comparison");
             }
 
-            if (requirements.Count(r => r.Type == RequirementType.None) != 1)
-                return new ParseErrorExpression(Name.Name + " does not support &&'d conditions");
+            bool isCombining = true;
+            foreach (var requirement in requirements)
+            {
+                switch (requirement.Type)
+                {
+                    case RequirementType.AddHits:
+                    case RequirementType.AddSource:
+                    case RequirementType.SubSource:
+                    case RequirementType.AndNext:
+                        isCombining = true;
+                        break;
+
+                    default:
+                        if (!isCombining)
+                            return new ParseErrorExpression(Name.Name + " does not support &&'d conditions");
+                        isCombining = false;
+                        break;
+                }
+            }
 
             return null;
         }

--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -537,7 +537,7 @@ namespace RATools.Parser
                         Right = new Field { Type = FieldType.Value, Value = (uint)((IntegerConstantExpression)right).Value },
                     };
 
-                    if (Evaluate(requirement))
+                    if (requirement.Evaluate() == true)
                         context.Trigger.Add(AlwaysTrueFunction.CreateAlwaysTrueRequirement());
                     else
                         context.Trigger.Add(AlwaysFalseFunction.CreateAlwaysFalseRequirement());

--- a/Parser/TriggerBuilderContext.cs
+++ b/Parser/TriggerBuilderContext.cs
@@ -202,11 +202,15 @@ namespace RATools.Parser
                 return false;
             }
 
-            var message = achievement.Optimize();
-            if (message != null)
+            // only optimize at the outermost level
+            if (ReferenceEquals(scope.GetOutermostContext<TriggerBuilderContext>(), scope.GetContext<TriggerBuilderContext>()))
             {
-                result = new ParseErrorExpression(message, expression);
-                return false;
+                var message = achievement.Optimize();
+                if (message != null)
+                {
+                    result = new ParseErrorExpression(message, expression);
+                    return false;
+                }
             }
 
             result = null;

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -341,6 +341,8 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x001234) > byte(0x001234)", "always_false()")] // never true
         [TestCase("once(byte(0x001234) == byte(0x001234))", "always_true()")] // always true
         [TestCase("repeated(3, byte(0x001234) == byte(0x001234))", "repeated(3, byte(0x001234) == byte(0x001234))")] // always true, but ignored for two frames
+        [TestCase("never(repeated(3, 1 == 1))", "never(repeated(3, 1 == 1))")] // always true, but ignored for two frames
+        [TestCase("byte(0x001234) == 1 && repeated(3, never(1 == 1))", "byte(0x001234) == 1 && never(repeated(3, 1 == 1))")] // always true, but ignored for two frames
         [TestCase("0 < 256", "always_true()")] // always true
         [TestCase("0 == 1", "always_false()")] // always false
         [TestCase("1 == 1", "always_true()")] // always true

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -332,6 +332,7 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x001234) > 256", "always_false()")] // can never be true
         [TestCase("byte(0x001234) < 256", "always_true()")] // always true
         [TestCase("byte(0x001234) == prev(byte(0x001234))", "byte(0x001234) == prev(byte(0x001234))")] // non-deterministic
+        [TestCase("byte(0x001234) == word(0x001234)", "byte(0x001234) == word(0x001234)")] // non-deterministic
         [TestCase("byte(0x001234) == byte(0x001234)", "always_true()")] // always true
         [TestCase("byte(0x001234) != byte(0x001234)", "always_false()")] // never true
         [TestCase("byte(0x001234) <= byte(0x001234)", "always_true()")] // always true

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -305,12 +305,12 @@ namespace RATools.Test.Parser
         [TestCase("bit0(0x001234) != 1", "bit0(0x001234) == 0")] // bit not equal to one must be 0
         [TestCase("bit0(0x001234) < 1", "bit0(0x001234) == 0")] // bit less than one must be 0
         [TestCase("byte(0x001234) < 1", "byte(0x001234) == 0")] // byte less than one must be 0
-        [TestCase("byte(0x001234) == 1 && byte(0x004567) < 0", "0 == 1")] // less than 0 can never be true, replace with always_false
-        [TestCase("byte(0x001234) == 1 && low4(0x004567) > 15", "0 == 1")] // nibble cannot be greater than 15, replace with always_false
-        [TestCase("byte(0x001234) == 1 && high4(0x004567) > 15", "0 == 1")] // nibble cannot be greater than 15, replace with always_false
-        [TestCase("byte(0x001234) == 1 && byte(0x004567) > 255", "0 == 1")] // byte cannot be greater than 255, replace with always_false
-        [TestCase("byte(0x001234) == 1 && word(0x004567) > 65535", "0 == 1")] // word cannot be greater than 255, replace with always_false
-        [TestCase("byte(0x001234) == 1 && dword(0x004567) > 4294967295", "0 == 1")] // dword cannot be greater than 4294967295, replace with always_false
+        [TestCase("byte(0x001234) == 1 && byte(0x004567) < 0", "always_false()")] // less than 0 can never be true, replace with always_false
+        [TestCase("byte(0x001234) == 1 && low4(0x004567) > 15", "always_false()")] // nibble cannot be greater than 15, replace with always_false
+        [TestCase("byte(0x001234) == 1 && high4(0x004567) > 15", "always_false()")] // nibble cannot be greater than 15, replace with always_false
+        [TestCase("byte(0x001234) == 1 && byte(0x004567) > 255", "always_false()")] // byte cannot be greater than 255, replace with always_false
+        [TestCase("byte(0x001234) == 1 && word(0x004567) > 65535", "always_false()")] // word cannot be greater than 255, replace with always_false
+        [TestCase("byte(0x001234) == 1 && dword(0x004567) > 4294967295", "always_false()")] // dword cannot be greater than 4294967295, replace with always_false
         [TestCase("byte(0x001234) == 1 && low4(0x004567) >= 15", "byte(0x001234) == 1 && low4(0x004567) == 15")] // nibble cannot be greater than 15, change to equals
         [TestCase("byte(0x001234) == 1 && high4(0x004567) >= 15", "byte(0x001234) == 1 && high4(0x004567) == 15")] // nibble cannot be greater than 15, change to equals
         [TestCase("byte(0x001234) == 1 && byte(0x004567) >= 255", "byte(0x001234) == 1 && byte(0x004567) == 255")] // byte cannot be greater than 255, change to equals
@@ -328,17 +328,26 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x001234) == 1 && word(0x004567) < 65535", "byte(0x001234) == 1 && word(0x004567) != 65535")] // word cannot be greater than 255, change to not equals
         [TestCase("byte(0x001234) == 1 && dword(0x004567) < 4294967295", "byte(0x001234) == 1 && dword(0x004567) != 4294967295")] // dword cannot be greater than 4294967295, change to not equals
         [TestCase("bit0(0x001234) + bit1(0x001234) == 2", "(bit0(0x001234) + bit1(0x001234)) == 2")] // addition can exceed max size of source
-        [TestCase("byte(0x001234) == 1000", "0 == 1")] // can never be true
-        [TestCase("byte(0x001234) > 256", "0 == 1")] // can never be true
-        [TestCase("byte(0x001234) < 256", "1 == 1")] // always true
-        [TestCase("0 < 256", "1 == 1")] // always true
-        [TestCase("0 == 1", "0 == 1")] // always false
-        [TestCase("1 == 1", "1 == 1")] // always true
-        [TestCase("3 > 6", "0 == 1")] // always false
-        [TestCase("0 == 1 && byte(0x001234) == 1", "0 == 1")] // always false and anything is always false
+        [TestCase("byte(0x001234) == 1000", "always_false()")] // can never be true
+        [TestCase("byte(0x001234) > 256", "always_false()")] // can never be true
+        [TestCase("byte(0x001234) < 256", "always_true()")] // always true
+        [TestCase("byte(0x001234) == prev(byte(0x001234))", "byte(0x001234) == prev(byte(0x001234))")] // non-deterministic
+        [TestCase("byte(0x001234) == byte(0x001234)", "always_true()")] // always true
+        [TestCase("byte(0x001234) != byte(0x001234)", "always_false()")] // never true
+        [TestCase("byte(0x001234) <= byte(0x001234)", "always_true()")] // always true
+        [TestCase("byte(0x001234) < byte(0x001234)", "always_false()")] // never true
+        [TestCase("byte(0x001234) >= byte(0x001234)", "always_true()")] // always true
+        [TestCase("byte(0x001234) > byte(0x001234)", "always_false()")] // never true
+        [TestCase("once(byte(0x001234) == byte(0x001234))", "always_true()")] // always true
+        [TestCase("repeated(3, byte(0x001234) == byte(0x001234))", "repeated(3, byte(0x001234) == byte(0x001234))")] // always true, but ignored for two frames
+        [TestCase("0 < 256", "always_true()")] // always true
+        [TestCase("0 == 1", "always_false()")] // always false
+        [TestCase("1 == 1", "always_true()")] // always true
+        [TestCase("3 > 6", "always_false()")] // always false
+        [TestCase("0 == 1 && byte(0x001234) == 1", "always_false()")] // always false and anything is always false
         [TestCase("1 == 1 && byte(0x001234) == 1", "byte(0x001234) == 1")] // always true and anything is the anything clause
-        [TestCase("once(byte(0x004567) == 2) && (byte(0x002345) == 3 || (0 == 1 && never(byte(0x001234) == 1) && byte(0x001235) == 2))",
-                  "once(byte(0x004567) == 2) && (byte(0x002345) == 3 || (never(byte(0x001234) == 1) && 0 == 1))")] // always_false paired with ResetIf does not eradicate the ResetIf
+        [TestCase("once(byte(0x004567) == 2) && (byte(0x002345) == 3 || (always_false() && never(byte(0x001234) == 1) && byte(0x001235) == 2))",
+                  "once(byte(0x004567) == 2) && (byte(0x002345) == 3 || (never(byte(0x001234) == 1) && always_false()))")] // always_false paired with ResetIf does not eradicate the ResetIf
         // ==== NormalizeNonHitCountResetAndPauseIfs ====
         [TestCase("never(byte(0x001234) != 5)", "byte(0x001234) == 5")]
         [TestCase("never(byte(0x001234) == 5)", "byte(0x001234) != 5")]
@@ -398,13 +407,13 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x001234) != 3 && byte(0x001234) == 2", "byte(0x001234) == 2")] // =2 is implicitly !=3
         [TestCase("byte(0x001234) == 3 && byte(0x001234) != 2", "byte(0x001234) == 3")] // =3 is implicitly !=2
         [TestCase("byte(0x001234) == 3 && byte(0x001234) == 3", "byte(0x001234) == 3")] // redundant
-        [TestCase("byte(0x001234) > 3 && byte(0x001234) < 2", "0 == 1")] // cannot both be true
-        [TestCase("byte(0x001234) > 2 && byte(0x001234) < 2", "0 == 1")] // cannot both be true
-        [TestCase("byte(0x001234) < 2 && byte(0x001234) > 2", "0 == 1")] // cannot both be true
-        [TestCase("byte(0x001234) < 2 && byte(0x001234) > 3", "0 == 1")] // cannot both be true
-        [TestCase("byte(0x001234) >= 3 && byte(0x001234) <= 2", "0 == 1")] // cannot both be true
-        [TestCase("byte(0x001234) <= 2 && byte(0x001234) >= 3", "0 == 1")] // cannot both be true
-        [TestCase("byte(0x001234) == 3 && byte(0x001234) == 2", "0 == 1")] // cannot both be true
+        [TestCase("byte(0x001234) > 3 && byte(0x001234) < 2", "always_false()")] // cannot both be true
+        [TestCase("byte(0x001234) > 2 && byte(0x001234) < 2", "always_false()")] // cannot both be true
+        [TestCase("byte(0x001234) < 2 && byte(0x001234) > 2", "always_false()")] // cannot both be true
+        [TestCase("byte(0x001234) < 2 && byte(0x001234) > 3", "always_false()")] // cannot both be true
+        [TestCase("byte(0x001234) >= 3 && byte(0x001234) <= 2", "always_false()")] // cannot both be true
+        [TestCase("byte(0x001234) <= 2 && byte(0x001234) >= 3", "always_false()")] // cannot both be true
+        [TestCase("byte(0x001234) == 3 && byte(0x001234) == 2", "always_false()")] // cannot both be true
         [TestCase("byte(0x001234) - prev(byte(0x001234)) == 1 && byte(0x001234) == 2", "(byte(0x001234) - prev(byte(0x001234))) == 1 && byte(0x001234) == 2")] // conflict with part of a SubSource clause should not be treated as wholly conflicting
         [TestCase("byte(0x001234) <= 2 && byte(0x001234) >= 2", "byte(0x001234) == 2")] // only overlap is the one value
         [TestCase("byte(0x001234) >= 2 && byte(0x001234) <= 2", "byte(0x001234) == 2")] // only overlap is the one value
@@ -437,10 +446,10 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x001234) <= 2 || byte(0x001234) >= 2", "byte(0x001234) <= 2 || byte(0x001234) >= 2")] // always true, can't really collapse
         [TestCase("byte(0x001234) >= 2 || byte(0x001234) <= 2", "byte(0x001234) >= 2 || byte(0x001234) <= 2")] // always true, can't really collapse
         [TestCase("always_false() || byte(0x001234) == 2 || byte(0x001234) == 3", "byte(0x001234) == 2 || byte(0x001234) == 3")] // always_false group can be removed
-        [TestCase("always_false() || byte(0x001234) == 2", "0 == 1 || byte(0x001234) == 2")] // minimum of two alts
-        [TestCase("always_true() || byte(0x001234) == 2 || byte(0x001234) == 3", "1 == 1")] // always_true group causes other groups to be ignored if they don't have a pauseif or resetif
+        [TestCase("always_false() || byte(0x001234) == 2", "always_false() || byte(0x001234) == 2")] // minimum of two alts
+        [TestCase("always_true() || byte(0x001234) == 2 || byte(0x001234) == 3", "always_true()")] // always_true group causes other groups to be ignored if they don't have a pauseif or resetif
         [TestCase("always_true() || byte(0x001234) == 2 || (byte(0x001234) == 3 && unless(byte(0x002345) == 1)) || (once(byte(0x001234) == 4) && never(byte(0x002345) == 1))",
-            "1 == 1 || (byte(0x001234) == 3 && unless(byte(0x002345) == 1)) || (once(byte(0x001234) == 4) && never(byte(0x002345) == 1))")] // always_true group causes group without pauseif or resetif to be removed
+            "always_true() || (byte(0x001234) == 3 && unless(byte(0x002345) == 1)) || (once(byte(0x001234) == 4) && never(byte(0x002345) == 1))")] // always_true group causes group without pauseif or resetif to be removed
         // ==== MergeBits ====
         [TestCase("bit0(0x001234) == 1 && bit1(0x001234) == 1 && bit2(0x001234) == 0 && bit3(0x001234) == 1", "low4(0x001234) == 11")]
         [TestCase("bit4(0x001234) == 1 && bit5(0x001234) == 1 && bit6(0x001234) == 0 && bit7(0x001234) == 1", "high4(0x001234) == 11")]
@@ -448,7 +457,7 @@ namespace RATools.Test.Parser
         // ==== Complex ====
         [TestCase("byte(0x001234) == 1 && ((low4(0x004567) == 1 && high4(0x004567) >= 12) || (low4(0x004567) == 9 && high4(0x004567) >= 12) || (low4(0x004567) == 1 && high4(0x004567) >= 13))",
                   "byte(0x001234) == 1 && high4(0x004567) >= 12 && (low4(0x004567) == 1 || low4(0x004567) == 9)")] // alts 1 + 3 can be merged together, then the high4 extracted
-        [TestCase("0 == 1 && never(byte(0x001234) == 1)", "0 == 1")] // ResetIf without available HitCount inverted, then can be eliminated by always false
+        [TestCase("0 == 1 && never(byte(0x001234) == 1)", "always_false()")] // ResetIf without available HitCount inverted, then can be eliminated by always false
         public void TestOptimize(string input, string expected)
         {
             var achievement = CreateAchievement(input);

--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -684,14 +684,21 @@ namespace RATools.ViewModels
                     groupEnumerator.MoveNext();
                     stream.Write("    trigger = ");
                     const int indent = 14; // "    trigger = ".length
-                    DumpPublishedRequirements(stream, dumpAchievement, groupEnumerator.Current, numberFormat, indent);
+
+                    bool isCoreEmpty = !groupEnumerator.Current.Requirements.Any();
+                    if (!isCoreEmpty)
+                        DumpPublishedRequirements(stream, dumpAchievement, groupEnumerator.Current, numberFormat, indent);
+
                     first = true;
                     while (groupEnumerator.MoveNext())
                     {
                         if (first)
                         {
-                            stream.WriteLine(" &&");
-                            stream.Write(new string(' ', indent));
+                            if (!isCoreEmpty)
+                            {
+                                stream.WriteLine(" &&");
+                                stream.Write(new string(' ', indent));
+                            }
                             stream.Write("((");
                             first = false;
                         }
@@ -718,7 +725,7 @@ namespace RATools.ViewModels
         private void DumpPublishedRequirements(StreamWriter stream, DumpAchievementItem dumpAchievement, 
             RequirementGroupViewModel requirementGroupViewModel, NumberFormat numberFormat, int indent)
         {
-            const int MaxWidth = 106; // 120 - "    trigger = ".Length
+            const int MaxWidth = 120;
 
             var definition = new StringBuilder();
             Parser.AchievementBuilder.AppendStringGroup(definition, 


### PR DESCRIPTION
fixes #68 

The basic problem was that `AchievementBuilder.ParseRequirements` wasn't handling the case where there was no core group correctly. Fixing that resulted in the dumper generating a trigger that said `1 == 1 &&`. Additional changes were made to convert that to `always_true() &&`. In the process, some duplicated code was merged.