### PR TITLE
Do not optimize away always-true ResetIf with hit count

### DIFF
--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -501,8 +501,12 @@ namespace RATools.Parser
 
                 if (requirement.Left.Type == FieldType.Value)
                 {
+
                     if (Evaluate(requirement))
-                        alwaysTrue.Add(requirementEx);
+                    {
+                        if (requirement.Type != RequirementType.ResetIf && requirement.Type != RequirementType.PauseIf)
+                            alwaysTrue.Add(requirementEx);
+                    }
                     else
                         alwaysFalse.Add(requirementEx);
 
@@ -675,6 +679,7 @@ namespace RATools.Parser
             }
             else if (alwaysTrue.Count > 0)
             {
+                var maxHitCount = alwaysTrue.Max(rEx => rEx.Requirements.Max(r => r.HitCount));
                 foreach (var requirementEx in alwaysTrue)
                     requirements.Remove(requirementEx);
 
@@ -682,6 +687,7 @@ namespace RATools.Parser
                 {
                     var requirementEx = new RequirementEx();
                     requirementEx.Requirements.Add(AlwaysTrueFunction.CreateAlwaysTrueRequirement());
+                    requirementEx.Requirements[0].HitCount = maxHitCount;
                     requirements.Add(requirementEx);
                 }
             }

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -449,6 +449,7 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x001234) == 1 && ((low4(0x004567) == 1 && high4(0x004567) >= 12) || (low4(0x004567) == 9 && high4(0x004567) >= 12) || (low4(0x004567) == 1 && high4(0x004567) >= 13))",
                   "byte(0x001234) == 1 && high4(0x004567) >= 12 && (low4(0x004567) == 1 || low4(0x004567) == 9)")] // alts 1 + 3 can be merged together, then the high4 extracted
         [TestCase("0 == 1 && never(byte(0x001234) == 1)", "0 == 1")] // ResetIf without available HitCount inverted, then can be eliminated by always false
+        [TestCase("byte(0x001234) == 1 && never(repeated(2, 1 == 1))", "byte(0x001234) == 1 && repeated(2, never(1 == 1))")]
         public void TestOptimize(string input, string expected)
         {
             var achievement = CreateAchievement(input);


### PR DESCRIPTION
An expression such as `repeated(2, never(1 == 1))` can be used to reset an
achievement every other frame. This expression is converted into a requirement
`1 == 1` with type `ResetIf` and an `HitCount` of 2.

The optimizer was optimizing the whole requirement away, because `1 == 1` is
always true. Even though that's correct, the removal of the `ResetIf` completely
changes the achievement's logic. Fixed by not removing always-true requirements
if their type is either `ResetIf` or `PauseIf`.

Another issue was that the optimizer also considered `repeated(2, 1 == 1)` to
be always true and replaced it with `1 == 1`, removing the hit count that
could be relevant for later (such as when wrapped in a `never` call). Fixed by
setting the hit count of the injected `1 == 1` requirement to be the maximum hit
count of the replaced always-true requirements.