### PR TITLE
add Core as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Core"]
+	path = Core
+	url = https://github.com/Jamiras/Core

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -254,10 +254,10 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Jamiras.Core.dll">
-          <HintPath>lib\Jamiras.Core.dll</HintPath>
-          <Name>Jamiras.Core.dll</Name>
-        </Reference>
+        <ProjectReference Include="Core\Jamiras.Core.csproj">
+          <Project>{4141f2ae-9e32-4a93-9fea-360a7dc7d97f}</Project>
+          <Name>Jamiras.Core</Name>
+        </ProjectReference>
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/RATools.sln
+++ b/RATools.sln
@@ -7,6 +7,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RATools", "RATools.csproj",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RATools.Tests", "Tests\RATools.Tests.csproj", "{A29018E0-76BF-4873-A6F7-785FCEAC508F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jamiras.Core", "Core\Jamiras.Core.csproj", "{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jamiras.Core.Tests", "Core\Tests\Jamiras.Core.Tests.csproj", "{8F415F4B-4184-429F-80A2-58DA15AFB26E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +43,30 @@ Global
 		{A29018E0-76BF-4873-A6F7-785FCEAC508F}.Release|Mixed Platforms.Build.0 = Release|x86
 		{A29018E0-76BF-4873-A6F7-785FCEAC508F}.Release|x86.ActiveCfg = Release|x86
 		{A29018E0-76BF-4873-A6F7-785FCEAC508F}.Release|x86.Build.0 = Release|x86
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Debug|x86.Build.0 = Debug|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Release|x86.ActiveCfg = Release|Any CPU
+		{4141F2AE-9E32-4A93-9FEA-360A7DC7D97F}.Release|x86.Build.0 = Release|Any CPU
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Debug|x86.ActiveCfg = Debug|x86
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Debug|x86.Build.0 = Debug|x86
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Release|Mixed Platforms.Build.0 = Release|x86
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Release|x86.ActiveCfg = Release|x86
+		{8F415F4B-4184-429F-80A2-58DA15AFB26E}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -1,17 +1,8 @@
 # RATools
-Script interpreter for writing achievements for retroachievements.org
+A script interpreter for writing achievements for retroachievements.org
+Also contains some analysis tools for examining site data
 
 
-### Build instructions (RATools only):
-1) Download the latest Core dll from [Core releases](https://github.com/Jamiras/Core/releases) and unzip 
-   into a "lib" directory under the RATools checkout.
-2) Download the [nUnit and Moq dlls](https://github.com/Jamiras/Core/wiki/files/nUnit.3.11.zip) and extract them to a "lib" subdirectory under the RATools checkout.
-3) Open the "RATools.sln" project.
-4) Compile.
+The 'RATools.sln' solution requires the Core submodule to be initialized, and is the solution most users should be using.
 
-### Build instructions (RATools + Core):
-1) Ensure your [Core](https://github.com/Jamiras/Core) checkout is in a directory beside the RATools checkout.
-2) Download the [nUnit and Moq dlls](https://github.com/Jamiras/Core/wiki/files/nUnit.3.11.zip) and extract them to a "libs" directory beside the RATools checkout.
-    * you should now have three directories at the top level: Core, libs, RATools
-3) Open the "RATools + Core.sln" project.
-4) Compile.
+The 'RATools + Core.sln' solution looks for the Core repository to be checked out next to the RATools repository and is used when making changes to both projects.

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -76,27 +76,27 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="Exists('..\lib\moq-4.3\net40\Moq.dll')">
+    <When Condition="Exists('$(SolutionDir)..\libs\moq-4.3\net40\Moq.dll')">
       <ItemGroup>
         <Reference Include="Moq">
-          <HintPath>..\lib\moq-4.3\net40\Moq.dll</HintPath>
+          <HintPath>$(SolutionDir)..\libs\moq-4.3\net40\Moq.dll</HintPath>
         </Reference>
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <Reference Include="Moq">
-          <HintPath>..\..\libs\moq-4.3\net40\Moq.dll</HintPath>
+          <HintPath>$(SolutionDir)lib\moq-4.3\net40\Moq.dll</HintPath>
         </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
   <Choose>
-    <When Condition="Exists('..\lib\nUnit-3.11\net40\nunit.framework.dll')">
+    <When Condition="Exists('$(SolutionDir)..\libs\nUnit-3.11\net40\nunit.framework.dll')">
       <ItemGroup>
         <Reference Include="nunit.framework, Version=4.0.30319, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
           <SpecificVersion>False</SpecificVersion>
-          <HintPath>..\lib\nUnit-3.11\net40\nunit.framework.dll</HintPath>
+          <HintPath>$(SolutionDir)..\libs\nUnit-3.11\net40\nunit.framework.dll</HintPath>
         </Reference>
       </ItemGroup>
     </When>
@@ -104,7 +104,7 @@
       <ItemGroup>
         <Reference Include="nunit.framework, Version=4.0.30319, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
           <SpecificVersion>False</SpecificVersion>
-          <HintPath>..\..\libs\nUnit-3.11\net40\nunit.framework.dll</HintPath>
+          <HintPath>$(SolutionDir)lib\nUnit-3.11\net40\nunit.framework.dll</HintPath>
         </Reference>
       </ItemGroup>
     </Otherwise>
@@ -153,10 +153,10 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Jamiras.Core.dll">
-          <HintPath>..\lib\Jamiras.Core.dll</HintPath>
-          <Name>Jamiras.Core.dll</Name>
-        </Reference>
+        <ProjectReference Include="..\Core\Jamiras.Core.csproj">
+          <Project>{4141f2ae-9e32-4a93-9fea-360a7dc7d97f}</Project>
+          <Name>Jamiras.Core</Name>
+        </ProjectReference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -164,6 +164,10 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Core\Tests\Jamiras.Core.Tests.csproj">
+      <Project>{8f415f4b-4184-429f-80a2-58da15afb26e}</Project>
+      <Name>Jamiras.Core.Tests</Name>
+    </ProjectReference>
     <ProjectReference Include="..\RATools.csproj">
       <Project>{965d9b5a-9070-40e5-9eaa-edc581f0f000}</Project>
       <Name>RATools</Name>


### PR DESCRIPTION
Implements #16

I chose to write a batch file that uses powershell to download and extract the nUnit DLLs.

The `RATools + Core.sln` solution behaves as before, where it looks for the Core repository to be next to the RATools repository. The `RATools.sln` solution now expects to find the Core repository as a submodule and will build it (instead of relying on a pre-built DLL).