### PR TITLE
only validate local achievements being updated

### DIFF
--- a/Parser/LocalAchievements.cs
+++ b/Parser/LocalAchievements.cs
@@ -1,6 +1,5 @@
 ﻿using Jamiras.Components;
 using Jamiras.Services;
-using Jamiras.ViewModels;
 using RATools.Data;
 using System;
 using System.Collections.Generic;
@@ -198,10 +197,8 @@ namespace RATools.Parser
         /// <summary>
         /// Commits the achivement list back to the 'XXX-User.txt' file.
         /// </summary>
-        public void Commit(string author)
+        public void Commit(string author, StringBuilder warning, Achievement achievementToValidate)
         {
-            var warning = new StringBuilder();
-
             using (var writer = new StreamWriter(_fileSystemService.CreateFile(_filename)))
             {
                 writer.WriteLine(_version);
@@ -213,7 +210,7 @@ namespace RATools.Parser
                     writer.Write(":\"");
 
                     var requirements = AchievementBuilder.SerializeRequirements(achievement);
-                    if (requirements.Length > AchievementMaxLength)
+                    if (requirements.Length > AchievementMaxLength && warning != null && (achievementToValidate == null || ReferenceEquals(achievementToValidate, achievement)))
                     {
                         warning.AppendFormat("Achievement \"{0}\" exceeds serialized limit ({1}/{2})", achievement.Title, requirements.Length, AchievementMaxLength);
                         warning.AppendLine();
@@ -242,9 +239,6 @@ namespace RATools.Parser
                     writer.WriteLine();
                 }
             }
-
-            if (warning.Length > 0)
-                MessageBoxViewModel.ShowMessage(warning.ToString());
         }
     }
 }

--- a/Tests/Parser/LocalAchievementsTests.cs
+++ b/Tests/Parser/LocalAchievementsTests.cs
@@ -126,7 +126,7 @@ namespace RATools.Test.Parser
 
             achievements.Replace(null, achievement);
 
-            achievements.Commit("Test");
+            achievements.Commit("Test", null, null);
 
             var output = Encoding.UTF8.GetString(memoryStream.ToArray());
             Assert.That(output, Is.EqualTo("0.099\r\nTitle\r\n0:\"0xH001234=1\":\"T\":\"D\": : : :Test:1:0:0:0:0:\r\n"));
@@ -154,7 +154,7 @@ namespace RATools.Test.Parser
 
             achievements.Replace(null, achievement);
 
-            achievements.Commit("Test");
+            achievements.Commit("Test", null, null);
 
             var output = Encoding.UTF8.GetString(memoryStream.ToArray());
             Assert.That(output, Is.EqualTo("0.030\r\nFromScript\r\n0:\"0xH001234=1\":\"T\":\"D\": : : :Test:1:0:0:0:0:\r\n"));

--- a/Tests/Parser/RegressionTests.cs
+++ b/Tests/Parser/RegressionTests.cs
@@ -64,7 +64,7 @@ namespace RATools.Test.Parser
             localAchievements.Title = Path.GetFileNameWithoutExtension(scriptFileName);
             foreach (var achievement in interpreter.Achievements)
                 localAchievements.Replace(null, achievement);
-            localAchievements.Commit("Author");
+            localAchievements.Commit("Author", null, null);
 
             if (interpreter.Leaderboards.Any())
             {

--- a/ViewModels/GameViewModel.cs
+++ b/ViewModels/GameViewModel.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace RATools.ViewModels
 {
@@ -198,7 +199,7 @@ namespace RATools.ViewModels
             set { SetValue(SelectedEditorProperty, value); }
         }
 
-        internal void UpdateLocal(Achievement achievement, Achievement localAchievement)
+        internal void UpdateLocal(Achievement achievement, Achievement localAchievement, StringBuilder warning, bool validateAll)
         {
             if (achievement == null)
             {
@@ -231,7 +232,7 @@ namespace RATools.ViewModels
                 }
             }
 
-            _localAchievements.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName);
+            _localAchievements.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, validateAll ? null : achievement);
         }
 
         public static readonly ModelProperty TitleProperty = ModelProperty.Register(typeof(MainWindowViewModel), "Title", typeof(string), String.Empty);

--- a/ViewModels/GeneratedAchievementViewModel.cs
+++ b/ViewModels/GeneratedAchievementViewModel.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Windows.Media;
 
 namespace RATools.ViewModels
@@ -38,8 +39,8 @@ namespace RATools.ViewModels
             }
             else
             {
-                UpdateLocalCommand = new DelegateCommand(() => UpdateLocal(owner));
-                DeleteLocalCommand = new DelegateCommand(() => DeleteLocal(owner));
+                UpdateLocalCommand = new DelegateCommand(UpdateLocal);
+                DeleteLocalCommand = new DelegateCommand(DeleteLocal);
             }
         }
 
@@ -357,7 +358,16 @@ namespace RATools.ViewModels
             yield return Core;
         }
 
-        private void UpdateLocal(GameViewModel owner)
+        private void UpdateLocal()
+        {
+            StringBuilder warning = new StringBuilder();
+            UpdateLocal(warning, false);
+
+            if (warning.Length > 0)
+                MessageBoxViewModel.ShowMessage(warning.ToString());
+        }
+
+        internal void UpdateLocal(StringBuilder warning, bool validateAll)
         {
             var achievement = Generated.Achievement;
 
@@ -366,9 +376,9 @@ namespace RATools.ViewModels
             if (!String.IsNullOrEmpty(Local.BadgeName))
                 achievement.BadgeName = Local.BadgeName;
 
-            owner.UpdateLocal(achievement, Local.Achievement);
+            _owner.UpdateLocal(achievement, Local.Achievement, warning, validateAll);
 
-            Local = new AchievementViewModel(owner, "Local");
+            Local = new AchievementViewModel(_owner, "Local");
             Local.LoadAchievement(achievement);
 
             OnPropertyChanged(() => Local);
@@ -376,11 +386,11 @@ namespace RATools.ViewModels
         }
 
         public CommandBase DeleteLocalCommand { get; protected set; }
-        private void DeleteLocal(GameViewModel owner)
+        private void DeleteLocal()
         {
-            owner.UpdateLocal(null, Local.Achievement);
+            _owner.UpdateLocal(null, Local.Achievement, null, false);
 
-            Local = new AchievementViewModel(owner, "Local");
+            Local = new AchievementViewModel(_owner, "Local");
             OnPropertyChanged(() => Local);
             UpdateModified();
         }

--- a/ViewModels/UpdateLocalViewModel.cs
+++ b/ViewModels/UpdateLocalViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 
 namespace RATools.ViewModels
 {
@@ -37,13 +38,23 @@ namespace RATools.ViewModels
 
         protected override void ExecuteOkCommand()
         {
+            var warning = new StringBuilder();
+
             foreach (var achievement in _achievements)
             {
                 if (achievement.IsUpdated)
-                    achievement.Achievement.UpdateLocalCommand.Execute();
+                {
+                    warning.Clear();
+                    achievement.Achievement.UpdateLocal(warning, true);
+                }
                 else if (achievement.IsDeleted)
+                {
                     achievement.Achievement.DeleteLocalCommand.Execute();
+                }
             }
+
+            if (warning.Length > 0)
+                MessageBoxViewModel.ShowMessage(warning.ToString());
 
             DialogResult = DialogResult.Ok;
         }


### PR DESCRIPTION
fixes #49 

When updating multiple achievements, each modification to the file is done serially, so it behaves the same as if you just did an Update Local for each selected achievement individually.

The problem is that the validation is occuring each time the file is written, regardless of which particular achievement is being written, so once the "too large" item is there, it'll be reported for every update after that.

I've modified the logic to only validate the file once on multi-update and only validate the individual achievement on single-update.