### PR TITLE
allow conditions with differing HitCounts to be merged

### DIFF
--- a/Data/Requirement.cs
+++ b/Data/Requirement.cs
@@ -126,6 +126,27 @@ namespace RATools.Data
                     break;
 
                 default:
+                    if (Operator != RequirementOperator.None)
+                    {
+                        var clone = new Requirement
+                        {
+                            Left = this.Left,
+                            Operator = this.Operator,
+                            Right = this.Right
+                        };
+                        var result = clone.Evaluate();
+                        if (result == true)
+                        {
+                            builder.Append("always_true()");
+                            return;
+                        }
+                        else if (result == false)
+                        {
+                            builder.Append("always_false()");
+                            return;
+                        }
+                    }
+
                     Left.AppendString(builder, numberFormat);
                     break;
             }
@@ -307,6 +328,23 @@ namespace RATools.Data
                 case RequirementOperator.LessThanOrEqual: return RequirementOperator.GreaterThan;
                 case RequirementOperator.GreaterThan: return RequirementOperator.LessThanOrEqual;
                 case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.LessThan;
+                default: return RequirementOperator.None;
+            }
+        }
+
+        /// <summary>
+        /// Gets the equivalent operator if the operands are switched.
+        /// </summary>
+        public static RequirementOperator GetReversedRequirementOperator(RequirementOperator op)
+        {
+            switch (op)
+            {
+                case RequirementOperator.Equal: return RequirementOperator.Equal;
+                case RequirementOperator.NotEqual: return RequirementOperator.NotEqual;
+                case RequirementOperator.LessThan: return RequirementOperator.GreaterThan;
+                case RequirementOperator.LessThanOrEqual: return RequirementOperator.GreaterThanOrEqual;
+                case RequirementOperator.GreaterThan: return RequirementOperator.LessThan;
+                case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.LessThanOrEqual;
                 default: return RequirementOperator.None;
             }
         }

--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -550,7 +550,7 @@ namespace RATools.Parser
                 left = right;
                 right = temp;
 
-                op = GetReversedRequirementOperator(op);
+                op = Requirement.GetReversedRequirementOperator(op);
             }
 
             var error = ExecuteAchievementExpression(left, scope);
@@ -705,20 +705,6 @@ namespace RATools.Parser
                 case ComparisonOperation.LessThanOrEqual: return RequirementOperator.LessThanOrEqual;
                 case ComparisonOperation.GreaterThan: return RequirementOperator.GreaterThan;
                 case ComparisonOperation.GreaterThanOrEqual: return RequirementOperator.GreaterThanOrEqual;
-                default: return RequirementOperator.None;
-            }
-        }
-
-        private static RequirementOperator GetReversedRequirementOperator(RequirementOperator op)
-        {
-            switch (op)
-            {
-                case RequirementOperator.Equal: return RequirementOperator.Equal;
-                case RequirementOperator.NotEqual: return RequirementOperator.NotEqual;
-                case RequirementOperator.LessThan: return RequirementOperator.GreaterThan;
-                case RequirementOperator.LessThanOrEqual: return RequirementOperator.GreaterThanOrEqual;
-                case RequirementOperator.GreaterThan: return RequirementOperator.LessThan;
-                case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.LessThanOrEqual;
                 default: return RequirementOperator.None;
             }
         }


### PR DESCRIPTION
also normalize conditions so constants are on the right

adresses two bullet points from #32:
* remove duplicate conditions inc. when operands are swapped
* remove duplicate conditions with differing hit counts (prioritize the lower hit count condition?)
  - higher hit count is correct - if A must be true for 3 frames and 5 frames, it must be true for 5 frames.

