### PR TITLE
Support for fallback value in rich presence lookups

### DIFF
--- a/Parser/Functions/RichPresenceLookupFunction.cs
+++ b/Parser/Functions/RichPresenceLookupFunction.cs
@@ -11,6 +11,9 @@ namespace RATools.Parser.Functions
             Parameters.Add(new VariableDefinitionExpression("name"));
             Parameters.Add(new VariableDefinitionExpression("expression"));
             Parameters.Add(new VariableDefinitionExpression("dictionary"));
+
+            Parameters.Add(new VariableDefinitionExpression("fallback"));
+            DefaultParameters["fallback"] = new StringConstantExpression("");
         }
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
@@ -37,7 +40,11 @@ namespace RATools.Parser.Functions
                 return false;
             }
 
-            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { name, expression, dictionary });
+            var fallback = GetParameter(scope, "fallback", out result);
+            if (fallback == null)
+                return false;
+
+            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { name, expression, dictionary, fallback });
             return true;
         }
 
@@ -46,13 +53,16 @@ namespace RATools.Parser.Functions
             var name = (StringConstantExpression)functionCall.Parameters.First();
             var expression = functionCall.Parameters.ElementAt(1);
             var dictionary = (DictionaryExpression)functionCall.Parameters.ElementAt(2);
+            var fallback = functionCall.Parameters.ElementAt(3);
 
             ExpressionBase result;
             var value = TriggerBuilderContext.GetValueString(expression, scope, out result);
             if (value == null)
                 return (ParseErrorExpression)result;
 
-            context.RichPresence.AddLookupField(name.Value, dictionary);
+            var error = context.RichPresence.AddLookupField(name.Value, dictionary, fallback);
+            if (error != null)
+                return error;
 
             context.DisplayString.Append('@');
             context.DisplayString.Append(name.Value);

--- a/Parser/RichPresenceBuilder.cs
+++ b/Parser/RichPresenceBuilder.cs
@@ -11,16 +11,28 @@ namespace RATools.Parser
     [DebuggerDisplay("{DisplayString}")]
     public class RichPresenceBuilder
     {
+        private class Lookup
+        {
+            public Lookup(IDictionary<int, string> dict, string fallback)
+            {
+                Dict = dict;
+                Fallback = fallback;
+            }
+
+            public IDictionary<int, string> Dict { get; private set; }
+            public string Fallback { get; private set; }
+        };
+
         public RichPresenceBuilder()
         {
             _valueFields = new TinyDictionary<string, ValueFormat>();
-            _lookupFields = new TinyDictionary<string, IDictionary<int, string>>();
+            _lookupFields = new TinyDictionary<string, Lookup>();
             _conditionalDisplayStrings = new List<string>();
         }
 
         private List<string> _conditionalDisplayStrings;
         private TinyDictionary<string, ValueFormat> _valueFields;
-        private TinyDictionary<string, IDictionary<int, string>> _lookupFields;
+        private TinyDictionary<string, Lookup> _lookupFields;
 
         public string DisplayString { get; set; }
         public int Line { get; set; }
@@ -35,28 +47,34 @@ namespace RATools.Parser
             _valueFields[name] = format;
         }
 
-        public void AddLookupField(string name, IDictionary<int, string> dict)
+        public void AddLookupField(string name, IDictionary<int, string> dict, string fallback)
         {
-            _lookupFields[name] = dict;
+            _lookupFields[name] = new Lookup(dict, fallback);
         }
 
         internal ParseErrorExpression AddLookupField(string name, DictionaryExpression dict)
         {
             var tinyDict = new TinyDictionary<int, string>();
+            string fallback = null;
             foreach (var entry in dict.Entries)
             {
-                var key = entry.Key as IntegerConstantExpression;
-                if (key == null)
-                    return new ParseErrorExpression("key is not an integer", entry.Key);
-
                 var value = entry.Value as StringConstantExpression;
                 if (value == null)
                     return new ParseErrorExpression("value is not a string", entry.Value);
 
-                tinyDict[key.Value] = value.Value;
+                var key = entry.Key as IntegerConstantExpression;
+                if (key != null)
+                    tinyDict[key.Value] = value.Value;
+                else
+                {
+                    var strKey = entry.Key as StringConstantExpression;
+                    if (strKey == null || strKey.Value != "*")
+                        return new ParseErrorExpression("key is not an integer or \"*\"", entry.Key);
+                    fallback = value.Value;
+                }
             }
 
-            AddLookupField(name, tinyDict);
+            AddLookupField(name, tinyDict, fallback);
             return null;
         }
 
@@ -72,14 +90,20 @@ namespace RATools.Parser
                 builder.Append("Lookup:");
                 builder.AppendLine(lookup.Key);
 
-                var list = new List<int>(lookup.Value.Keys);
+                var list = new List<int>(lookup.Value.Dict.Keys);
                 list.Sort();
 
                 foreach (var key in list)
                 {
                     builder.Append(key);
                     builder.Append('=');
-                    builder.AppendLine(lookup.Value[key]);
+                    builder.AppendLine(lookup.Value.Dict[key]);
+                }
+
+                if (lookup.Value.Fallback != null)
+                {
+                    builder.Append("*=");
+                    builder.AppendLine(lookup.Value.Fallback);
                 }
 
                 builder.AppendLine();

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -721,6 +721,22 @@ namespace RATools.Test.Parser
         }
 
         [Test]
+        public void TestRichPresenceLookupFallback()
+        {
+            var parser = Parse("dict = { 1:\"Yes\", 2:\"No\" }\n" +
+                               "rich_presence_display(\"value {0} here\", rich_presence_lookup(\"Test\", byte(0x1234), dict, \"Maybe\"))");
+            Assert.That(parser.RichPresence, Is.EqualTo("Lookup:Test\r\n1=Yes\r\n2=No\r\n*=Maybe\r\n\r\nDisplay:\r\nvalue @Test(0xH001234) here\r\n"));
+        }
+
+        [Test]
+        public void TestRichPresenceLookupInvalidFallback()
+        {
+            var parser = Parse("dict = { 1:\"Yes\", 2:\"No\" }\n" +
+                               "rich_presence_display(\"value {0} here\", rich_presence_lookup(\"Test\", byte(0x1234), dict, 1))", false);
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("2:90 Fallback value is not a string"));
+        }
+
+        [Test]
         public void TestLeaderboard()
         {
             var parser = Parse("leaderboard(\"T\", \"D\", byte(0x1234) == 1, byte(0x1234) == 2, byte(0x1234) == 3, byte(0x4567))");


### PR DESCRIPTION
As specified in the Rich Presence docs: If a lookup doesn't contain a mapping
for a value, it will result in a blank (no space) value. You can change this
behavior by adding a single line to the lookup mapping '*' to the desired
fallback value.

Added support for that in RATools. The lookup map simply has to include a
"*" string constant key.