### PR TITLE
Some fixes to rich-presence-related error reporting

### DIFF
--- a/Parser/Functions/RichPresenceLookupFunction.cs
+++ b/Parser/Functions/RichPresenceLookupFunction.cs
@@ -52,7 +52,9 @@ namespace RATools.Parser.Functions
             if (value == null)
                 return (ParseErrorExpression)result;
 
-            context.RichPresence.AddLookupField(name.Value, dictionary);
+            var error = context.RichPresence.AddLookupField(name.Value, dictionary);
+            if (error != null)
+                return error;
 
             context.DisplayString.Append('@');
             context.DisplayString.Append(name.Value);


### PR DESCRIPTION
1) Rich presence format parameters must be function calls. If anything else was
provided instead, a null object exception would bubble up to the user. An editor
error, "Invalid parameter, expected function call", is now reported to the user
instead.

2) In rich presence format strings, an empty placeholder resulted in a .net
exception bubbling up to the user. The tokenizer read an empty token inside the
brackets which was then passed onto Int32.Parse, causing the exception. There
are now 2 editor errors instead: if the brackets do not contain a number,
"Empty parameter index" is reported. Otherwise, if Int32.Parse fails,
"Invalid parameter index" is reported (can happen if the number is a float).

3) A minor bug that caused errors generated while processing a rich
presence lookup to not bubble-up to the editor. The lookup was silently not
generated.