### PR TITLE
improve logic for normalizing comparisons

### DIFF
--- a/Parser/Internal/MathematicExpression.cs
+++ b/Parser/Internal/MathematicExpression.cs
@@ -196,6 +196,43 @@ namespace RATools.Parser.Internal
                             result = new IntegerConstantExpression(integerLeft.Value + integerRight.Value);
                             return true;
                         }
+
+                        var mathematicLeft = left as MathematicExpression;
+                        if (mathematicLeft != null)
+                        {
+                            integerLeft = mathematicLeft.Right as IntegerConstantExpression;
+                            if (integerLeft != null)
+                            {
+                                if (mathematicLeft.Operation == MathematicOperation.Add)
+                                {
+                                    mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value + integerRight.Value);
+                                    result = mathematicLeft;
+                                    return true;
+                                }
+
+                                if (mathematicLeft.Operation == MathematicOperation.Subtract)
+                                {
+                                    if (integerLeft.Value == integerRight.Value)
+                                    {
+                                        result = mathematicLeft.Left;
+                                        return true;
+                                    }
+
+                                    if (integerLeft.Value > integerRight.Value)
+                                    {
+                                        mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value - integerRight.Value);
+                                    }
+                                    else
+                                    {
+                                        mathematicLeft.Right = new IntegerConstantExpression(integerRight.Value - integerLeft.Value);
+                                        mathematicLeft.Operation = MathematicOperation.Add;
+                                    }
+
+                                    result = mathematicLeft;
+                                    return true;
+                                }
+                            }
+                        }
                     }
                     break;
 
@@ -213,8 +250,44 @@ namespace RATools.Parser.Internal
                             result = new IntegerConstantExpression(integerLeft.Value - integerRight.Value);
                             return true;
                         }
-                    }
 
+                        var mathematicLeft = left as MathematicExpression;
+                        if (mathematicLeft != null)
+                        {
+                            integerLeft = mathematicLeft.Right as IntegerConstantExpression;
+                            if (integerLeft != null)
+                            {
+                                if (mathematicLeft.Operation == MathematicOperation.Subtract)
+                                {
+                                    mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value + integerRight.Value);
+                                    result = mathematicLeft;
+                                    return true;
+                                }
+
+                                if (mathematicLeft.Operation == MathematicOperation.Add)
+                                {
+                                    if (integerLeft.Value == integerRight.Value)
+                                    {
+                                        result = mathematicLeft.Left;
+                                        return true;
+                                    }
+
+                                    if (integerLeft.Value > integerRight.Value)
+                                    {
+                                        mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value - integerRight.Value);
+                                    }
+                                    else
+                                    {
+                                        mathematicLeft.Right = new IntegerConstantExpression(integerRight.Value - integerLeft.Value);
+                                        mathematicLeft.Operation = MathematicOperation.Subtract;
+                                    }
+
+                                    result = mathematicLeft;
+                                    return true;
+                                }
+                            }
+                        }
+                    }
                     break;
 
                 case MathematicOperation.Multiply:
@@ -247,6 +320,21 @@ namespace RATools.Parser.Internal
                             result = new IntegerConstantExpression(integerLeft.Value * integerRight.Value);
                             return true;
                         }
+
+                        var mathematicLeft = left as MathematicExpression;
+                        if (mathematicLeft != null)
+                        {
+                            integerLeft = mathematicLeft.Right as IntegerConstantExpression;
+                            if (integerLeft != null)
+                            {
+                                if (mathematicLeft.Operation == MathematicOperation.Multiply)
+                                {
+                                    mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value * integerRight.Value);
+                                    result = mathematicLeft;
+                                    return true;
+                                }
+                            }
+                        }
                     }
                     break;
 
@@ -269,6 +357,34 @@ namespace RATools.Parser.Internal
                         {
                             result = new IntegerConstantExpression(integerLeft.Value / integerRight.Value);
                             return true;
+                        }
+
+                        var mathematicLeft = left as MathematicExpression;
+                        if (mathematicLeft != null)
+                        {
+                            integerLeft = mathematicLeft.Right as IntegerConstantExpression;
+                            if (integerLeft != null)
+                            {
+                                if (mathematicLeft.Operation == MathematicOperation.Divide)
+                                {
+                                    mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value * integerRight.Value);
+                                    result = mathematicLeft;
+                                    return true;
+                                }
+
+                                if (mathematicLeft.Operation == MathematicOperation.Multiply && (integerLeft.Value % integerRight.Value == 0))
+                                {
+                                    if (integerLeft.Value == integerRight.Value)
+                                    {
+                                        result = mathematicLeft.Left;
+                                        return true;
+                                    }
+
+                                    mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value / integerRight.Value);
+                                    result = mathematicLeft;
+                                    return true;
+                                }
+                            }
                         }
                     }
                     break;

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -136,6 +136,7 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x1234) == prev(byte(0x1234)) + 3", "(byte(0x001234) - 3) == prev(byte(0x001234))")] // value increases by 3
         [TestCase("byte(0x1234) - prev(byte(0x1234)) == 3", "(byte(0x001234) - prev(byte(0x001234))) == 3")] // value increases by 3
         [TestCase("byte(0x1234) + 1 == byte(0x4321) - 1", "(2 + byte(0x001234)) == byte(0x004321)")] // modifiers on different addresses
+        [TestCase("(word(0x1234) - 1) * 4 > (prev(word(0x1234)) - 1) * 4", "word(0x001234) > prev(word(0x001234))")]
         public void TestTransitiveCondition(string trigger, string expectedRequirement)
         {
             var parser = Parse("achievement(\"T\", \"D\", 5, " + trigger + ")");
@@ -796,6 +797,9 @@ namespace RATools.Test.Parser
         [TestCase("word(0x1234) * 10 + byte(0x1235) == 10000", false, "1:26 Cannot normalize expression to eliminate multiplication")]
         [TestCase("byte(0x1235) + word(0x1234) * 10 == 10000", false, "1:26 Cannot normalize expression to eliminate multiplication")]
         [TestCase("word(0x1234) * 10 + byte(0x1235) * 2 == 10000", false, "1:26 Cannot normalize expression to eliminate multiplication")]
+        [TestCase("(word(0x1234) - 1) * 4 < 100", true, "word(0x001234) < 26")]
+        [TestCase("(word(0x1234) - 1) / 4 < 100", true, "word(0x001234) < 401")]
+        [TestCase("(word(0x1234) - 1) * 4 < 99", true, "word(0x001234) < 25")]
         public void TestMultiplicationInExpression(string input, bool expectedResult, string output)
         {
             var parser = Parse("achievement(\"T\", \"D\", 5, " + input + ")\n", expectedResult);


### PR DESCRIPTION
For normalizing complex comparisons like:
* `(word(0x1234) - 1) * 4 < 100`   to   `word(0x1234) < 401` 
* `(word(0x1234) - 1) * 4 > (prev(word(0x1234)) - 1) * 4`   to   `word(0x001234) > prev(word(0x001234))`