### PR TITLE
prevent modifying location of parameter data when evaluating parameters

### DIFF
--- a/Parser/Functions/AlwaysFalseFunction.cs
+++ b/Parser/Functions/AlwaysFalseFunction.cs
@@ -16,6 +16,7 @@ namespace RATools.Parser.Functions
                 return false;
 
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[0]);
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Functions/AlwaysTrueFunction.cs
+++ b/Parser/Functions/AlwaysTrueFunction.cs
@@ -16,6 +16,7 @@ namespace RATools.Parser.Functions
                 return false;
 
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[0]);
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Functions/BitFunction.cs
+++ b/Parser/Functions/BitFunction.cs
@@ -28,6 +28,7 @@ namespace RATools.Parser.Functions
                 return false;
 
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { index, address });
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Functions/ComparisonModificationFunction.cs
+++ b/Parser/Functions/ComparisonModificationFunction.cs
@@ -23,6 +23,7 @@ namespace RATools.Parser.Functions
                 return false;
 
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { comparison });
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Functions/FlagConditionFunction.cs
+++ b/Parser/Functions/FlagConditionFunction.cs
@@ -34,6 +34,7 @@ namespace RATools.Parser.Functions
                 right = result;
 
                 result = new ConditionalExpression(left, ConditionalOperation.And, right);
+                CopyLocation(result);
                 return true;
             }
 

--- a/Parser/Functions/MemoryAccessorFunction.cs
+++ b/Parser/Functions/MemoryAccessorFunction.cs
@@ -26,6 +26,7 @@ namespace RATools.Parser.Functions
                 return false;
 
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { address });
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Functions/OnceFunction.cs
+++ b/Parser/Functions/OnceFunction.cs
@@ -20,6 +20,7 @@ namespace RATools.Parser.Functions
                 return false;
 
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { comparison });
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Functions/PrevPriorFunction.cs
+++ b/Parser/Functions/PrevPriorFunction.cs
@@ -51,6 +51,7 @@ namespace RATools.Parser.Functions
                 }
 
                 result = new MathematicExpression(left, mathematic.Operation, right);
+                CopyLocation(result);
                 return true;
             }
 
@@ -70,6 +71,7 @@ namespace RATools.Parser.Functions
             }
 
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { functionCall });
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Functions/RangeFunction.cs
+++ b/Parser/Functions/RangeFunction.cs
@@ -62,6 +62,7 @@ namespace RATools.Parser.Functions
             }
 
             result = array;
+            CopyLocation(result);
             return true;
         }
     }

--- a/Parser/Functions/RepeatedFunction.cs
+++ b/Parser/Functions/RepeatedFunction.cs
@@ -34,6 +34,7 @@ namespace RATools.Parser.Functions
                 return false;
 
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { count, comparison });
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Functions/RichPresenceLookupFunction.cs
+++ b/Parser/Functions/RichPresenceLookupFunction.cs
@@ -45,6 +45,7 @@ namespace RATools.Parser.Functions
                 return false;
 
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { name, expression, dictionary, fallback });
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Functions/RichPresenceValueFunction.cs
+++ b/Parser/Functions/RichPresenceValueFunction.cs
@@ -41,6 +41,7 @@ namespace RATools.Parser.Functions
                 return false;
 
             result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { name, expression, format });
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Internal/ArrayExpression.cs
+++ b/Parser/Internal/ArrayExpression.cs
@@ -48,7 +48,8 @@ namespace RATools.Parser.Internal
         {
             if (Entries.Count == 0)
             {
-                result = this;
+                result = new ArrayExpression { Entries = new List<ExpressionBase>() };
+                CopyLocation(result);
                 return true;
             }
 
@@ -70,6 +71,7 @@ namespace RATools.Parser.Internal
             }
 
             result = new ArrayExpression { Entries = entries };
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Internal/AssignmentExpression.cs
+++ b/Parser/Internal/AssignmentExpression.cs
@@ -62,6 +62,7 @@ namespace RATools.Parser.Internal
             }
 
             result = new AssignmentExpression(Variable, value);
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Internal/ComparisonExpression.cs
+++ b/Parser/Internal/ComparisonExpression.cs
@@ -82,9 +82,8 @@ namespace RATools.Parser.Internal
                 return false;
             }
 
-            var comparison = new ComparisonExpression(left, Operation, right);
-            CopyLocation(comparison);
-            result = comparison;
+            result = new ComparisonExpression(left, Operation, right);
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Internal/ConditionalExpression.cs
+++ b/Parser/Internal/ConditionalExpression.cs
@@ -79,10 +79,8 @@ namespace RATools.Parser.Internal
                 return false;
             }
 
-            var condition = new ConditionalExpression(left, Operation, right);
-            condition.Line = Line;
-            condition.Column = Column;
-            result = condition;
+            result = new ConditionalExpression(left, Operation, right);
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Internal/DictionaryExpression.cs
+++ b/Parser/Internal/DictionaryExpression.cs
@@ -95,7 +95,8 @@ namespace RATools.Parser.Internal
         {
             if (Entries.Count == 0)
             {
-                result = this;
+                result = new DictionaryExpression { Entries = new List<DictionaryEntry>() };
+                CopyLocation(result);
                 return true;
             }
 
@@ -161,6 +162,7 @@ namespace RATools.Parser.Internal
             }
 
             result = new DictionaryExpression { Entries = entries };
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -501,8 +501,6 @@ namespace RATools.Parser.Internal
 
                     SkipWhitespace(tokenizer);
 
-                    var commaLine = tokenizer.Line;
-                    var commaColumn = tokenizer.Column;
                     if (tokenizer.NextChar != ',')
                         break;
 

--- a/Parser/Internal/IntegerConstantExpression.cs
+++ b/Parser/Internal/IntegerConstantExpression.cs
@@ -23,6 +23,13 @@ namespace RATools.Parser.Internal
             builder.Append(Value);
         }
 
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            result = new IntegerConstantExpression(Value);
+            CopyLocation(result);
+            return true;
+        }
+
         /// <summary>
         /// Determines whether the specified <see cref="IntegerConstantExpression" /> is equal to this instance.
         /// </summary>

--- a/Parser/Internal/MathematicExpression.cs
+++ b/Parser/Internal/MathematicExpression.cs
@@ -155,12 +155,14 @@ namespace RATools.Parser.Internal
                         if (stringRight != null)
                         {
                             result = new StringConstantExpression(stringLeft.Value + stringRight.Value);
+                            CopyLocation(result);
                             return true;
                         }
 
                         if (integerRight != null)
                         {
                             result = new StringConstantExpression(stringLeft.Value + integerRight.Value.ToString());
+                            CopyLocation(result);
                             return true;
                         }
                     }
@@ -169,6 +171,7 @@ namespace RATools.Parser.Internal
                         if (integerLeft != null)
                         {
                             result = new StringConstantExpression(integerLeft.Value.ToString() + stringRight.Value);
+                            CopyLocation(result);
                             return true;
                         }
                     }
@@ -194,6 +197,7 @@ namespace RATools.Parser.Internal
                         if (integerLeft != null)
                         {
                             result = new IntegerConstantExpression(integerLeft.Value + integerRight.Value);
+                            CopyLocation(result);
                             return true;
                         }
 
@@ -205,8 +209,9 @@ namespace RATools.Parser.Internal
                             {
                                 if (mathematicLeft.Operation == MathematicOperation.Add)
                                 {
-                                    mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value + integerRight.Value);
-                                    result = mathematicLeft;
+                                    result = new MathematicExpression(mathematicLeft.Left, MathematicOperation.Add, 
+                                        new IntegerConstantExpression(integerLeft.Value + integerRight.Value));
+                                    CopyLocation(result);
                                     return true;
                                 }
 
@@ -220,15 +225,16 @@ namespace RATools.Parser.Internal
 
                                     if (integerLeft.Value > integerRight.Value)
                                     {
-                                        mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value - integerRight.Value);
+                                        result = new MathematicExpression(mathematicLeft.Left, MathematicOperation.Subtract,
+                                            new IntegerConstantExpression(integerLeft.Value - integerRight.Value));
                                     }
                                     else
                                     {
-                                        mathematicLeft.Right = new IntegerConstantExpression(integerRight.Value - integerLeft.Value);
-                                        mathematicLeft.Operation = MathematicOperation.Add;
+                                        result = new MathematicExpression(mathematicLeft.Left, MathematicOperation.Add,
+                                            new IntegerConstantExpression(integerRight.Value - integerLeft.Value));
                                     }
 
-                                    result = mathematicLeft;
+                                    CopyLocation(result);
                                     return true;
                                 }
                             }
@@ -248,6 +254,7 @@ namespace RATools.Parser.Internal
                         if (integerLeft != null)
                         {
                             result = new IntegerConstantExpression(integerLeft.Value - integerRight.Value);
+                            CopyLocation(result);
                             return true;
                         }
 
@@ -259,8 +266,9 @@ namespace RATools.Parser.Internal
                             {
                                 if (mathematicLeft.Operation == MathematicOperation.Subtract)
                                 {
-                                    mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value + integerRight.Value);
-                                    result = mathematicLeft;
+                                    result = new MathematicExpression(mathematicLeft.Left, MathematicOperation.Subtract,
+                                        new IntegerConstantExpression(integerLeft.Value + integerRight.Value));
+                                    CopyLocation(result);
                                     return true;
                                 }
 
@@ -274,15 +282,16 @@ namespace RATools.Parser.Internal
 
                                     if (integerLeft.Value > integerRight.Value)
                                     {
-                                        mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value - integerRight.Value);
+                                        result = new MathematicExpression(mathematicLeft.Left, MathematicOperation.Add,
+                                            new IntegerConstantExpression(integerLeft.Value - integerRight.Value));
                                     }
                                     else
                                     {
-                                        mathematicLeft.Right = new IntegerConstantExpression(integerRight.Value - integerLeft.Value);
-                                        mathematicLeft.Operation = MathematicOperation.Subtract;
+                                        result = new MathematicExpression(mathematicLeft.Left, MathematicOperation.Subtract,
+                                            new IntegerConstantExpression(integerRight.Value - integerLeft.Value));
                                     }
 
-                                    result = mathematicLeft;
+                                    CopyLocation(result);
                                     return true;
                                 }
                             }
@@ -318,6 +327,7 @@ namespace RATools.Parser.Internal
                         if (integerLeft != null)
                         {
                             result = new IntegerConstantExpression(integerLeft.Value * integerRight.Value);
+                            CopyLocation(result);
                             return true;
                         }
 
@@ -329,8 +339,9 @@ namespace RATools.Parser.Internal
                             {
                                 if (mathematicLeft.Operation == MathematicOperation.Multiply)
                                 {
-                                    mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value * integerRight.Value);
-                                    result = mathematicLeft;
+                                    result = new MathematicExpression(mathematicLeft.Left, MathematicOperation.Multiply,
+                                        new IntegerConstantExpression(integerLeft.Value * integerRight.Value));
+                                    CopyLocation(result);
                                     return true;
                                 }
                             }
@@ -356,6 +367,7 @@ namespace RATools.Parser.Internal
                         if (integerLeft != null)
                         {
                             result = new IntegerConstantExpression(integerLeft.Value / integerRight.Value);
+                            CopyLocation(result);
                             return true;
                         }
 
@@ -367,8 +379,9 @@ namespace RATools.Parser.Internal
                             {
                                 if (mathematicLeft.Operation == MathematicOperation.Divide)
                                 {
-                                    mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value * integerRight.Value);
-                                    result = mathematicLeft;
+                                    result = new MathematicExpression(mathematicLeft.Left, MathematicOperation.Divide,
+                                       new IntegerConstantExpression(integerLeft.Value * integerRight.Value));
+                                    CopyLocation(result);
                                     return true;
                                 }
 
@@ -380,8 +393,9 @@ namespace RATools.Parser.Internal
                                         return true;
                                     }
 
-                                    mathematicLeft.Right = new IntegerConstantExpression(integerLeft.Value / integerRight.Value);
-                                    result = mathematicLeft;
+                                    result = new MathematicExpression(mathematicLeft.Left, MathematicOperation.Multiply,
+                                        new IntegerConstantExpression(integerLeft.Value / integerRight.Value));
+                                    CopyLocation(result);
                                     return true;
                                 }
                             }
@@ -401,22 +415,22 @@ namespace RATools.Parser.Internal
                         if (integerRight.Value == 1) // anything modulus 1 is 0
                         {
                             result = new IntegerConstantExpression(0);
+                            CopyLocation(result);
                             return true;
                         }
 
                         if (integerLeft != null)
                         {
                             result = new IntegerConstantExpression(integerLeft.Value % integerRight.Value);
+                            CopyLocation(result);
                             return true;
                         }
                     }
                     break;
             }
 
-            var mathematic = new MathematicExpression(left, Operation, right);
-            mathematic.Line = Line;
-            mathematic.Column = Column;
-            result = mathematic;
+            result = new MathematicExpression(left, Operation, right);
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Internal/ReturnExpression.cs
+++ b/Parser/Internal/ReturnExpression.cs
@@ -62,6 +62,7 @@ namespace RATools.Parser.Internal
             }
 
             result = new ReturnExpression(value);
+            CopyLocation(result);
             return true;
         }
 

--- a/Parser/Internal/StringConstantExpression.cs
+++ b/Parser/Internal/StringConstantExpression.cs
@@ -25,6 +25,13 @@ namespace RATools.Parser.Internal
             builder.Append('"');
         }
 
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            result = new StringConstantExpression(Value);
+            CopyLocation(result);
+            return true;
+        }
+
         /// <summary>
         /// Determines whether the specified <see cref="StringConstantExpression" /> is equal to this instance.
         /// </summary>

--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -582,6 +582,7 @@ namespace RATools.Parser
             if (newRoot.Left.Type == ExpressionType.Mathematic)
                 return RebalanceMathematicComparison(newRoot, scope, out result);
 
+            comparisonExpression.CopyLocation(newRoot);
             result = newRoot;
             return true;
         }


### PR DESCRIPTION
Fixes an issue where function parameters would sometimes not be highlighted if they were passed to an inner function. 

![image](https://user-images.githubusercontent.com/32680403/65644665-1ae68b00-dfb2-11e9-9d53-1657fe626c38.png)

The syntax validation code was updating the location of the parameter each time it was passed to a lower function, thereby preventing the syntax highlighting code from finding it.

This was mostly an issue with constants as they were unmodified by the variable replacement code, allowing the location to be updated on the original expression. The solution is to always create a copy of the expression when calling `ReplaceVariables`, even if nothing is replaced.

I've also sprinkled a lot of `CopyLocation` calls on all of the copied expressions to ensure the location is correct if `ReplaceVariables` is called for something other than parameter expansion.