### PR TITLE
account for possible underflow when transferring variables from one side of a condition to the other

### DIFF
--- a/Data/Field.cs
+++ b/Data/Field.cs
@@ -147,6 +147,38 @@ namespace RATools.Data
         }
 
         /// <summary>
+        /// Gets the maximum value representable by the specified size.
+        /// </summary>
+        public static uint GetMaxValue(FieldSize size)
+        {
+            switch (size)
+            {
+                case FieldSize.Bit0:
+                case FieldSize.Bit1:
+                case FieldSize.Bit2:
+                case FieldSize.Bit3:
+                case FieldSize.Bit4:
+                case FieldSize.Bit5:
+                case FieldSize.Bit6:
+                case FieldSize.Bit7:
+                    return 1;
+
+                case FieldSize.LowNibble:
+                case FieldSize.HighNibble:
+                    return 15;
+
+                case FieldSize.Byte:
+                    return 255;
+
+                case FieldSize.Word:
+                    return 65535;
+
+                default:
+                    return uint.MaxValue;
+            }
+        }
+
+        /// <summary>
         /// Gets whether or not the field references memory.
         /// </summary>
         public bool IsMemoryReference

--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -619,62 +619,31 @@ namespace RATools.Parser
                     continue;
                 }
 
-                uint max;
-
-                switch (requirement.Left.Size)
+                uint max = Field.GetMaxValue(requirement.Left.Size);
+                if (max == 1)
                 {
-                    case FieldSize.Bit0:
-                    case FieldSize.Bit1:
-                    case FieldSize.Bit2:
-                    case FieldSize.Bit3:
-                    case FieldSize.Bit4:
-                    case FieldSize.Bit5:
-                    case FieldSize.Bit6:
-                    case FieldSize.Bit7:
-                        max = 1;
-
-                        if (requirement.Right.Value == 0)
+                    if (requirement.Right.Value == 0)
+                    {
+                        switch (requirement.Operator)
                         {
-                            switch (requirement.Operator)
-                            {
-                                case RequirementOperator.NotEqual: // bit != 0 -> bit == 1
-                                case RequirementOperator.GreaterThan: // bit > 0 -> bit == 1
-                                    requirement.Operator = RequirementOperator.Equal;
-                                    requirement.Right = new Field { Size = requirement.Right.Size, Type = FieldType.Value, Value = 1 };
-                                    continue;
-                            }
+                            case RequirementOperator.NotEqual: // bit != 0 -> bit == 1
+                            case RequirementOperator.GreaterThan: // bit > 0 -> bit == 1
+                                requirement.Operator = RequirementOperator.Equal;
+                                requirement.Right = new Field { Size = requirement.Right.Size, Type = FieldType.Value, Value = 1 };
+                                continue;
                         }
-                        else
+                    }
+                    else
+                    {
+                        switch (requirement.Operator)
                         {
-                            switch (requirement.Operator)
-                            {
-                                case RequirementOperator.NotEqual: // bit != 1 -> bit == 0
-                                case RequirementOperator.LessThan: // bit < 1 -> bit == 0
-                                    requirement.Operator = RequirementOperator.Equal;
-                                    requirement.Right = new Field { Size = requirement.Right.Size, Type = FieldType.Value, Value = 0 };
-                                    continue;
-                            }
+                            case RequirementOperator.NotEqual: // bit != 1 -> bit == 0
+                            case RequirementOperator.LessThan: // bit < 1 -> bit == 0
+                                requirement.Operator = RequirementOperator.Equal;
+                                requirement.Right = new Field { Size = requirement.Right.Size, Type = FieldType.Value, Value = 0 };
+                                continue;
                         }
-
-                        break;
-
-                    case FieldSize.LowNibble:
-                    case FieldSize.HighNibble:
-                        max = 15;
-                        break;
-
-                    case FieldSize.Byte:
-                        max = 255;
-                        break;
-
-                    case FieldSize.Word:
-                        max = 65535;
-                        break;
-
-                    default:
-                    case FieldSize.DWord:
-                        max = uint.MaxValue;
-                        break;
+                    }
                 }
 
                 if (requirement.Right.Value >= max)

--- a/Parser/Functions/MemoryAccessorFunction.cs
+++ b/Parser/Functions/MemoryAccessorFunction.cs
@@ -9,12 +9,12 @@ namespace RATools.Parser.Functions
         public MemoryAccessorFunction(string name, FieldSize size)
             : base(name)
         {
-            _size = size;
+            Size = size;
 
             Parameters.Add(new VariableDefinitionExpression("address"));
         }
 
-        private readonly FieldSize _size;
+        public FieldSize Size { get; private set; }
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
@@ -34,7 +34,7 @@ namespace RATools.Parser.Functions
         {
             var requirement = new Requirement();
             var address = (IntegerConstantExpression)functionCall.Parameters.First();
-            requirement.Left = new Field { Size = _size, Type = FieldType.MemoryAddress, Value = (uint)address.Value };
+            requirement.Left = new Field { Size = this.Size, Type = FieldType.MemoryAddress, Value = (uint)address.Value };
             context.Trigger.Add(requirement);
             return null;
         }

--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -687,6 +687,7 @@ namespace RATools.Parser
                     if (underflowAdjustment != 0 &&
                         (comparison.Operation == ComparisonOperation.LessThan || comparison.Operation == ComparisonOperation.LessThanOrEqual))
                     {
+                        // if the user has specified an underflow adjustment, keep it, regardless of the calculated value
                         if (mathematic.Right is IntegerConstantExpression)
                             underflowAdjustment = ((IntegerConstantExpression)mathematic.Right).Value;
                     }

--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -11,10 +11,7 @@ namespace RATools.Parser
     {
         public ScriptInterpreterAchievementBuilder() : base()
         {
-            _equalityModifiers = new Stack<ValueModifier>();
         }
-
-        private Stack<ValueModifier> _equalityModifiers;
 
         /// <summary>
         /// Begins an new alt group.
@@ -352,8 +349,11 @@ namespace RATools.Parser
 
         private ParseErrorExpression ExecuteAchievementMathematic(MathematicExpression mathematic, InterpreterScope scope)
         {
-            var left = mathematic.Left;
             var operation = mathematic.Operation;
+            if (operation != MathematicOperation.Add && operation != MathematicOperation.Subtract)
+                return new ParseErrorExpression("Cannot normalize expression to eliminate " + MathematicExpression.GetOperatorType(operation), mathematic);
+
+            var left = mathematic.Left;
             var context = scope.GetContext<TriggerBuilderContext>();
             ParseErrorExpression error;
 
@@ -361,20 +361,27 @@ namespace RATools.Parser
             if (!mathematic.Right.ReplaceVariables(scope, out right))
                 return (ParseErrorExpression)right;
 
+            var integerOperand = right as IntegerConstantExpression;
+            if (integerOperand != null)
+            {
+                context.Trigger.Add(new Requirement
+                {
+                    Type = (operation == MathematicOperation.Add) ? RequirementType.AddSource : RequirementType.SubSource,
+                    Left = new Field { Type = FieldType.Value, Value = (uint)integerOperand.Value },
+                    Operator = RequirementOperator.None,
+                    Right = new Field()
+                });
+            }
+
             if (operation == MathematicOperation.Subtract && (right is FunctionCallExpression || right is MathematicExpression))
             {
                 // if subtracting a non-integer, swap the order to perform a SubSource
-                var newEqualityModifiers = new Stack<ValueModifier>();
-                var oldEqualityModifiers = _equalityModifiers;
-                _equalityModifiers = newEqualityModifiers;
-
                 var requirements = new List<Requirement>();
                 var innerContext = new TriggerBuilderContext() { Trigger = requirements };
                 var innerScope = new InterpreterScope(scope) { Context = innerContext };
 
                 // generate the condition for the right side
                 error = ExecuteAchievementExpression(right, innerScope);
-                _equalityModifiers = oldEqualityModifiers;
                 if (error != null)
                     return error;
 
@@ -396,21 +403,6 @@ namespace RATools.Parser
                     context.Trigger.Add(requirement);
                 }
 
-                foreach (var modifier in newEqualityModifiers)
-                {
-                    switch (modifier.Operation)
-                    {
-                        case MathematicOperation.Add:
-                            _equalityModifiers.Push(new ValueModifier(MathematicOperation.Subtract, modifier.Amount));
-                            break;
-                        case MathematicOperation.Subtract:
-                            _equalityModifiers.Push(new ValueModifier(MathematicOperation.Add, modifier.Amount));
-                            break;
-                        default:
-                            return new ParseErrorExpression("Cannot normalize expression for negation", mathematic);
-                    }
-                }
-
                 right = mathematic.Left;
                 operation = MathematicOperation.Add;
             }
@@ -422,39 +414,11 @@ namespace RATools.Parser
                     return error;
             }
 
-            var integerOperand = right as IntegerConstantExpression;
             if (integerOperand != null)
-            {
-                var oppositeOperation = MathematicExpression.GetOppositeOperation(operation);
-                if (oppositeOperation == MathematicOperation.None)
-                    return new ParseErrorExpression(String.Format("Cannot normalize expression to eliminate {0}", MathematicExpression.GetOperatorType(mathematic.Operation)), mathematic);
-
-                var priority = MathematicExpression.GetPriority(mathematic.Operation);
-                if (priority != MathematicPriority.Add)
-                {
-                    if (context.Trigger.Count > 1)
-                    {
-                        var previousRequirementType = context.Trigger.ElementAt(context.Trigger.Count - 2).Type;
-                        if (previousRequirementType == RequirementType.AddSource || previousRequirementType == RequirementType.SubSource)
-                            return new ParseErrorExpression(String.Format("Cannot normalize expression to eliminate {0}", MathematicExpression.GetOperatorType(mathematic.Operation)), mathematic);
-                    }
-
-                    if (_equalityModifiers.Any(e => MathematicExpression.GetPriority(e.Operation) != priority))
-                        return new ParseErrorExpression(String.Format("Cannot normalize expression to eliminate {0}", MathematicExpression.GetOperatorType(mathematic.Operation)), mathematic);
-                }
-
-                _equalityModifiers.Push(new ValueModifier(oppositeOperation, integerOperand.Value));
                 return null;
-            }
 
             if (operation == MathematicOperation.Add)
             {
-                foreach (var modifier in _equalityModifiers)
-                {
-                    if (MathematicExpression.GetPriority(modifier.Operation) != MathematicPriority.Add)
-                        return new ParseErrorExpression(String.Format("Cannot normalize expression to eliminate {0}", MathematicExpression.GetOperatorType(MathematicExpression.GetOppositeOperation(modifier.Operation))), mathematic);
-                }
-
                 // adding two memory accessors - make sure previous is AddSource or SubSource
                 if (context.LastRequirement.Type != RequirementType.SubSource)
                 {
@@ -513,11 +477,13 @@ namespace RATools.Parser
             return new ParseErrorExpression("Unsupported conditional", condition);
         }
 
-        private bool RebalanceMathematicComparison(ComparisonExpression comparisonExpression, InterpreterScope scope, out ExpressionBase result)
+        private bool MoveConstantsToRightHandSide(ComparisonExpression comparisonExpression, InterpreterScope scope, out ExpressionBase result)
         {
+            ComparisonExpression newRoot;
             var mathematic = (MathematicExpression)comparisonExpression.Left;
 
-            // can only apply transitive property to integer constants
+            // if the rightmost expression of the left side of the comparison is an integer, shift it to the 
+            // right side of the equation and attempt to merge it with whatever is already there.
             var integer = mathematic.Right as IntegerConstantExpression;
             if (integer == null)
             {
@@ -578,29 +544,204 @@ namespace RATools.Parser
             }
 
             // construct the new equation and recurse if applicable
-            var newRoot = new ComparisonExpression(mathematic.Left, comparisonOperation, newRight);
+            newRoot = new ComparisonExpression(mathematic.Left, comparisonOperation, newRight);
             if (newRoot.Left.Type == ExpressionType.Mathematic)
-                return RebalanceMathematicComparison(newRoot, scope, out result);
+                return MoveConstantsToRightHandSide(newRoot, scope, out result);
 
             comparisonExpression.CopyLocation(newRoot);
             result = newRoot;
             return true;
         }
 
+        private bool EnsureSingleExpressionOnRightHandSide(ComparisonExpression comparisonExpression, InterpreterScope scope, ref int underflowAdjustment, out ExpressionBase result)
+        {
+            MathematicExpression newLeft;
+            ComparisonExpression newRoot;
+
+            // if the right hand side of the comparison is a mathematic, shift part of it to the left hand side so 
+            // the right hand side eventually has a single value/address
+            var mathematic = (MathematicExpression)comparisonExpression.Right;
+            bool moveLeft = true;
+
+            switch (mathematic.Operation)
+            {
+                case MathematicOperation.Add:
+                    // the leftmost part of the right side will be moved to the left side as a subtraction.
+                    // when subtracting a memory accessor, the result could be negative. since we're using
+                    // unsigned values, this could result in a very high positive number. if not doing an exact
+                    // comparison, check for potential underflow and offset total calculation to prevent it.
+                    if (comparisonExpression.Operation != ComparisonOperation.Equal && comparisonExpression.Operation != ComparisonOperation.NotEqual)
+                    {
+                        var functionCall = mathematic.Left as FunctionCallExpression;
+                        if (functionCall != null)
+                        {
+                            var memoryAccessor = scope.GetFunction(functionCall.FunctionName.Name) as MemoryAccessorFunction;
+                            if (memoryAccessor != null && memoryAccessor.Size != FieldSize.DWord)
+                                underflowAdjustment += (int)Field.GetMaxValue(memoryAccessor.Size);
+                        }
+                    }
+
+                    if (mathematic.Right is IntegerConstantExpression)
+                        moveLeft = false;
+                    break;
+
+                case MathematicOperation.Subtract:
+                    // the rightmost part of the right side will be moved to the left side as an addition
+                    moveLeft = false;
+                    break;
+
+                default:
+                    result = new ParseErrorExpression("Cannot eliminate " + MathematicExpression.GetOperatorType(mathematic.Operation) +
+                        " from right side of comparison", comparisonExpression);
+                    return false;
+            }
+
+            if (moveLeft)
+            {
+                // left side is implicitly added on the right, so explicitly subtract it on the left
+                newLeft = new MathematicExpression(comparisonExpression.Left, MathematicOperation.Subtract, mathematic.Left);
+                newRoot = new ComparisonExpression(newLeft, comparisonExpression.Operation, mathematic.Right);
+            }
+            else
+            {
+                // invert the operation when moving the right side to the left
+                newLeft = new MathematicExpression(comparisonExpression.Left, MathematicExpression.GetOppositeOperation(mathematic.Operation), mathematic.Right);
+                newRoot = new ComparisonExpression(newLeft, comparisonExpression.Operation, mathematic.Left);
+            }
+
+            // ensure the IntegerConstant is the rightmost element of the left side
+            mathematic = comparisonExpression.Left as MathematicExpression;
+            if (mathematic != null && mathematic.Right is IntegerConstantExpression)
+            {
+                newLeft.Left = mathematic.Left;
+                mathematic.Left = newLeft;
+                newRoot.Left = mathematic;
+            }
+
+            // recurse if necessary
+            if (newRoot.Right is MathematicExpression)
+                return EnsureSingleExpressionOnRightHandSide(newRoot, scope, ref underflowAdjustment, out result);
+
+            result = newRoot;
+            return true;
+        }
+
+        private static int CalculateUnderflow(MathematicExpression mathematic, InterpreterScope scope, bool invert, bool hasSubtract)
+        {
+            int underflowAdjustment = 0;
+
+            var subsourceOperation = invert ? MathematicOperation.Add : MathematicOperation.Subtract;
+            if (mathematic.Operation == subsourceOperation)
+            {
+                var functionCall = mathematic.Right as FunctionCallExpression;
+                if (functionCall != null)
+                {
+                    var memoryAccessor = scope.GetFunction(functionCall.FunctionName.Name) as MemoryAccessorFunction;
+                    if (memoryAccessor != null && memoryAccessor.Size != FieldSize.DWord)
+                        underflowAdjustment += (int)Field.GetMaxValue(memoryAccessor.Size);
+                }
+            }
+            else if (hasSubtract)
+            {
+                var functionCall = mathematic.Left as FunctionCallExpression;
+                if (functionCall != null)
+                {
+                    var memoryAccessor = scope.GetFunction(functionCall.FunctionName.Name) as MemoryAccessorFunction;
+                    if (memoryAccessor != null && memoryAccessor.Size != FieldSize.DWord)
+                        underflowAdjustment += (int)Field.GetMaxValue(memoryAccessor.Size);
+                }
+            }
+
+            var mathematicLeft = mathematic.Left as MathematicExpression;
+            if (mathematicLeft != null)
+                underflowAdjustment += CalculateUnderflow(mathematicLeft, scope, invert, hasSubtract);
+
+            var mathematicRight = mathematic.Right as MathematicExpression;
+            if (mathematicRight != null)
+            {
+                if (mathematic.Operation == MathematicOperation.Subtract)
+                    underflowAdjustment += CalculateUnderflow(mathematicRight, scope, !invert, true);
+                else
+                    underflowAdjustment += CalculateUnderflow(mathematicRight, scope, invert, hasSubtract);
+            }
+
+            return underflowAdjustment;
+        }
+
         private ParseErrorExpression ExecuteAchievementComparison(ComparisonExpression comparison, InterpreterScope scope)
         {
-            _equalityModifiers.Clear();
-
             var context = scope.GetContext<TriggerBuilderContext>();
             var insertIndex = context.Trigger.Count;
+            int underflowAdjustment = 0;
 
             if (comparison.Left.Type == ExpressionType.Mathematic)
             {
+                var mathematic = (MathematicExpression)comparison.Left;
+                comparison.Left = mathematic = MathematicExpression.BubbleUpIntegerConstant(mathematic);
+
+                // if comparison is not direct equality/inequality, need to check for underflow
+                if (comparison.Operation != ComparisonOperation.Equal && comparison.Operation != ComparisonOperation.NotEqual)
+                {
+                    underflowAdjustment = CalculateUnderflow((MathematicExpression)comparison.Left, scope, false, false);
+
+                    if (underflowAdjustment != 0 &&
+                        (comparison.Operation == ComparisonOperation.LessThan || comparison.Operation == ComparisonOperation.LessThanOrEqual))
+                    {
+                        if (mathematic.Right is IntegerConstantExpression)
+                            underflowAdjustment = ((IntegerConstantExpression)mathematic.Right).Value;
+                    }
+                }
+
                 ExpressionBase result;
-                if (!RebalanceMathematicComparison(comparison, scope, out result))
+                if (!MoveConstantsToRightHandSide(comparison, scope, out result))
                     return (ParseErrorExpression)result;
 
                 comparison = (ComparisonExpression)result;
+            }
+
+            if (comparison.Right.Type == ExpressionType.Mathematic)
+            {
+                ExpressionBase result;
+                if (!EnsureSingleExpressionOnRightHandSide(comparison, scope, ref underflowAdjustment, out result))
+                    return (ParseErrorExpression)result;
+
+                comparison = (ComparisonExpression)result;
+            }
+
+            if (underflowAdjustment > 0)
+            {
+                // add a dummy variable to the right side and rebalance again to move the existing right hand side to the left hand side
+                var newRight = new MathematicExpression(comparison.Right, MathematicOperation.Add, new VariableExpression("unused"));
+                comparison = new ComparisonExpression(comparison.Left, comparison.Operation, newRight);
+
+                ExpressionBase result;
+                if (!EnsureSingleExpressionOnRightHandSide(comparison, scope, ref underflowAdjustment, out result))
+                    return (ParseErrorExpression)result;
+
+                comparison = (ComparisonExpression)result;
+                System.Diagnostics.Debug.Assert(comparison.Right is VariableExpression);
+
+                // add the new underflow to both sides of the comparison
+                MathematicExpression newLeft = comparison.Left as MathematicExpression;
+                if (newLeft != null && newLeft.Right is IntegerConstantExpression)
+                {
+                    var value = ((IntegerConstantExpression)newLeft.Right).Value;
+                    if (newLeft.Operation == MathematicOperation.Add)
+                    {
+                        newLeft.Right = new IntegerConstantExpression(value + underflowAdjustment);
+                        comparison = new ComparisonExpression(newLeft, comparison.Operation, new IntegerConstantExpression(underflowAdjustment));
+                    }
+                    else if (newLeft.Operation == MathematicOperation.Subtract)
+                    {
+                        newLeft = new MathematicExpression(newLeft.Left, MathematicOperation.Add, new IntegerConstantExpression(underflowAdjustment));
+                        comparison = new ComparisonExpression(newLeft, comparison.Operation, new IntegerConstantExpression(underflowAdjustment + value));
+                    }
+                }
+                else
+                {
+                    newLeft = new MathematicExpression(comparison.Left, MathematicOperation.Add, new IntegerConstantExpression(underflowAdjustment));
+                    comparison = new ComparisonExpression(newLeft, comparison.Operation, new IntegerConstantExpression(underflowAdjustment));
+                }
             }
 
             var left = comparison.Left;
@@ -645,124 +786,15 @@ namespace RATools.Parser
             {
                 int newValue = integerRight.Value;
 
-                // SubSource of a memory accessor may cause overflow - if comparing for less than,
-                // modifiers should not be merged into the compare target
-                if (_equalityModifiers.Count > 0 &&
-                    (op == RequirementOperator.LessThan || op == RequirementOperator.LessThanOrEqual))
-                {
-                    bool hasSubSource = false;
-                    for (int i = context.Trigger.Count - 2; i >= 0; i++)
-                    {
-                        var requirementType = context.Trigger.ElementAt(i).Type;
-                        if (requirementType == RequirementType.SubSource)
-                        {
-                            hasSubSource = true;
-                            break;
-                        }
-                        else if (requirementType != RequirementType.AddSource &&
-                            requirementType != RequirementType.AddHits)
-                        {
-                            break;
-                        }
-                    }
-
-                    if (hasSubSource)
-                    {
-                        var last = context.Trigger.Last();
-                        context.Trigger.Remove(last);
-                        foreach (var modifier in _equalityModifiers)
-                        {
-                            if (modifier.Operation != MathematicOperation.Subtract && modifier.Operation != MathematicOperation.Add)
-                                return new ParseErrorExpression("Cannot normalize expression containing SubSource", left);
-
-                            context.Trigger.Add(new Requirement
-                            {
-                                Type = (modifier.Operation == MathematicOperation.Subtract) ? RequirementType.AddSource : RequirementType.SubSource,
-                                Left = new Field { Type = FieldType.Value, Value = (uint)modifier.Amount },
-                                Operator = RequirementOperator.None,
-                                Right = new Field()
-                            });
-                        }
-                        context.Trigger.Add(last);
-
-                        _equalityModifiers.Clear();
-                    }
-                }
-
-                while (_equalityModifiers.Count > 0)
-                {
-                    var originalValue = newValue;
-                    var modifier = _equalityModifiers.Pop();
-                    newValue = modifier.Apply(newValue);
-
-                    var restoredValue = modifier.Remove(newValue);
-                    switch (op)
-                    {
-                        case RequirementOperator.Equal:
-                            if (restoredValue != originalValue)
-                                return new ParseErrorExpression("Result can never be true using integer math", comparison);
-                            break;
-
-                        case RequirementOperator.NotEqual:
-                            if (restoredValue != originalValue)
-                                return new ParseErrorExpression("Result is always true using integer math", comparison);
-                            break;
-
-                        case RequirementOperator.GreaterThanOrEqual:
-                            if (restoredValue != originalValue)
-                                op = RequirementOperator.GreaterThan;
-                            break;
-                    }
-                }
-
                 var requirement = context.LastRequirement;
                 requirement.Operator = op;
                 requirement.Right = new Field { Size = requirement.Left.Size, Type = FieldType.Value, Value = (uint)newValue };
             }
             else
             {
-                var leftModifiers = new Stack<ValueModifier>(_equalityModifiers.Reverse());
-                _equalityModifiers.Clear();
-
                 error = ExecuteAchievementExpression(right, scope);
                 if (error != null)
                     return error;
-
-                if (leftModifiers.Count > 0 || _equalityModifiers.Count > 0)
-                {
-                    var rightValue = 1234567;
-                    var leftValue = rightValue;
-                    while (leftModifiers.Count > 0)
-                    {
-                        var modifier = leftModifiers.Pop();
-                        leftValue = ValueModifier.Apply(leftValue, MathematicExpression.GetOppositeOperation(modifier.Operation), modifier.Amount);
-                    }
-
-                    while (_equalityModifiers.Count > 0)
-                    {
-                        var modifier = _equalityModifiers.Pop();
-                        rightValue = ValueModifier.Apply(rightValue, MathematicExpression.GetOppositeOperation(modifier.Operation), modifier.Amount);
-                    }
-
-                    var diff = leftValue - rightValue;
-                    if (diff != 0)
-                    {
-                        var modifier = new Requirement();
-
-                        if (diff < 0)
-                        {
-                            modifier.Left = new Field { Type = FieldType.Value, Value = (uint)(-diff) };
-                            modifier.Type = RequirementType.SubSource;
-                        }
-                        else
-                        {
-                            modifier.Left = new Field { Type = FieldType.Value, Value = (uint)diff };
-                            modifier.Type = RequirementType.AddSource;
-                        }
-
-                        ((IList<Requirement>)context.Trigger).Insert(insertIndex, modifier);
-                    }
-                }
 
                 var extraRequirement = context.LastRequirement;
                 context.Trigger.Remove(extraRequirement);

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -137,6 +137,10 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x1234) - prev(byte(0x1234)) == 3", "(byte(0x001234) - prev(byte(0x001234))) == 3")] // value increases by 3
         [TestCase("byte(0x1234) + 1 == byte(0x4321) - 1", "(2 + byte(0x001234)) == byte(0x004321)")] // modifiers on different addresses
         [TestCase("(word(0x1234) - 1) * 4 > (prev(word(0x1234)) - 1) * 4", "word(0x001234) > prev(word(0x001234))")]
+        [TestCase("bit1(0x1234) + bit2(0x1234) > bit3(0x1234) + bit4(0x1234)", "(2 + bit1(0x001234) + bit2(0x001234) - bit4(0x001234) - bit3(0x001234)) > 2")]
+        [TestCase("bit1(0x1234) + bit2(0x1234) > bit3(0x1234) - bit4(0x1234)", "(bit1(0x001234) + bit2(0x001234) + bit4(0x001234)) > bit3(0x001234)")]
+        [TestCase("bit1(0x1234) + bit2(0x1234) > bit3(0x1234) + bit4(0x1234) + 1", "(2 + bit1(0x001234) + bit2(0x001234) - bit4(0x001234) - bit3(0x001234)) > 3")]
+        [TestCase("bit1(0x1234) + bit2(0x1234) + 3 > bit3(0x1234) + bit4(0x1234) + 5", "(2 + bit1(0x001234) + bit2(0x001234) - bit4(0x001234) - bit3(0x001234)) > 4")]
         public void TestTransitiveCondition(string trigger, string expectedRequirement)
         {
             var parser = Parse("achievement(\"T\", \"D\", 5, " + trigger + ")");
@@ -604,11 +608,11 @@ namespace RATools.Test.Parser
         [Test]
         [TestCase("byte(0x1234) + 1 - byte(0x1235) == 3", "(byte(0x001234) - byte(0x001235)) == 2")]
         [TestCase("byte(0x1234) + 1 - byte(0x1235) != 3", "(byte(0x001234) - byte(0x001235)) != 2")]
-        [TestCase("byte(0x1234) + 1 - byte(0x1235) >= 3", "(byte(0x001234) - byte(0x001235)) >= 2")]
-        [TestCase("byte(0x1234) + 1 - byte(0x1235) >  3", "(byte(0x001234) - byte(0x001235)) > 2")]
+        [TestCase("byte(0x1234) + 1 - byte(0x1235) >= 3", "(255 + byte(0x001234) - byte(0x001235)) >= 257")]
+        [TestCase("byte(0x1234) + 1 - byte(0x1235) >  3", "(255 + byte(0x001234) - byte(0x001235)) > 257")]
         [TestCase("byte(0x1234) + 1 - byte(0x1235) <= 3", "(1 + byte(0x001234) - byte(0x001235)) <= 3")]
         [TestCase("byte(0x1234) + 1 - byte(0x1235) <  3", "(1 + byte(0x001234) - byte(0x001235)) < 3")]
-        public void TestSubSourceMemoryPreventsBalancing(string input, string expected)
+        public void TestUnderflowAdjustment(string input, string expected)
         {
             // SubSource(mem) can cause wraparound, so if modifiers are present when doing a
             // less than comparison, assume they're there to prevent the wraparound and don't

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -141,6 +141,11 @@ namespace RATools.Test.Parser
         [TestCase("bit1(0x1234) + bit2(0x1234) > bit3(0x1234) - bit4(0x1234)", "(bit1(0x001234) + bit2(0x001234) + bit4(0x001234)) > bit3(0x001234)")]
         [TestCase("bit1(0x1234) + bit2(0x1234) > bit3(0x1234) + bit4(0x1234) + 1", "(2 + bit1(0x001234) + bit2(0x001234) - bit4(0x001234) - bit3(0x001234)) > 3")]
         [TestCase("bit1(0x1234) + bit2(0x1234) + 3 > bit3(0x1234) + bit4(0x1234) + 5", "(2 + bit1(0x001234) + bit2(0x001234) - bit4(0x001234) - bit3(0x001234)) > 4")]
+        [TestCase("bit1(0x1234) + bit2(0x1234) < bit3(0x1234) + bit4(0x1234) + 1", "(2 + bit1(0x001234) + bit2(0x001234) - bit4(0x001234) - bit3(0x001234)) < 3")]
+        [TestCase("bit1(0x1234) + bit2(0x1234) - bit3(0x1234) - bit4(0x1234) < 1", "(2 + bit1(0x001234) + bit2(0x001234) - bit4(0x001234) - bit3(0x001234)) < 3")]
+        [TestCase("bit1(0x1234) + bit2(0x1234) + 2 - bit3(0x1234) - bit4(0x1234) < 3", "(2 + bit1(0x001234) + bit2(0x001234) - bit4(0x001234) - bit3(0x001234)) < 3")]
+        [TestCase("byte(0x1234) + 1 - byte(0x2345) >= 2", "(255 + byte(0x001234) - byte(0x002345)) >= 256")] // 254 added to both sides to prevent underflow
+        [TestCase("byte(0x1234) + 1 - byte(0x2345) < 2", "(1 + byte(0x001234) - byte(0x002345)) < 2")]
         public void TestTransitiveCondition(string trigger, string expectedRequirement)
         {
             var parser = Parse("achievement(\"T\", \"D\", 5, " + trigger + ")");


### PR DESCRIPTION
fixes #96 and #97

Replaces the accumulator with actual rebalancing and combining logic. 

Any time a memory read is subtracted on the left side of a comparison and the comparison is not "equal" or "not equal", a buffer value (maximum value of the memory read) is added to both sides of the equation to ensure the subtraction doesn't result in an underflow.

As such, the example in #96: `(count_a() > count_b() + 1)` becomes `(2 + bit1(0xabcd) + bit2(0xabcd) - bit4(0xabcd) - bit3(0xabcd)) > 3`, as does the equivalent `(count_a() - count_b() > 1)`. The third alternative from #97: `count_a() + 2 - count_b() > 3` also results in the same generated result.

There is an exception to this rule. If the user specifies their own adjustment for a "less than" condition: `byte(1) + 1 - byte(2) <= 2`, then that adjustment is kept instead of calculating one. In this example, the calculated value would be 255, but the user specified 1, so the 1 is kept. A user-specified adjustment is identified as the sum of all constants on the left side of a comparison that also has a subtracted memory reference. FYI, this represents `abs(byte(1)-byte(2)) <= 1`.


