### PR TITLE
add support for AddAddress

### DIFF
--- a/Data/Field.cs
+++ b/Data/Field.cs
@@ -40,7 +40,7 @@ namespace RATools.Data
         /// <summary>
         /// Appends the textual representation of this expression to <paramref name="builder"/>.
         /// </summary>
-        internal void AppendString(StringBuilder builder, NumberFormat numberFormat)
+        internal void AppendString(StringBuilder builder, NumberFormat numberFormat, string addAddress = null)
         {
             if (Type == FieldType.None)
             {
@@ -102,7 +102,7 @@ namespace RATools.Data
             else if (Type == FieldType.PriorValue)
                 builder.Append("prior(");
 
-            AppendMemoryReference(builder, Value, Size);
+            AppendMemoryReference(builder, Value, Size, addAddress);
 
             if (Type == FieldType.PreviousValue || Type == FieldType.PriorValue)
                 builder.Append(')');
@@ -118,10 +118,15 @@ namespace RATools.Data
             return builder.ToString();
         }
 
-        private static void AppendMemoryReference(StringBuilder builder, uint address, FieldSize size)
+        private static void AppendMemoryReference(StringBuilder builder, uint address, FieldSize size, string addAddress = null)
         {
             builder.Append(GetSizeFunction(size));
-            builder.Append("(0x");
+            builder.Append('(');
+
+            if (!string.IsNullOrEmpty(addAddress))
+                builder.Append(addAddress);
+
+            builder.Append("0x");
             builder.AppendFormat("{0:X6}", address);
             builder.Append(')');
         }

--- a/Data/Requirement.cs
+++ b/Data/Requirement.cs
@@ -50,40 +50,48 @@ namespace RATools.Data
         /// Appends the textual representation of this expression to <paramref name="builder"/>.
         /// </summary>
         internal void AppendString(StringBuilder builder, NumberFormat numberFormat, 
-            string addSources = null, string subSources = null, string addHits = null, string andNext = null)
+            string addSources = null, string subSources = null, string addHits = null, 
+            string andNext = null, string addAddress = null)
         {
             switch (Type)
             {
                 case RequirementType.ResetIf:
                     builder.Append("never(");
-                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress);
                     builder.Append(')');
                     break;
 
                 case RequirementType.PauseIf:
                     builder.Append("unless(");
-                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress);
                     builder.Append(')');
                     break;
 
                 case RequirementType.Measured:
                     builder.Append("measured(");
-                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress);
                     builder.Append(')');
                     break;
 
+                case RequirementType.AddAddress:
+                    // this is displayed in the achievement details page and doesn't accurately represent the syntax
+                    builder.Append("addaddress(");
+                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress);
+                    builder.Append(") ->");
+                    break;
+
                 default:
-                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress);
                     break;
             }
         }
 
         private void AppendRepeatedCondition(StringBuilder builder, NumberFormat numberFormat,
-            string addSources, string subSources, string addHits, string andNext)
+            string addSources, string subSources, string addHits, string andNext, string addAddress)
         {
             if (HitCount == 0)
             {
-                AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+                AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress);
             }
             else
             {
@@ -92,14 +100,15 @@ namespace RATools.Data
                 else
                     builder.AppendFormat("repeated({0}, ", HitCount);
 
-                AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext);
+                AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress);
 
                 builder.Append(')');
             }
         }
 
         internal void AppendCondition(StringBuilder builder, NumberFormat numberFormat, 
-            string addSources = null, string subSources = null, string addHits = null, string andNext = null)
+            string addSources = null, string subSources = null, string addHits = null, 
+            string andNext = null, string addAddress = null)
         {
             if (!string.IsNullOrEmpty(addSources))
             {
@@ -153,7 +162,7 @@ namespace RATools.Data
                         }
                     }
 
-                    Left.AppendString(builder, numberFormat);
+                    Left.AppendString(builder, numberFormat, addAddress);
                     break;
             }
 
@@ -192,7 +201,7 @@ namespace RATools.Data
                     return;
             }
 
-            Right.AppendString(builder, numberFormat);
+            Right.AppendString(builder, numberFormat, addAddress);
         }
 
         /// <summary>
@@ -441,5 +450,10 @@ namespace RATools.Data
         /// Meta-flag indicating that this condition tracks progress.
         /// </summary>
         Measured,
+
+        /// <summary>
+        /// Adds the Left part of the requirement to the addresses in the next requirement.
+        /// </summary>
+        AddAddress,
     }
 }

--- a/Parser/Functions/ComparisonModificationFunction.cs
+++ b/Parser/Functions/ComparisonModificationFunction.cs
@@ -84,6 +84,7 @@ namespace RATools.Parser.Functions
                     case RequirementType.AddSource:
                     case RequirementType.SubSource:
                     case RequirementType.AndNext:
+                    case RequirementType.AddAddress:
                         isCombining = true;
                         break;
 

--- a/Parser/Functions/MemoryAccessorFunction.cs
+++ b/Parser/Functions/MemoryAccessorFunction.cs
@@ -79,7 +79,7 @@ namespace RATools.Parser.Functions
                         if (error != null)
                             return error;
 
-                        context.Trigger.Last().Type = RequirementType.AddAddress;
+                        context.LastRequirement.Type = RequirementType.AddAddress;
 
                         requirement.Left = new Field { Size = this.Size, Type = FieldType.MemoryAddress, Value = (uint)integerConstant.Value };
                         context.Trigger.Add(requirement);

--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -803,6 +803,28 @@ namespace RATools.Parser
                 var requirement = context.LastRequirement;
                 if (requirement != null)
                 {
+                    if (requirement.Type == RequirementType.AddAddress)
+                    {
+                        var addAddressRequirements = new List<Requirement>();
+                        do
+                        {
+                            addAddressRequirements.Add(requirement);
+                            ((IList<Requirement>)context.Trigger).RemoveAt(context.Trigger.Count - 1);
+
+                            requirement = context.LastRequirement;
+                        } while (requirement.Type == RequirementType.AddAddress);
+
+                        if (context.Trigger.Count <= addAddressRequirements.Count)
+                            return new ParseErrorExpression("Indirect memory addresses must match on both sides of a comparison", comparison);
+
+                        for (int i = 0; i < addAddressRequirements.Count; i++)
+                        {
+                            var previousRequirement = context.Trigger.ElementAt(context.Trigger.Count - addAddressRequirements.Count - 1 + i);
+                            if (previousRequirement != addAddressRequirements[i])
+                                return new ParseErrorExpression("Indirect memory addresses must match on both sides of a comparison", comparison);
+                        }
+                    }
+
                     requirement.Operator = op;
                     requirement.Right = extraRequirement.Left;
                 }

--- a/Tests/Parser/Functions/MemoryAccessFunctionTests.cs
+++ b/Tests/Parser/Functions/MemoryAccessFunctionTests.cs
@@ -93,7 +93,6 @@ namespace RATools.Test.Parser.Functions
         [Test]
         public void TestSizes()
         {
-            var scope = AchievementScriptInterpreter.GetGlobalScope();
             var sizes = new Dictionary<string, FieldSize>
             {
                 {"byte(0x1234)", FieldSize.Byte },


### PR DESCRIPTION
Allows memory accessors inside of memory accessors with a possible offset:

```
byte(word(0x1234))
bit6(dword(0x4567) + 10)
```

Indirect accessors on both sides of a condition must match, but allow for delta comparisons:

```
byte(word(0x1234) + 20) > prev(byte(word(0x1234) + 20))
```