### PR TITLE
simplify rebalancing comparisons by eliminating common modifiers

### DIFF
--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -137,6 +137,7 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x1234) - prev(byte(0x1234)) == 3", "(byte(0x001234) - prev(byte(0x001234))) == 3")] // value increases by 3
         [TestCase("byte(0x1234) + 1 == byte(0x4321) - 1", "(2 + byte(0x001234)) == byte(0x004321)")] // modifiers on different addresses
         [TestCase("(word(0x1234) - 1) * 4 > (prev(word(0x1234)) - 1) * 4", "word(0x001234) > prev(word(0x001234))")]
+        [TestCase("(word(0x1234) - 1) / 4 > (prev(word(0x1234)) - 1) / 4", "word(0x001234) > prev(word(0x001234))")]
         [TestCase("bit1(0x1234) + bit2(0x1234) > bit3(0x1234) + bit4(0x1234)", "(2 + bit1(0x001234) + bit2(0x001234) - bit4(0x001234) - bit3(0x001234)) > 2")]
         [TestCase("bit1(0x1234) + bit2(0x1234) > bit3(0x1234) - bit4(0x1234)", "(bit1(0x001234) + bit2(0x001234) + bit4(0x001234)) > bit3(0x001234)")]
         [TestCase("bit1(0x1234) + bit2(0x1234) > bit3(0x1234) + bit4(0x1234) + 1", "(2 + bit1(0x001234) + bit2(0x001234) - bit4(0x001234) - bit3(0x001234)) > 3")]


### PR DESCRIPTION
Previous implementation relied on mathematically combining modifiers, which was sometimes avoided to prevent rounding errors. For comparisons (particularly comparing a value to its delta), the common modifiers can be eliminated instead of merged, so there's no reason to be concerned about the rounding errors.