### PR TITLE
correctly dump tickets with empty and non-breakable lines

### DIFF
--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -645,15 +645,29 @@ namespace RATools.ViewModels
                                     stream.Write("//               ");
 
                                 var line = lines[i].Trim();
+                                if (line.Length == 0)
+                                {
+                                    stream.WriteLine("");
+                                    continue;
+                                }
+
                                 while (line.Length > MaxLength)
                                 {
                                     var index = line.LastIndexOf(' ', MaxLength - 1);
-                                    var front = line.Substring(0, index).Trim();
-                                    stream.WriteLine(front);
-                                    line = line.Substring(index + 1).Trim();
+                                    if (index < 0)
+                                    {
+                                        stream.WriteLine(line);
+                                        line = "";
+                                    }
+                                    else
+                                    {
+                                        var front = line.Substring(0, index).Trim();
+                                        stream.WriteLine(front);
+                                        line = line.Substring(index + 1).Trim();
 
-                                    if (line.Length > 0)
-                                        stream.Write("//               ");
+                                        if (line.Length > 0)
+                                            stream.Write("//               ");
+                                    }
                                 }
 
                                 if (line.Length > 0)


### PR DESCRIPTION
If a ticket's text contained a large line without a space, RATools
would fail to dump it and crash whilst trying to break it into smaller
lines. Happened with a URL to a proof image.

Also noticed that empty lines were not dumped correctly: the newline
would be missing and the following line would be double-commented:

```
//               //               next line
```