### PR TITLE
allow removal of always_false alt group even if only two alt groups remain

### DIFF
--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -493,8 +493,10 @@ namespace RATools.Parser
                     builder.Append(' ', indent);
                     width = wrapWidth - indent;
                 }
-
-                width -= definition.Length;
+                else
+                {
+                    width -= definition.Length;
+                }
 
                 builder.Append(definition.ToString());
             }

--- a/Parser/Functions/RepeatedFunction.cs
+++ b/Parser/Functions/RepeatedFunction.cs
@@ -74,7 +74,6 @@ namespace RATools.Parser.Functions
             ExpressionBase result;
 
             var builder = new ScriptInterpreterAchievementBuilder();
-            builder.CoreRequirements.Add(new Requirement()); // empty core requirement required for optimize call, we'll ignore it
             if (!TriggerBuilderContext.ProcessAchievementConditions(builder, condition, scope, out result))
                 return (ParseErrorExpression)result;
 

--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -721,8 +721,16 @@ namespace RATools.ViewModels
                                 stream.WriteLine(" &&");
                                 stream.Write(new string(' ', indent));
                             }
-                            stream.Write("((");
+                            stream.Write('(');
                             first = false;
+
+                            if (achievementViewModel.RequirementGroups.Count() == 2)
+                            {
+                                // only core and one alt, inject an always_false clause to prevent the compiler from joining them
+                                stream.Write("always_false() || ");
+                            }
+
+                            stream.Write('(');
                         }
                         else
                         {


### PR DESCRIPTION
As mentioned in #106, it's reasonable to expect always_false groups to be removed. There was already logic to do so as long as at least two alt groups remained because if only one alt group remained, it was merged into the core group.

I've added a second pass to the optimization code to remove all always_false alt groups after other optimization logic is applied (primarily promoting common alt logic to the core).