### PR TITLE
remove internal comments from expression tooltips

### DIFF
--- a/ViewModels/EditorViewModel.cs
+++ b/ViewModels/EditorViewModel.cs
@@ -153,15 +153,27 @@ namespace RATools.ViewModels
                 var text = GetText(expression.Line, expression.Column, expression.EndLine, expression.EndColumn + 1);
                 var builder = new StringBuilder();
                 bool lastCharWasWhitespace = true;
+                bool inComment = false;
                 foreach (var c in text)
                 {
-                    if (Char.IsWhiteSpace(c))
+                    if (inComment)
+                    {
+                        inComment = (c != '\n');
+                    }
+                    else if (Char.IsWhiteSpace(c))
                     {
                         if (lastCharWasWhitespace)
                             continue;
 
                         builder.Append(' ');
                         lastCharWasWhitespace = true;
+                    }
+                    else if (c == '/' && (builder.Length > 0 && builder[builder.Length - 1] == '/'))
+                    {
+                        inComment = true;
+                        builder.Length--;
+
+                        lastCharWasWhitespace = (builder.Length == 0 || builder[builder.Length - 1] == ' ');
                     }
                     else
                     {


### PR DESCRIPTION
Given the function definition
```
function trigger_in_level() => current_screen() == screen_in_game || // normal
                               current_screen() == screen_death      // after continue
```
The existing behavior shows
```
current_screen() == screen_in_game || // normal current_screen() == screen_death
```
as the tooltip when hovering over a reference to `trigger_in_level`. This changes the behavior to show
```
current_screen() == screen_in_game || current_screen() == screen_death
```

