### PR TITLE
report error when trigger condition has no comparison

### DIFF
--- a/Parser/Functions/ComparisonModificationFunction.cs
+++ b/Parser/Functions/ComparisonModificationFunction.cs
@@ -38,7 +38,7 @@ namespace RATools.Parser.Functions
             var builder = new ScriptInterpreterAchievementBuilder();
             ExpressionBase result;
             if (!TriggerBuilderContext.ProcessAchievementConditions(builder, condition, scope, out result))
-                return (ParseErrorExpression)result;
+                return new ParseErrorExpression("comparison did not evaluate to a valid comparison", condition) { InnerError = (ParseErrorExpression)result };
 
             if (builder.AlternateRequirements.Count > 0)
                 return new ParseErrorExpression(Name.Name + " does not support ||'d conditions", condition);

--- a/Tests/Parser/Functions/OnceFunctionTests.cs
+++ b/Tests/Parser/Functions/OnceFunctionTests.cs
@@ -102,7 +102,7 @@ namespace RATools.Test.Parser.Functions
         [Test]
         public void TestNonConditionConstant()
         {
-            Evaluate("once(6+2)", "Cannot generate trigger from IntegerConstant");
+            Evaluate("once(6+2)", "comparison did not evaluate to a valid comparison");
         }
 
         [Test]

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -121,7 +121,7 @@ namespace RATools.Test.Parser.Functions
         [Test]
         public void TestNonConditionConstant()
         {
-            Evaluate("repeated(4, 6+2)", "Cannot generate trigger from IntegerConstant");
+            Evaluate("repeated(4, 6+2)", "comparison did not evaluate to a valid comparison");
         }
 
         [Test]


### PR DESCRIPTION
This achievement was not generating an error when compiled, but did generate an error in the emulator as it resulted in a condition without a comparison:
```
achievement("Test", "Test", 1, bit1(0x1234))
```
The intent is that bit1 is non-zero, which is supported in some languages like C, but to support construction of AddHits/AddSource chains, we can't assume that to be true. Besides, a more explicit comparison ensures the logic is what the user intended and is more readable for less experienced programmers.
```
achievement("Test", "Test", 1, bit1(0x1234) != 0)
```
The first example will now generate an "Incomplete trigger condition" error.