### PR TITLE
allow combining flags in common portion of AddHits chain

### DIFF
--- a/Parser/Functions/RepeatedFunction.cs
+++ b/Parser/Functions/RepeatedFunction.cs
@@ -69,6 +69,43 @@ namespace RATools.Parser.Functions
             return null;
         }
 
+        private static ParseErrorExpression ProcessAddHitsSubClause(ICollection<Requirement> requirements)
+        {
+            int i = requirements.Count - 1;
+            var requirement = requirements.ElementAt(i);
+            if (requirement.Type != RequirementType.None)
+                return new ParseErrorExpression("modifier not allowed in multi-condition repeated clause");
+
+            // all but the last clause need to be converted to AddHits.
+            // we'll change it back after we've merged all the clauses.
+            requirement.Type = RequirementType.AddHits;
+
+            while (i > 0)
+            {
+                --i;
+                requirement = requirements.ElementAt(i);
+                switch (requirement.Type)
+                {
+                    case RequirementType.None:
+                        // convert a chain of normal conditions into AndNexts so they're grouped within the AddHits
+                        requirement.Type = RequirementType.AndNext;
+                        break;
+
+                    case RequirementType.AddHits:
+                        // AddHits is a combining flag, but cannot be nested in another AddHits
+                        return new ParseErrorExpression("modifier not allowed in multi-condition repeated clause");
+
+                    default:
+                        // non-constructing conditions are not allowed within the AddHits clause
+                        if (!requirement.IsCombining)
+                            return new ParseErrorExpression("modifier not allowed in multi-condition repeated clause");
+                        break;
+                }
+            }
+
+            return null;
+        }
+
         private ParseErrorExpression EvaluateAddHits(TriggerBuilderContext context, InterpreterScope scope, ConditionalExpression condition)
         {
             ExpressionBase result;
@@ -80,50 +117,22 @@ namespace RATools.Parser.Functions
             if (builder.AlternateRequirements.Count == 0)
                 return BuildTriggerCondition(context, scope, condition);
 
-            // core requirements have to be injected into each subclause as a series of AndNext's
-            foreach (var requirement in builder.CoreRequirements)
+            if (builder.CoreRequirements.Any())
             {
-                if (requirement.Type != RequirementType.None)
-                {
-                    if (requirement == builder.CoreRequirements.Last() || requirement.Type != RequirementType.AndNext)
-                        return new ParseErrorExpression("modifier not allowed in multi-condition repeated clause");
-                }
+                var error = ProcessAddHitsSubClause(builder.CoreRequirements);
+                if (error != null)
+                    return error;
 
-                requirement.Type = RequirementType.AndNext;
+                // core requirements have to be injected into each subclass as a series of AndNext's
+                builder.CoreRequirements.Last().Type = RequirementType.AndNext;
             }
 
             var requirements = new List<ICollection<Requirement>>();
             foreach (var altGroup in builder.AlternateRequirements)
             {
-                int i = altGroup.Count - 1;
-                var requirement = altGroup.ElementAt(i);
-                if (requirement.Type != RequirementType.None)
-                    return new ParseErrorExpression("modifier not allowed in multi-condition repeated clause");
-
-                // all but the last clause need to be converted to AddHits
-                requirement.Type = RequirementType.AddHits;
-
-                while (i > 0)
-                {
-                    --i;
-                    switch (altGroup.ElementAt(i).Type)
-                    {
-                        case RequirementType.None:
-                            // convert a chain of normal conditions into AndNexts so they're grouped within the AddHits
-                            altGroup.ElementAt(i).Type = RequirementType.AndNext;
-                            break;
-
-                        case RequirementType.AddHits:
-                            // AddHits is a combining flag, but cannot be nested in another AddHits
-                            return new ParseErrorExpression("modifier not allowed in multi-condition repeated clause");
-
-                        default:
-                            // non-constructing conditions are not allowed within the AddHits clause
-                            if (!altGroup.ElementAt(i).IsCombining)
-                                return new ParseErrorExpression("modifier not allowed in multi-condition repeated clause");
-                            break;
-                    }
-                }
+                var error = ProcessAddHitsSubClause(altGroup);
+                if (error != null)
+                    return error;
 
                 if (builder.CoreRequirements.Any())
                 {

--- a/Parser/Functions/RepeatedFunction.cs
+++ b/Parser/Functions/RepeatedFunction.cs
@@ -77,7 +77,7 @@ namespace RATools.Parser.Functions
                 return new ParseErrorExpression("modifier not allowed in multi-condition repeated clause");
 
             // all but the last clause need to be converted to AddHits.
-            // we'll change it back after we've merged all the clauses.
+            // we'll change the last one back after we've processed all the clauses.
             requirement.Type = RequirementType.AddHits;
 
             while (i > 0)
@@ -123,7 +123,7 @@ namespace RATools.Parser.Functions
                 if (error != null)
                     return error;
 
-                // core requirements have to be injected into each subclass as a series of AndNext's
+                // core requirements have to be injected into each subclause as a series of AndNext's
                 builder.CoreRequirements.Last().Type = RequirementType.AndNext;
             }
 

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -368,6 +368,34 @@ namespace RATools.Test.Parser.Functions
         }
 
         [Test]
+        public void TestAddHitsAddAddressCommonClause()
+        {
+            var requirements = Evaluate("repeated(3, (byte(byte(0x9999)) == 9 && byte(0x1111) == 1) || (byte(byte(0x9999)) == 9 && byte(0x1111) == 2))");
+            Assert.That(requirements.Count, Is.EqualTo(6));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x009999)"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.AddAddress));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x000000)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("9"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.AndNext));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("byte(0x001111)"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.AddHits));
+            Assert.That(requirements[3].Left.ToString(), Is.EqualTo("byte(0x009999)"));
+            Assert.That(requirements[3].Type, Is.EqualTo(RequirementType.AddAddress));
+            Assert.That(requirements[4].Left.ToString(), Is.EqualTo("byte(0x000000)"));
+            Assert.That(requirements[4].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[4].Right.ToString(), Is.EqualTo("9"));
+            Assert.That(requirements[4].Type, Is.EqualTo(RequirementType.AndNext));
+            Assert.That(requirements[5].Left.ToString(), Is.EqualTo("byte(0x001111)"));
+            Assert.That(requirements[5].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[5].Right.ToString(), Is.EqualTo("2"));
+            Assert.That(requirements[5].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[5].HitCount, Is.EqualTo(3));
+        }
+
+        [Test]
         public void TestAddHitsAddSourceSubSource()
         {
             var requirements = Evaluate("repeated(4, byte(0x1234) + byte(0x2345) == 56 || byte(0x1234) - byte(0x2345) == 34)");

--- a/ViewModels/RequirementViewModel.cs
+++ b/ViewModels/RequirementViewModel.cs
@@ -132,14 +132,24 @@ namespace RATools.ViewModels
             {
                 var builder2 = new StringBuilder();
                 requirement.AppendString(builder2, numberFormat, "~", "~");
-                builder2.Remove(0, 2); // remove "(~"
-                for (int i = 0; i < builder2.Length; i++)
+                var i = 0;
+                while (i < builder2.Length - 1)
                 {
-                    if (builder2[i] == '~')
+                    if (builder2[i+1] == '~' && builder2[i] == '(')
+                    {
+                        builder2.Remove(i, 2); // remove "(~"
+                        break;
+                    }
+                    i++;
+                }
+                while (i < builder2.Length)
+                {
+                    if (builder2[i] == '~' && builder2[i + 1] == ')')
                     {
                         builder2.Remove(i, 2); // remove "~)"
                         break;
                     }
+                    i++;
                 }
                 builder.Append(builder2);
             }


### PR DESCRIPTION
fixes #150 

extends #129 to also support combining flags in the common portion of the clause (represented by Core group of sub-trigger).