### PR TITLE
support generating Rich Presence code when dumping achievements for existing game

### DIFF
--- a/Data/Field.cs
+++ b/Data/Field.cs
@@ -281,19 +281,33 @@ namespace RATools.Data
             FieldSize size = FieldSize.None;
             switch (tokenizer.NextChar)
             {
+                case 'm':
                 case 'M': size = FieldSize.Bit0; tokenizer.Advance(); break;
+                case 'n':
                 case 'N': size = FieldSize.Bit1; tokenizer.Advance(); break;
+                case 'o':
                 case 'O': size = FieldSize.Bit2; tokenizer.Advance(); break;
+                case 'p':
                 case 'P': size = FieldSize.Bit3; tokenizer.Advance(); break;
+                case 'q':
                 case 'Q': size = FieldSize.Bit4; tokenizer.Advance(); break;
+                case 'r':
                 case 'R': size = FieldSize.Bit5; tokenizer.Advance(); break;
+                case 's':
                 case 'S': size = FieldSize.Bit6; tokenizer.Advance(); break;
+                case 't':
                 case 'T': size = FieldSize.Bit7; tokenizer.Advance(); break;
+                case 'l':
                 case 'L': size = FieldSize.LowNibble; tokenizer.Advance(); break;
+                case 'u':
                 case 'U': size = FieldSize.HighNibble; tokenizer.Advance(); break;
+                case 'h':
                 case 'H': size = FieldSize.Byte; tokenizer.Advance(); break;
+                case 'w':
                 case 'W': size = FieldSize.TByte; tokenizer.Advance(); break;
+                case 'x':
                 case 'X': size = FieldSize.DWord; tokenizer.Advance(); break;
+                case 'k':
                 case 'K': size = FieldSize.BitCount; tokenizer.Advance(); break;
                 case '0':
                 case '1':

--- a/Data/Leaderboard.cs
+++ b/Data/Leaderboard.cs
@@ -85,6 +85,39 @@ namespace RATools.Data
             }
         }
 
+        public static string GetFormatString(ValueFormat format)
+        {
+            switch (format)
+            {
+                case ValueFormat.Value:
+                    return "VALUE";
+
+                case ValueFormat.Score:
+                    return "SCORE";
+
+                case ValueFormat.TimeSecs:
+                    return "SECS";
+
+                case ValueFormat.TimeMillisecs:
+                    return "MILLISECS";
+
+                case ValueFormat.TimeFrames:
+                    return "FRAMES";
+
+                case ValueFormat.TimeMinutes:
+                    return "MINUTES";
+
+                case ValueFormat.TimeSecsAsMins:
+                    return "SECS_AS_MINS";
+
+                case ValueFormat.Other:
+                    return "OTHER";
+
+                default:
+                    return "UNKNOWN";
+            }
+        }
+
         internal int SourceLine { get; set; }
     }
 

--- a/Parser/RichPresenceBuilder.cs
+++ b/Parser/RichPresenceBuilder.cs
@@ -113,40 +113,7 @@ namespace RATools.Parser
                 builder.AppendLine(value.Key);
 
                 builder.Append("FormatType=");
-                switch (value.Value)
-                {
-                    case ValueFormat.Value:
-                        builder.AppendLine("VALUE");
-                        break;
-
-                    case ValueFormat.Score:
-                        builder.AppendLine("SCORE");
-                        break;
-
-                    case ValueFormat.TimeSecs:
-                        builder.AppendLine("SECS");
-                        break;
-
-                    case ValueFormat.TimeMillisecs:
-                        builder.AppendLine("MILLISECS");
-                        break;
-
-                    case ValueFormat.TimeFrames:
-                        builder.AppendLine("FRAMES");
-                        break;
-
-                    case ValueFormat.TimeMinutes:
-                        builder.AppendLine("MINUTES");
-                        break;
-
-                    case ValueFormat.TimeSecsAsMins:
-                        builder.AppendLine("SECS_AS_MINS");
-                        break;
-
-                    case ValueFormat.Other:
-                        builder.AppendLine("OTHER");
-                        break;
-                }
+                builder.AppendLine(Leaderboard.GetFormatString(value.Value));
 
                 builder.AppendLine();
             }

--- a/Parser/TriggerBuilderContext.cs
+++ b/Parser/TriggerBuilderContext.cs
@@ -56,7 +56,8 @@ namespace RATools.Parser
                     case FieldType.Value:
                         if (term.field.Value == 0)
                         {
-                            builder.Length--;
+                            if (builder.Length > 0)
+                                builder.Length--;
                             break;
                         }
 

--- a/ViewModels/GameViewModel.cs
+++ b/ViewModels/GameViewModel.cs
@@ -342,13 +342,14 @@ namespace RATools.ViewModels
                     builtAchievement.Published = UnixEpoch.AddSeconds(publishedAchievement.GetField("Created").IntegerValue.GetValueOrDefault());
                     builtAchievement.LastModified = UnixEpoch.AddSeconds(publishedAchievement.GetField("Modified").IntegerValue.GetValueOrDefault());
 
-                    if (publishedAchievement.GetField("Flags").IntegerValue == 5)
+                    var flags = publishedAchievement.GetField("Flags").IntegerValue;
+                    if (flags == 5)
                     {
                         achievement.Unofficial.LoadAchievement(builtAchievement);
                         unofficialCount++;
                         unofficialPoints += points;
                     }
-                    else
+                    else if (flags == 3)
                     {
                         achievement.Core.LoadAchievement(builtAchievement);
                         coreCount++;

--- a/ViewModels/RichPresenceViewModel.cs
+++ b/ViewModels/RichPresenceViewModel.cs
@@ -73,15 +73,15 @@ namespace RATools.ViewModels
 
                 if (genLines[genIndex].Length == 0)
                 {
-                    // blank generated line, advance core
-                    lines.Add(new RichPresenceLine(localLines[localIndex++], genLines[genIndex]));
+                    // extra blank line in generated output, ignore it
+                    genIndex++;
                     continue;
                 }
 
                 if (localLines[localIndex].Length == 0)
                 {
-                    // blank core line, advance generated
-                    lines.Add(new RichPresenceLine(localLines[localIndex], genLines[genIndex++]));
+                    // extra blank line in local file, ignore it
+                    localIndex++;
                     continue;
                 }
 
@@ -94,7 +94,11 @@ namespace RATools.ViewModels
 
                 if (genTagLine != -1 && localTagLine != -1)
                 {
-                    if (genTagLine > localTagLine)
+                    if (genTagLine < genIndex)
+                        genTagLine = -1;
+                    else if (localTagLine < localIndex)
+                        localTagLine = -1;
+                    else if (genTagLine > localTagLine)
                         genTagLine = -1;
                     else
                         localTagLine = -1;

--- a/Views/NewScriptDialog.xaml
+++ b/Views/NewScriptDialog.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:RATools.Views"
-             mc:Ignorable="d" Width="960" Height="488"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True"
+             RenderOptions.BitmapScalingMode="HighQuality"
+             mc:Ignorable="d" Width="960" Height="492"
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -52,11 +54,41 @@
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="16" />
-                            <ColumnDefinition Width="200" />
+                            <ColumnDefinition Width="16" />
+                            <ColumnDefinition Width="182" />
                             <ColumnDefinition Width="20" />
                         </Grid.ColumnDefinitions>
                         <CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" IsChecked="{Binding IsSelected}" />
-                        <TextBlock Grid.Column="1" Text="{Binding Label}">
+                        <Grid Grid.Column="1" Width="14" Height="13" Background="Transparent">
+                            <Image Margin="0,-1,0,-1" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                <Image.Style>
+                                    <Style TargetType="{x:Type Image}">
+                                        <Setter Property="Width" Value="12" />
+                                        <Setter Property="Height" Value="12" />
+                                        <Setter Property="Source" Value="/RATools;component/Resources/achievement.png" />
+                                        <Setter Property="ToolTip" Value="Achievement" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsRichPresence}" Value="True">
+                                                <Setter Property="Width" Value="14" />
+                                                <Setter Property="Height" Value="14" />
+                                                <Setter Property="Source" Value="/RATools;component/Resources/rich_presence.png" />
+                                                <Setter Property="ToolTip" Value="Rich Presence" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding IsLookup}" Value="True">
+                                                <Setter Property="Width" Value="14" />
+                                                <Setter Property="Height" Value="14" />
+                                                <Setter Property="Source" Value="/RATools;component/Resources/script.png" />
+                                                <Setter Property="ToolTip" Value="Lookup" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding IsUnofficial}" Value="True">
+                                                <Setter Property="ToolTip" Value="Unofficial Achievement" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Image.Style>
+                            </Image>
+                        </Grid>
+                        <TextBlock Grid.Column="2" Text="{Binding Label}" Margin="0,0,0,1" TextTrimming="CharacterEllipsis" VerticalAlignment="Center">
                             <TextBlock.Style>
                                 <Style TargetType="{x:Type TextBlock}">
                                     <Style.Triggers>
@@ -67,7 +99,7 @@
                                 </Style>
                             </TextBlock.Style>
                         </TextBlock>
-                        <TextBlock Grid.Column="2" HorizontalAlignment="Right" Margin="0,0,2,0" Text="{Binding OpenTicketCount}">
+                        <TextBlock Grid.Column="3" HorizontalAlignment="Right" Margin="0,0,2,1" Text="{Binding OpenTicketCount}" VerticalAlignment="Center">
                             <TextBlock.Style>
                                 <Style TargetType="{x:Type TextBlock}">
                                     <Style.Triggers>


### PR DESCRIPTION
Implements #69 

The lookups and display string appear as additional items in the New Script dialog (initially not selected):
![image](https://user-images.githubusercontent.com/32680403/83474631-ad94cf00-a449-11ea-989d-9235bf1425c7.png)

When selected, they will be included in the generated script, and will use any aliased memory reads defined on the right side of the dialog.

Lookups are defined near their associated memory when the memory has an aliased function:
```
// $0756: Set to 01 when large mario, 02 when fire-flower mario
function mario_powerup() => byte(0x000756)

PowerupLookup = {
    0: "Small",
    1: "Super",
    2: "Fire",
}
```
Otherwise, they appear after the memory functions, but before the achievement functions. The rich presence functions appear at the end of the script.

There are a couple of caveats.
1) BCD memory reads generate a `bcd()` wrapper function that is not implemented.
2) Multiplication by non-integer values will correctly dump, but resolves to integer multiplication when processed.
3) Dumped lookups will use the decimal/hex keys as provided in the original script, but the resulting generated script will always have decimal keys.

The first results in a compile error. The second changes the calculation so it's incorrect, but does not generate any errors. The third is just a superficial difference.