### PR TITLE
allow one clause in complex chain to have AndNext

### DIFF
--- a/Data/RequirementEx.cs
+++ b/Data/RequirementEx.cs
@@ -113,6 +113,9 @@ namespace RATools.Data
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Constructs a series of <see cref="RequirementEx" />s from a series of <see cref="Requirement" />s.
+        /// </summary>
         public static List<RequirementEx> Combine(IEnumerable<Requirement> requirements)
         {
             var group = new List<RequirementEx>();

--- a/Parser/Functions/AchievementFunction.cs
+++ b/Parser/Functions/AchievementFunction.cs
@@ -60,8 +60,12 @@ namespace RATools.Parser.Functions
 
             if (!TriggerBuilderContext.ProcessAchievementConditions(achievement, trigger, scope, out result))
             {
-                var error = (ParseErrorExpression)result;
-                result = new ParseErrorExpression(error.Message, trigger) { InnerError = error };
+                if (result.Column != trigger.Column || result.EndColumn != trigger.EndColumn || result.Line != trigger.Line || result.EndLine != trigger.EndLine)
+                {
+                    var error = (ParseErrorExpression)result;
+                    result = new ParseErrorExpression(error.Message, trigger) { InnerError = error };
+                }
+
                 return false;
             }
 

--- a/Parser/Functions/TallyFunction.cs
+++ b/Parser/Functions/TallyFunction.cs
@@ -69,6 +69,10 @@ namespace RATools.Parser.Functions
                 requirements.Add(conditionRequirements);
             }
 
+            // if no requirements were generated, we're done
+            if (requirements.Count == 0)
+                return null;
+
             // the last item cannot have its own HitCount as it will hold the HitCount for the group.
             // if necessary, find one without a HitCount and make it the last.
             AchievementBuilder.EnsureLastGroupHasNoHitCount(requirements);

--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -371,7 +371,7 @@ namespace RATools.Parser
                 return error;
 
             var context = scope.GetContext<TriggerBuilderContext>();
-            if (context.LastRequirement.Operator == RequirementOperator.None)
+            if (context.LastRequirement == null || context.LastRequirement.Operator == RequirementOperator.None)
                 return new ParseErrorExpression("Incomplete trigger condition", expression);
 
             return null;

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -123,6 +123,14 @@ namespace RATools.Test.Parser
         }
 
         [Test]
+        public void TestEmptyTrigger()
+        {
+            // tally() of empty array will result in to conditions for the trigger
+            var parser = Parse("achievement(\"T\", \"D\", 5, tally(4, []))", false);
+            Assert.That(parser.ErrorMessage, Is.EqualTo("1:26 Incomplete trigger condition"));
+        }
+
+        [Test]
         [TestCase("byte(0x1234) - 1 == 4", "byte(0x001234) == 5")]
         [TestCase("byte(0x1234) + 1 == 4", "byte(0x001234) == 3")]
         [TestCase("byte(0x1234) * 2 == 4", "byte(0x001234) == 2")]

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -181,7 +181,7 @@ namespace RATools.Test.Parser.Functions
         [Test]
         public void TestOrNextAndNext()
         {
-            var errorMessage = "Subclause is too complex";
+            var errorMessage = "Combination of &&s and ||s is too complex for subclause";
             Evaluate("repeated(4, (byte(0x1234) == 56 && byte(0x2345) == 67) || (byte(0x1234) == 34 && byte(0x2345) == 45))", errorMessage);
         }
 

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -186,6 +186,28 @@ namespace RATools.Test.Parser.Functions
         }
 
         [Test]
+        public void TestAndNextWithOr()
+        {
+            var requirements = Evaluate("repeated(4, byte(0x1234) == 56 || (byte(0x1234) == 34 && byte(0x2345) == 45))");
+            Assert.That(requirements.Count, Is.EqualTo(3));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("34"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.AndNext));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("45"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.OrNext));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(4));
+        }
+
+        [Test]
         public void TestCommonClauseIsEntireCondition()
         {
             // if every clause contains the same subclause, and that subclase is an entire clause


### PR DESCRIPTION
This loosens the restriction that mixing AndNext with OrNext is not allowed to allowing one AndNext as the singular AndNext can be moved to the front of the chain and not affect the logic.

Also fixes a NullReferenceException if `tally()` is passed an empty array.