### PR TITLE
show InnerError chain in Error List

### DIFF
--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -123,6 +123,8 @@ namespace RATools.Parser.Internal
             if (!functionDefinition.Evaluate(functionScope, out result))
             {
                 var error = result as ParseErrorExpression;
+                if (error.Line == 0)
+                    this.CopyLocation(error);
                 result = new ParseErrorExpression(FunctionName.Name + " call failed", FunctionName) { InnerError = error };
                 return false;
             }

--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -82,7 +82,11 @@ namespace RATools.Parser.Internal
 
             functionScope.Context = this;
             if (!functionDefinition.ReplaceVariables(functionScope, out result))
+            {
+                var error = result as ParseErrorExpression;
+                result = new ParseErrorExpression(FunctionName.Name + " call failed", FunctionName) { InnerError = error };
                 return false;
+            }
 
             CopyLocation(result);
             return true;
@@ -117,7 +121,11 @@ namespace RATools.Parser.Internal
 
             functionScope.Context = this;
             if (!functionDefinition.Evaluate(functionScope, out result))
+            {
+                var error = result as ParseErrorExpression;
+                result = new ParseErrorExpression(FunctionName.Name + " call failed", FunctionName) { InnerError = error };
                 return false;
+            }
 
             scope.ReturnValue = result;
             return true;
@@ -173,7 +181,10 @@ namespace RATools.Parser.Internal
                     // not a basic type, evaluate it
                     var assignmentScope = new InterpreterScope(scope) { Context = assignment };
                     if (!value.ReplaceVariables(assignmentScope, out value))
-                        return new ParseErrorExpression(value, assignment.Value);
+                    {
+                        var error = (ParseErrorExpression)value;
+                        return new ParseErrorExpression("Invalid value for parameter: " + assignment.Variable.Name, assignment.Value) { InnerError = error };
+                    }
                     break;
             }
 

--- a/Parser/Internal/IndexedVariableExpression.cs
+++ b/Parser/Internal/IndexedVariableExpression.cs
@@ -53,7 +53,7 @@ namespace RATools.Parser.Internal
                 return false;
 
             result = entry.Value;
-            return true;
+            return result.ReplaceVariables(scope, out result);
         }
 
         internal DictionaryExpression.DictionaryEntry GetDictionaryEntry(InterpreterScope scope, out ExpressionBase result, bool create)

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -127,7 +127,7 @@ namespace RATools.Test.Parser
         {
             // tally() of empty array will result in to conditions for the trigger
             var parser = Parse("achievement(\"T\", \"D\", 5, tally(4, []))", false);
-            Assert.That(parser.ErrorMessage, Is.EqualTo("1:26 Incomplete trigger condition"));
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:26 Incomplete trigger condition"));
         }
 
         [Test]
@@ -530,7 +530,7 @@ namespace RATools.Test.Parser
             var parser = Parse("function test() { p = 6 }\n" +
                                "test()\n" +
                                "achievement(\"T\", \"D\", p, prev(byte(0x1234)) == 1)", false);
-            Assert.That(parser.ErrorMessage, Is.EqualTo("3:23 Unknown variable: p"));
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("3:23 Unknown variable: p"));
         }
 
         [Test]
@@ -583,7 +583,7 @@ namespace RATools.Test.Parser
                 "\n" +
                 "achievement(\"Test\", \"Description\", 5, foo(1) && byte(0x0001) == b)\n" + // global b not defined yet, should error
                 "b = 1\n", false);
-            Assert.That(parser.ErrorMessage, Is.EqualTo("7:65 Unknown variable: b"));
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("7:65 Unknown variable: b"));
         }
 
         [Test]

--- a/Tests/Parser/Functions/ArrayPopFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayPopFunctionTests.cs
@@ -45,6 +45,8 @@ namespace RATools.Test.Parser.Functions
                 Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
 
                 var parseError = (ParseErrorExpression)error;
+                while (parseError.InnerError != null)
+                    parseError = parseError.InnerError;
                 Assert.That(parseError.Message, Is.EqualTo(expectedError));
 
                 return null;

--- a/Tests/Parser/Functions/ArrayPushFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayPushFunctionTests.cs
@@ -47,6 +47,8 @@ namespace RATools.Test.Parser.Functions
                 Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
 
                 var parseError = (ParseErrorExpression)error;
+                while (parseError.InnerError != null)
+                    parseError = parseError.InnerError;
                 Assert.That(parseError.Message, Is.EqualTo(expectedError));
             }
         }

--- a/Tests/Parser/Functions/FormatFunctionTests.cs
+++ b/Tests/Parser/Functions/FormatFunctionTests.cs
@@ -145,7 +145,10 @@ namespace RATools.Test.Parser.Functions
             Assert.That(expression.Evaluate(scope, out result), Is.False);
 
             Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            return ((ParseErrorExpression)result).Message;
+            var parseError = (ParseErrorExpression)result;
+            while (parseError.InnerError != null)
+                parseError = parseError.InnerError;
+            return parseError.Message;
         }
 
         [Test]

--- a/Tests/Parser/Functions/LengthFunctionTests.cs
+++ b/Tests/Parser/Functions/LengthFunctionTests.cs
@@ -46,6 +46,8 @@ namespace RATools.Test.Parser.Functions
                 Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
 
                 var parseError = (ParseErrorExpression)error;
+                while (parseError.InnerError != null)
+                    parseError = parseError.InnerError;
                 Assert.That(parseError.Message, Is.EqualTo(expectedError));
 
                 return int.MinValue;

--- a/Tests/Parser/Internal/DictionaryExpressionTests.cs
+++ b/Tests/Parser/Internal/DictionaryExpressionTests.cs
@@ -184,7 +184,10 @@ namespace RATools.Test.Parser.Internal
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
             Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("func did not return a value"));
+            var parseError = (ParseErrorExpression)result;
+            while (parseError.InnerError != null)
+                parseError = parseError.InnerError;
+            Assert.That(parseError.Message, Is.EqualTo("func did not return a value"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Internal/FunctionCallExpressionTests.cs
@@ -313,7 +313,10 @@ namespace RATools.Test.Parser.Internal
             ExpressionBase result;
             Assert.That(functionCall.ReplaceVariables(scope, out result), Is.False);
             Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("func did not return a value"));
+            var parseError = (ParseErrorExpression)result;
+            while (parseError.InnerError != null)
+                parseError = parseError.InnerError;
+            Assert.That(parseError.Message, Is.EqualTo("func did not return a value"));
         }
 
         [Test]


### PR DESCRIPTION
Provides more information on where an error occurred.

![image](https://user-images.githubusercontent.com/32680403/85177591-ad624500-b239-11ea-9e1b-5a862e30d601.png)

Only the final point of failure will be underlined in the editor. The other lines serve as context of where the error occurred, and can be double-clicked to jump to the related code.