### PR TITLE
only pass dictionary by reference if parameter was a variable

### DIFF
--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -151,9 +151,19 @@ namespace RATools.Parser.Internal
             {
                 value = scope.GetVariable(variable.Name);
 
-                // could not find variable, fallback to VariableExpression.ReplaceVariables generating an error
                 if (value == null)
+                {
+                    // could not find variable, fallback to VariableExpression.ReplaceVariables generating an error
                     value = assignment.Value;
+                }
+                else
+                {
+                    // when a parameter is assigned to a variable that is an array or dictionary,
+                    // assume it has already been evaluated and pass it by reference. this is magnitudes
+                    // more performant, and allows the function to modify the data in the container.
+                    if (value.Type == ExpressionType.Dictionary || value.Type == ExpressionType.Array)
+                        return value;
+                }
             }
 
             switch (value.Type)
@@ -162,12 +172,6 @@ namespace RATools.Parser.Internal
                 case ExpressionType.StringConstant:
                     // already a basic type, do nothing
                     break;
-
-                case ExpressionType.Array:
-                case ExpressionType.Dictionary:
-                    // pass array and dictionary by reference so function can modify them.
-                    // also eliminates copying the entire object to pass it as a parameter.
-                    return value;
 
                 default:
                     // not a basic type, evaluate it

--- a/Parser/Internal/IndexedVariableExpression.cs
+++ b/Parser/Internal/IndexedVariableExpression.cs
@@ -107,17 +107,17 @@ namespace RATools.Parser.Internal
             var dict = value as DictionaryExpression;
             if (dict != null)
             {
-                var entry = dict.Entries.FirstOrDefault(e => Object.Equals(e.Key, index));
-                if (entry != null)
+                var entry = new DictionaryExpression.DictionaryEntry() { Key = index };
+                var entryIndex = dict.Entries.BinarySearch(entry, entry);
+                if (entryIndex >= 0)
                 {
                     result = dict;
-                    return entry;
+                    return dict.Entries[entryIndex];
                 }
 
                 if (create)
                 {
-                    entry = new DictionaryExpression.DictionaryEntry { Key = index };
-                    dict.Entries.Add(entry);
+                    dict.Entries.Insert(~entryIndex, entry);
                     result = dict;
                     return entry;
                 }

--- a/Tests/Parser/Internal/DictionaryExpressionTests.cs
+++ b/Tests/Parser/Internal/DictionaryExpressionTests.cs
@@ -112,10 +112,12 @@ namespace RATools.Test.Parser.Internal
             Assert.That(result, Is.InstanceOf<DictionaryExpression>());
             var dictResult = (DictionaryExpression)result;
             Assert.That(dictResult.Entries.Count, Is.EqualTo(2));
-            Assert.That(dictResult.Entries[0].Key, Is.EqualTo(value1));
-            Assert.That(dictResult.Entries[0].Value, Is.EqualTo(value3));
-            Assert.That(dictResult.Entries[1].Key, Is.EqualTo(value4));
-            Assert.That(dictResult.Entries[1].Value, Is.EqualTo(value2));
+
+            // resulting list will be sorted for quicker lookups
+            Assert.That(dictResult.Entries[0].Key, Is.EqualTo(value4));
+            Assert.That(dictResult.Entries[0].Value, Is.EqualTo(value2));
+            Assert.That(dictResult.Entries[1].Key, Is.EqualTo(value1));
+            Assert.That(dictResult.Entries[1].Value, Is.EqualTo(value3));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #173 

When a dictionary is passed to a function without first being stored in a variable, any variables in the dictionary should be immediately expanded.

Also changes the dictionary lookup code to use a binary search for faster lookups.