### PR TITLE
make processing script asynchronous

### DIFF
--- a/ViewModels/EditorViewModel.cs
+++ b/ViewModels/EditorViewModel.cs
@@ -42,20 +42,95 @@ namespace RATools.ViewModels
 
         private readonly GameViewModel _owner;
 
+        private class ScriptInterpreterCallback : IScriptInterpreterCallback
+        {
+            public ScriptInterpreterCallback(EditorViewModel owner, ContentChangedEventArgs e)
+            {
+                _owner = owner;
+                _args = e;
+            }
+
+            private EditorViewModel _owner;
+            private ContentChangedEventArgs _args;
+
+            public bool IsAborted
+            {
+                get { return _args.IsAborted; }
+            }
+
+            public void UpdateProgress(int percentage, int line)
+            {
+                _owner.UpdateProgress(percentage, line);
+            }
+        }
+
         protected override void OnUpdateSyntax(ContentChangedEventArgs e)
         {
+            // show progress bar
+            UpdateProgress(1, 0);
+
+            // parse immediately so we can update the syntax highlighting
             var parser = new AchievementScriptParser();
             _parsedContent = parser.Parse(Tokenizer.CreateTokenizer(e.Content));
 
+            // if more changes have been made, bail
             if (e.IsAborted)
-                return;
+            {
+                // make sure the progress bar is hidden
+                UpdateProgress(0, 0);
+            }
+            else if (!e.IsWhitespaceOnlyChange)
+            {
+                // make sure to at least show the script file in the editor list
+                if (!_owner.Editors.Any())
+                    _owner.PopulateEditorList(null);
 
-            var interpreter = new AchievementScriptInterpreter();
-            interpreter.Run(_parsedContent, out _scope);
+                // running the script can take a lot of time, push that work onto a background thread
+                ServiceRepository.Instance.FindService<IBackgroundWorkerService>().RunAsync(() =>
+                {
+                    if (!e.IsAborted)
+                    {
+                        // run the script
+                        var callback = new ScriptInterpreterCallback(this, e);
+                        var interpreter = new AchievementScriptInterpreter();
+                        interpreter.Run(_parsedContent, callback, out _scope);
 
-            if (e.IsAborted)
-                return;
+                        if (!e.IsAborted)
+                        {
+                            UpdateProgress(100, 0);
 
+                            // report any errors
+                            UpdateErrorList();
+
+                            if (!e.IsAborted)
+                            {
+                                // wait a short while before updating the editor list
+                                System.Threading.Thread.Sleep(700);
+
+                                if (!e.IsAborted)
+                                {
+                                    // update the editor list
+                                    _owner.PopulateEditorList(interpreter);
+                                }
+                            }
+                        }
+                    }
+
+                    // make sure the progress bar is hidden
+                    UpdateProgress(0, 0);
+                });
+            }
+
+            base.OnUpdateSyntax(e);
+        }
+
+        internal void UpdateProgress(int progress, int line)
+        {
+            _owner.UpdateCompileProgress(progress, line);
+        }
+
+        private void UpdateErrorList()
+        {
             ServiceRepository.Instance.FindService<IBackgroundWorkerService>().InvokeOnUiThread(() =>
             {
                 ErrorsToolWindow.References.Clear();
@@ -85,24 +160,6 @@ namespace RATools.ViewModels
                     });
                 }
             });
-
-            if (e.IsAborted)
-                return;
-
-            if (e.IsWhitespaceOnlyChange)
-                return;
-
-            // wait a short while before updating the editor list
-            ServiceRepository.Instance.FindService<ITimerService>().Schedule(() =>
-            {
-                if (e.IsAborted)
-                    return;
-
-                _owner.PopulateEditorList(interpreter);
-
-            }, TimeSpan.FromMilliseconds(700));
-
-            base.OnUpdateSyntax(e);
         }
 
         protected override void OnContentChanged(ContentChangedEventArgs e)

--- a/ViewModels/GameViewModel.cs
+++ b/ViewModels/GameViewModel.cs
@@ -184,7 +184,25 @@ namespace RATools.ViewModels
         internal int GameId { get; private set; }
         internal string RACacheDirectory { get; private set; }
         internal TinyDictionary<int, string> Notes { get; private set; }
-        
+
+        public int CompileProgress { get; internal set; }
+        public int CompileProgressLine { get; internal set; }
+
+        internal void UpdateCompileProgress(int progress, int line)
+        {
+            if (CompileProgress != progress)
+            {
+                CompileProgress = progress;
+                OnPropertyChanged(() => CompileProgress);
+            }
+
+            if (CompileProgressLine != line)
+            {
+                CompileProgressLine = line;
+                OnPropertyChanged(() => CompileProgressLine);
+            }
+        }
+
         public static readonly ModelProperty EditorsProperty = ModelProperty.Register(typeof(GameViewModel), "Editors", typeof(IEnumerable<GeneratedItemViewModelBase>), new GeneratedItemViewModelBase[0]);
         public IEnumerable<GeneratedItemViewModelBase> Editors
         {

--- a/Views/GameViewer.xaml
+++ b/Views/GameViewer.xaml
@@ -135,6 +135,7 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Margin="4,0,4,0">
                         <TextBlock.Style>
@@ -185,7 +186,41 @@
                         <Run Text="pts" />
                     </TextBlock>
 
-                    <TextBlock Grid.Column="3" Margin="4,0,4,0" HorizontalAlignment="Right">
+                    <Grid Grid.Column="3" Margin="4,0,24,0" HorizontalAlignment="Right">
+                        <Grid.Style>
+                            <Style TargetType="{x:Type Grid}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CompileProgress}" Value="0">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
+                        <Grid.ToolTip>
+                            <TextBlock>
+                                <Run Text="Processing line" />
+                                <TextBlock Text="{Binding CompileProgressLine}" />
+                            </TextBlock>
+                        </Grid.ToolTip>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="32" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Text="Processing" Margin="0,0,2,0" />
+                        <Border Grid.Column="1" BorderThickness="1" BorderBrush="#808080" Background="#A0A0A0" Width="100" Height="10">
+                            <Border Background="#80C080" Width="{Binding CompileProgress}" Height="8" 
+                                    VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0" />
+                        </Border>
+                        <TextBlock Grid.Column="2" Margin="2,0,0,0" HorizontalAlignment="Right">
+                            <TextBlock Text="{Binding CompileProgress}" Margin="0,0,-2,0" />
+                            <Run Text="%" />
+                        </TextBlock>
+                    </Grid>
+
+                    <TextBlock Grid.Column="4" Margin="4,0,4,0" HorizontalAlignment="Right">
                         <Run Text="Ln " />
                         <TextBlock Text="{Binding Script.Editor.CursorLine, FallbackValue=0}" />
                         <Run Text="   Col " />


### PR DESCRIPTION
Separates processing the script from parsing it. The processing is offloaded to a background thread so the UI doesn't "hang" when processing a complex script. Parsing and syntax highlighting still happens on the UI thread, but takes almost no time, even with a complex script.

While processing, a progress bar is shown in the status bar. If a script is taking a long time, you can hover over the progress bar to see what it's processing. In this case, it's processing a `for` loop, which gives a bit of an idea what's running slowly, but not exactly where the code needs improvement.

![image](https://user-images.githubusercontent.com/32680403/85188273-ae5b9c80-b262-11ea-8ea8-9583784b6389.png)
