### PR TITLE
Add ability to customize colors

### DIFF
--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -191,10 +191,11 @@ namespace RATools.Parser.Internal
                         var error = (ParseErrorExpression)value;
                         return new ParseErrorExpression("Invalid value for parameter: " + assignment.Variable.Name, assignment.Value) { InnerError = error };
                     }
+
+                    assignment.Value.CopyLocation(value);
                     break;
             }
 
-            assignment.Value.CopyLocation(value);
             return value;
         }
 

--- a/Parser/Internal/FunctionDefinitionExpression.cs
+++ b/Parser/Internal/FunctionDefinitionExpression.cs
@@ -324,7 +324,11 @@ namespace RATools.Parser.Internal
             if (_keyword != null && _keyword.Line == line)
                 expressions.Add(_keyword);
             if (Name.Line == line)
-                expressions.Add(Name);
+            {
+                var name = new FunctionDefinitionExpression(Name.Name);
+                Name.CopyLocation(name);
+                expressions.Add(name);
+            }
 
             foreach (var parameter in Parameters)
             {

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Services\ISettings.cs" />
     <Compile Include="Services\RAWebCache.cs" />
     <Compile Include="Services\Settings.cs" />
+    <Compile Include="Services\Theme.cs" />
     <Compile Include="ViewModels\AboutDialogViewModel.cs" />
     <Compile Include="ViewModels\EditorViewModel.cs" />
     <Compile Include="ViewModels\NewScriptDialogViewModel.cs" />

--- a/Services/Settings.cs
+++ b/Services/Settings.cs
@@ -55,6 +55,10 @@ namespace RATools.Services
                 string apiKey;
                 if (values.TryGetValue("ApiKey", out apiKey) && apiKey.Length > 0)
                     ApiKey = apiKey;
+
+                string colors;
+                if (values.TryGetValue("Colors", out colors) && colors.Length > 0)
+                    Colors = colors;
             }
             catch (FileNotFoundException)
             {
@@ -90,6 +94,8 @@ namespace RATools.Services
 
             values.Remove("RACacheDirectory");
 
+            values["Colors"] = Colors;
+
             file.Write(values);
         }
 
@@ -102,6 +108,8 @@ namespace RATools.Services
         public string UserName { get; set; }
 
         public string ApiKey { get; set; }
+
+        public string Colors { get; set; }
 
         public bool HexValues
         {

--- a/Services/Theme.cs
+++ b/Services/Theme.cs
@@ -47,7 +47,7 @@ namespace RATools.Services
             SetColor(Color.EditorIntegerConstant, Colors.DarkGray);
             SetColor(Color.EditorStringConstant, Colors.DarkSeaGreen);
             SetColor(Color.EditorVariable, Colors.Violet);
-            SetColor(Color.EditorFunctionDefinition, Colors.DarkViolet);
+            SetColor(Color.EditorFunctionDefinition, System.Windows.Media.Color.FromRgb(0xC0, 0x40, 0xD0));
             SetColor(Color.EditorFunctionCall, Colors.DarkViolet);
 
             SetColor(Color.DiffAdded, System.Windows.Media.Color.FromRgb(0x00, 0xD0, 0x40));
@@ -68,7 +68,7 @@ namespace RATools.Services
             SetColor(Color.EditorIntegerConstant, System.Windows.Media.Color.FromRgb(0x70, 0x70, 0x80));
             SetColor(Color.EditorStringConstant, System.Windows.Media.Color.FromRgb(0xC0, 0xC0, 0x80));
             SetColor(Color.EditorVariable, System.Windows.Media.Color.FromRgb(0x90, 0xA0, 0xC0));
-            SetColor(Color.EditorFunctionDefinition, System.Windows.Media.Color.FromRgb(0x50, 0xF0, 0x80));
+            SetColor(Color.EditorFunctionDefinition, System.Windows.Media.Color.FromRgb(0x80, 0xA0, 0x90));
             SetColor(Color.EditorFunctionCall, System.Windows.Media.Color.FromRgb(0xC0, 0xB8, 0xB8));
 
             SetColor(Color.DiffAdded, System.Windows.Media.Color.FromRgb(0x20, 0x80, 0x40));

--- a/Services/Theme.cs
+++ b/Services/Theme.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Windows.Media;
+
+namespace RATools.Services
+{
+    public class Theme
+    {
+        public enum Color
+        {
+            None,
+
+            EditorBackground,
+            EditorForeground,
+            EditorSelection,
+            EditorLineNumbers,
+
+            EditorKeyword,
+            EditorComment,
+            EditorIntegerConstant,
+            EditorStringConstant,
+            EditorVariable,
+            EditorFunctionDefinition,
+            EditorFunctionCall,
+            EditorError,
+        }
+
+        static Theme()
+        {
+            _colors[(int)Color.EditorBackground] = Colors.White;
+            _colors[(int)Color.EditorForeground] = Colors.Black;
+            _colors[(int)Color.EditorSelection] = Colors.LightGray;
+            _colors[(int)Color.EditorLineNumbers] = Colors.LightGray;
+
+            _colors[(int)Color.EditorKeyword] = Colors.DarkGoldenrod;
+            _colors[(int)Color.EditorComment] = Colors.DarkCyan;
+            _colors[(int)Color.EditorIntegerConstant] = Colors.DarkGray;
+            _colors[(int)Color.EditorStringConstant] = Colors.DarkSeaGreen;
+            _colors[(int)Color.EditorVariable] = Colors.Violet;
+            _colors[(int)Color.EditorFunctionDefinition] = Colors.DarkViolet;
+            _colors[(int)Color.EditorFunctionCall] = Colors.DarkViolet;
+            _colors[(int)Color.EditorError] = Colors.Red;
+        }
+
+        public static System.Windows.Media.Color GetColor(Color color)
+        {
+            return _colors[(int)color];
+        }
+
+        public static void SetColor(Color color, System.Windows.Media.Color value)
+        {
+            var oldValue = _colors[(int)color];
+            if (value != oldValue)
+            {
+                _colors[(int)color] = value;
+                OnColorChanged(new ColorChangedEventArgs(color, value, oldValue));
+            }
+        }
+
+        private static readonly System.Windows.Media.Color[] _colors = new System.Windows.Media.Color[16];
+
+        public class ColorChangedEventArgs : EventArgs
+        {
+            public ColorChangedEventArgs(Color color, System.Windows.Media.Color value, System.Windows.Media.Color oldValue)
+            {
+                Color = color;
+                NewValue = value;
+                OldValue = oldValue;
+            }
+
+            public Color Color { get; private set; }
+            public System.Windows.Media.Color NewValue { get; private set; }
+            public System.Windows.Media.Color OldValue { get; private set; }
+        }
+
+        private static void OnColorChanged(ColorChangedEventArgs e)
+        {
+            if (ColorChanged != null)
+                ColorChanged(typeof(Theme), e);
+        }
+
+        public static event EventHandler<ColorChangedEventArgs> ColorChanged;
+    }
+}

--- a/Services/Theme.cs
+++ b/Services/Theme.cs
@@ -1,6 +1,5 @@
 ﻿using Jamiras.Components;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Windows.Media;
@@ -13,8 +12,9 @@ namespace RATools.Services
         {
             None,
 
-            EditorBackground,
-            EditorForeground,
+            Background,
+            Foreground,
+
             EditorSelection,
             EditorLineNumbers,
 
@@ -25,6 +25,9 @@ namespace RATools.Services
             EditorVariable,
             EditorFunctionDefinition,
             EditorFunctionCall,
+
+            DiffAdded,
+            DiffRemoved,
         }
 
         static Theme()
@@ -34,8 +37,8 @@ namespace RATools.Services
 
         public static void InitDefault()
         {
-            SetColor(Color.EditorBackground, Colors.White);
-            SetColor(Color.EditorForeground, Colors.Black);
+            SetColor(Color.Background, Colors.White);
+            SetColor(Color.Foreground, Colors.Black);
             SetColor(Color.EditorSelection, Colors.LightGray);
             SetColor(Color.EditorLineNumbers, Colors.LightGray);
 
@@ -47,13 +50,16 @@ namespace RATools.Services
             SetColor(Color.EditorFunctionDefinition, Colors.DarkViolet);
             SetColor(Color.EditorFunctionCall, Colors.DarkViolet);
 
+            SetColor(Color.DiffAdded, System.Windows.Media.Color.FromRgb(0x00, 0xD0, 0x40));
+            SetColor(Color.DiffRemoved, System.Windows.Media.Color.FromRgb(0xE0, 0x40, 0x40));
+
             _themeName = "Default";
         }
 
         public static void InitDark()
         {
-            SetColor(Color.EditorBackground, System.Windows.Media.Color.FromRgb(0x12, 0x12, 0x12));
-            SetColor(Color.EditorForeground, System.Windows.Media.Color.FromRgb(0x90, 0x90, 0x90));
+            SetColor(Color.Background, System.Windows.Media.Color.FromRgb(0x12, 0x12, 0x12));
+            SetColor(Color.Foreground, System.Windows.Media.Color.FromRgb(0x90, 0x90, 0x90));
             SetColor(Color.EditorSelection, System.Windows.Media.Color.FromRgb(0x30, 0x30, 0x30));
             SetColor(Color.EditorLineNumbers, System.Windows.Media.Color.FromRgb(0x50, 0x50, 0x50));
 
@@ -64,6 +70,9 @@ namespace RATools.Services
             SetColor(Color.EditorVariable, System.Windows.Media.Color.FromRgb(0x90, 0xA0, 0xC0));
             SetColor(Color.EditorFunctionDefinition, System.Windows.Media.Color.FromRgb(0x50, 0xF0, 0x80));
             SetColor(Color.EditorFunctionCall, System.Windows.Media.Color.FromRgb(0xC0, 0xB8, 0xB8));
+
+            SetColor(Color.DiffAdded, System.Windows.Media.Color.FromRgb(0x20, 0x80, 0x40));
+            SetColor(Color.DiffRemoved, System.Windows.Media.Color.FromRgb(0xA0, 0x30, 0x20));
 
             _themeName = "Dark";
         }

--- a/Services/Theme.cs
+++ b/Services/Theme.cs
@@ -43,8 +43,8 @@ namespace RATools.Services
         {
             SetColor(Color.Background, Colors.White);
             SetColor(Color.Foreground, Colors.Black);
-            SetColor(Color.ScrollBarBackground, Colors.LightGray);
-            SetColor(Color.ScrollBarForeground, Colors.Gray);
+            SetColor(Color.ScrollBarBackground, System.Windows.Media.Color.FromRgb(0xE0, 0xE0, 0xE0));
+            SetColor(Color.ScrollBarForeground, System.Windows.Media.Color.FromRgb(0xC0, 0xC0, 0xC0));
             SetColor(Color.EditorSelection, Colors.LightGray);
             SetColor(Color.EditorLineNumbers, Colors.LightGray);
 
@@ -66,8 +66,8 @@ namespace RATools.Services
         {
             SetColor(Color.Background, System.Windows.Media.Color.FromRgb(0x12, 0x12, 0x12));
             SetColor(Color.Foreground, System.Windows.Media.Color.FromRgb(0x90, 0x90, 0x90));
-            SetColor(Color.ScrollBarBackground, Colors.LightGray);
-            SetColor(Color.ScrollBarForeground, Colors.Gray);
+            SetColor(Color.ScrollBarBackground, System.Windows.Media.Color.FromRgb(0x20, 0x20, 0x20));
+            SetColor(Color.ScrollBarForeground, System.Windows.Media.Color.FromRgb(0x38, 0x38, 0x38));
             SetColor(Color.EditorSelection, System.Windows.Media.Color.FromRgb(0x30, 0x30, 0x30));
             SetColor(Color.EditorLineNumbers, System.Windows.Media.Color.FromRgb(0x50, 0x50, 0x50));
 
@@ -80,7 +80,7 @@ namespace RATools.Services
             SetColor(Color.EditorFunctionCall, System.Windows.Media.Color.FromRgb(0xC0, 0xB8, 0xB8));
 
             SetColor(Color.DiffAdded, System.Windows.Media.Color.FromRgb(0x20, 0x80, 0x40));
-            SetColor(Color.DiffRemoved, System.Windows.Media.Color.FromRgb(0xA0, 0x30, 0x20));
+            SetColor(Color.DiffRemoved, System.Windows.Media.Color.FromRgb(0x80, 0x20, 0x20));
 
             _themeName = "Dark";
         }

--- a/Services/Theme.cs
+++ b/Services/Theme.cs
@@ -16,6 +16,8 @@ namespace RATools.Services
 
             Background,
             Foreground,
+            ScrollBarBackground,
+            ScrollBarForeground,
 
             EditorSelection,
             EditorLineNumbers,
@@ -41,6 +43,8 @@ namespace RATools.Services
         {
             SetColor(Color.Background, Colors.White);
             SetColor(Color.Foreground, Colors.Black);
+            SetColor(Color.ScrollBarBackground, Colors.LightGray);
+            SetColor(Color.ScrollBarForeground, Colors.Gray);
             SetColor(Color.EditorSelection, Colors.LightGray);
             SetColor(Color.EditorLineNumbers, Colors.LightGray);
 
@@ -62,6 +66,8 @@ namespace RATools.Services
         {
             SetColor(Color.Background, System.Windows.Media.Color.FromRgb(0x12, 0x12, 0x12));
             SetColor(Color.Foreground, System.Windows.Media.Color.FromRgb(0x90, 0x90, 0x90));
+            SetColor(Color.ScrollBarBackground, Colors.LightGray);
+            SetColor(Color.ScrollBarForeground, Colors.Gray);
             SetColor(Color.EditorSelection, System.Windows.Media.Color.FromRgb(0x30, 0x30, 0x30));
             SetColor(Color.EditorLineNumbers, System.Windows.Media.Color.FromRgb(0x50, 0x50, 0x50));
 

--- a/ViewModels/EditorViewModel.cs
+++ b/ViewModels/EditorViewModel.cs
@@ -31,7 +31,6 @@ namespace RATools.ViewModels
                 _themeColors[Theme.Color.EditorVariable] = ExpressionType.Variable;
                 _themeColors[Theme.Color.EditorFunctionDefinition] = ExpressionType.FunctionDefinition;
                 _themeColors[Theme.Color.EditorFunctionCall] = ExpressionType.FunctionCall;
-                _themeColors[Theme.Color.EditorError] = ExpressionType.ParseError;
             }
 
             Theme.ColorChanged += Theme_ColorChanged;

--- a/ViewModels/EditorViewModel.cs
+++ b/ViewModels/EditorViewModel.cs
@@ -37,8 +37,8 @@ namespace RATools.ViewModels
 
             foreach (var kvp in _themeColors)
                Style.SetCustomColor((int)kvp.Value, Theme.GetColor(kvp.Key));
-            Style.Background = Theme.GetColor(Theme.Color.EditorBackground);
-            Style.Foreground = Theme.GetColor(Theme.Color.EditorForeground);
+            Style.Background = Theme.GetColor(Theme.Color.Background);
+            Style.Foreground = Theme.GetColor(Theme.Color.Foreground);
             Style.Selection = Theme.GetColor(Theme.Color.EditorSelection);
             Style.LineNumber = Theme.GetColor(Theme.Color.EditorLineNumbers);
 
@@ -61,11 +61,11 @@ namespace RATools.ViewModels
         {
             switch (e.Color)
             {
-                case Theme.Color.EditorBackground:
+                case Theme.Color.Background:
                     Style.Background = e.NewValue;
                     break;
 
-                case Theme.Color.EditorForeground:
+                case Theme.Color.Foreground:
                     Style.Foreground = e.NewValue;
                     break;
 

--- a/ViewModels/EditorViewModel.cs
+++ b/ViewModels/EditorViewModel.cs
@@ -7,28 +7,41 @@ using Jamiras.ViewModels.CodeEditor;
 using Jamiras.ViewModels.CodeEditor.ToolWindows;
 using RATools.Parser;
 using RATools.Parser.Internal;
+using RATools.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Windows.Media;
 
 namespace RATools.ViewModels
 {
-    public class EditorViewModel : CodeEditorViewModel
+    public class EditorViewModel : CodeEditorViewModel, IDisposable
     {
         public EditorViewModel(GameViewModel owner)
         {
             _owner = owner;
 
-            Style.SetCustomColor((int)ExpressionType.Comment, Colors.DarkCyan);
-            Style.SetCustomColor((int)ExpressionType.IntegerConstant, Colors.DarkGray);
-            Style.SetCustomColor((int)ExpressionType.FunctionDefinition, Colors.DarkViolet);
-            Style.SetCustomColor((int)ExpressionType.FunctionCall, Colors.DarkViolet);
-            Style.SetCustomColor((int)ExpressionType.Variable, Colors.Violet);
-            Style.SetCustomColor((int)ExpressionType.StringConstant, Colors.DarkSeaGreen);
-            Style.SetCustomColor((int)ExpressionType.Keyword, Colors.DarkGoldenrod);
-            Style.SetCustomColor((int)ExpressionType.ParseError, Colors.Red);
+            if (_themeColors == null)
+            {
+                _themeColors = new Dictionary<Theme.Color, ExpressionType>();
+                _themeColors[Theme.Color.EditorKeyword] = ExpressionType.Keyword;
+                _themeColors[Theme.Color.EditorComment] = ExpressionType.Comment;
+                _themeColors[Theme.Color.EditorIntegerConstant] = ExpressionType.IntegerConstant;
+                _themeColors[Theme.Color.EditorStringConstant] = ExpressionType.StringConstant;
+                _themeColors[Theme.Color.EditorVariable] = ExpressionType.Variable;
+                _themeColors[Theme.Color.EditorFunctionDefinition] = ExpressionType.FunctionDefinition;
+                _themeColors[Theme.Color.EditorFunctionCall] = ExpressionType.FunctionCall;
+                _themeColors[Theme.Color.EditorError] = ExpressionType.ParseError;
+            }
+
+            Theme.ColorChanged += Theme_ColorChanged;
+
+            foreach (var kvp in _themeColors)
+               Style.SetCustomColor((int)kvp.Value, Theme.GetColor(kvp.Key));
+            Style.Background = Theme.GetColor(Theme.Color.EditorBackground);
+            Style.Foreground = Theme.GetColor(Theme.Color.EditorForeground);
+            Style.Selection = Theme.GetColor(Theme.Color.EditorSelection);
+            Style.LineNumber = Theme.GetColor(Theme.Color.EditorLineNumbers);
 
             Braces['('] = ')';
             Braces['['] = ']';
@@ -39,6 +52,47 @@ namespace RATools.ViewModels
 
             GotoDefinitionCommand = new DelegateCommand(GotoDefinitionAtCursor);
         }
+
+        public virtual void Dispose()
+        {
+            Theme.ColorChanged -= Theme_ColorChanged;
+        }
+
+        private void Theme_ColorChanged(object sender, Theme.ColorChangedEventArgs e)
+        {
+            switch (e.Color)
+            {
+                case Theme.Color.EditorBackground:
+                    Style.Background = e.NewValue;
+                    break;
+
+                case Theme.Color.EditorForeground:
+                    Style.Foreground = e.NewValue;
+                    break;
+
+                case Theme.Color.EditorSelection:
+                    Style.Selection = e.NewValue;
+                    break;
+
+                case Theme.Color.EditorLineNumbers:
+                    Style.LineNumber = e.NewValue;
+                    break;
+
+                default:
+                    ExpressionType type;
+                    if (!_themeColors.TryGetValue(e.Color, out type))
+                        return;
+
+                    Style.SetCustomColor((int)type, e.NewValue);
+                    break;
+            }
+
+            // force repaint of all lines
+            foreach (var line in Lines)
+                line.Refresh();
+        }
+
+        private static Dictionary<Theme.Color, ExpressionType> _themeColors;
 
         private readonly GameViewModel _owner;
 

--- a/ViewModels/GameViewModel.cs
+++ b/ViewModels/GameViewModel.cs
@@ -494,6 +494,8 @@ namespace RATools.ViewModels
             {
                 DiffAddedBrush = CreateBrush(Theme.Color.DiffAdded);
                 DiffRemovedBrush = CreateBrush(Theme.Color.DiffRemoved);
+                ScrollBarBackgroundBrush = CreateBrush(Theme.Color.ScrollBarBackground);
+                ScrollBarForegroundBrush = CreateBrush(Theme.Color.ScrollBarForeground);
 
                 Theme.ColorChanged += Theme_ColorChanged;
             }
@@ -502,6 +504,16 @@ namespace RATools.ViewModels
             {
                 switch (e.Color)
                 {
+                    case Theme.Color.ScrollBarBackground:
+                        ScrollBarBackgroundBrush = CreateBrush(Theme.Color.ScrollBarBackground);
+                        OnPropertyChanged(() => ScrollBarBackgroundBrush);
+                        break;
+
+                    case Theme.Color.ScrollBarForeground:
+                        ScrollBarForegroundBrush = CreateBrush(Theme.Color.ScrollBarForeground);
+                        OnPropertyChanged(() => ScrollBarForegroundBrush);
+                        break;
+
                     case Theme.Color.DiffAdded:
                         DiffAddedBrush = CreateBrush(Theme.Color.DiffAdded);
                         OnPropertyChanged(() => DiffAddedBrush);
@@ -521,6 +533,8 @@ namespace RATools.ViewModels
                 return brush;
             }
 
+            public Brush ScrollBarBackgroundBrush { get; private set; }
+            public Brush ScrollBarForegroundBrush { get; private set; }
             public Brush DiffAddedBrush { get; private set; }
             public Brush DiffRemovedBrush { get; private set; }
         }

--- a/ViewModels/GameViewModel.cs
+++ b/ViewModels/GameViewModel.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Windows.Media;
 
 namespace RATools.ViewModels
 {
@@ -24,6 +25,7 @@ namespace RATools.ViewModels
             GameId = gameId;
             Title = title;
             Script = new ScriptViewModel(this);
+            Resources = new ResourceContainer();
             SelectedEditor = Script;
             Notes = new TinyDictionary<int, string>();
             GoToSourceCommand = new DelegateCommand<int>(GoToSource);
@@ -485,5 +487,44 @@ namespace RATools.ViewModels
 
             _logger.WriteVerbose(String.Format("Merged {0} local achievements ({1} points)", LocalAchievementCount, LocalAchievementPoints));
         }
+
+        public class ResourceContainer : PropertyChangedObject
+        {
+            public ResourceContainer()
+            {
+                DiffAddedBrush = CreateBrush(Theme.Color.DiffAdded);
+                DiffRemovedBrush = CreateBrush(Theme.Color.DiffRemoved);
+
+                Theme.ColorChanged += Theme_ColorChanged;
+            }
+
+            private void Theme_ColorChanged(object sender, Theme.ColorChangedEventArgs e)
+            {
+                switch (e.Color)
+                {
+                    case Theme.Color.DiffAdded:
+                        DiffAddedBrush = CreateBrush(Theme.Color.DiffAdded);
+                        OnPropertyChanged(() => DiffAddedBrush);
+                        break;
+
+                    case Theme.Color.DiffRemoved:
+                        DiffRemovedBrush = CreateBrush(Theme.Color.DiffRemoved);
+                        OnPropertyChanged(() => DiffRemovedBrush);
+                        break;
+                }
+            }
+
+            private static Brush CreateBrush(Theme.Color color)
+            {
+                var brush = new SolidColorBrush(Theme.GetColor(color));
+                brush.Freeze();
+                return brush;
+            }
+
+            public Brush DiffAddedBrush { get; private set; }
+            public Brush DiffRemovedBrush { get; private set; }
+        }
+
+        public ResourceContainer Resources { get; private set; }
     }
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -43,6 +43,7 @@ namespace RATools.ViewModels
             var settings = new Settings();
             ServiceRepository.Instance.RegisterInstance<ISettings>(settings);
             ShowHexValues = settings.HexValues;
+            Theme.Deserialize(settings.Colors);
 
             var persistance = ServiceRepository.Instance.FindService<IPersistantDataRepository>();
             var recent = persistance.GetValue("RecentFiles");

--- a/ViewModels/OptionsDialogViewModel.cs
+++ b/ViewModels/OptionsDialogViewModel.cs
@@ -48,6 +48,8 @@ namespace RATools.ViewModels
             var colors = new List<ColorViewModel>();
             colors.Add(new ColorViewModel(Theme.Color.Background, "Background"));
             colors.Add(new ColorViewModel(Theme.Color.Foreground, "Foreground"));
+            colors.Add(new ColorViewModel(Theme.Color.ScrollBarBackground, "ScrollBar Background"));
+            colors.Add(new ColorViewModel(Theme.Color.ScrollBarForeground, "ScrollBar Foreground"));
             colors.Add(new ColorViewModel(Theme.Color.EditorSelection, "Editor Selection"));
             colors.Add(new ColorViewModel(Theme.Color.EditorLineNumbers, "Editor Line Numbers"));
             colors.Add(new ColorViewModel(Theme.Color.EditorKeyword, "Editor Keyword"));

--- a/ViewModels/OptionsDialogViewModel.cs
+++ b/ViewModels/OptionsDialogViewModel.cs
@@ -63,6 +63,8 @@ namespace RATools.ViewModels
 
             DefaultColorsCommand = new DelegateCommand(DefaultColors);
             DarkColorsCommand = new DelegateCommand(DarkColors);
+            ExportColorsCommand = new DelegateCommand(ExportColors);
+            ImportColorsCommand = new DelegateCommand(ImportColors);
         }
 
         private readonly ISettings _settings;
@@ -186,6 +188,37 @@ namespace RATools.ViewModels
         }
 
         public IEnumerable<ColorViewModel> Colors { get; private set; }
+
+
+        public CommandBase ExportColorsCommand { get; private set; }
+        private void ExportColors()
+        {
+            var vm = new FileDialogViewModel();
+            vm.DialogTitle = "Export Colors";
+            vm.Filters["JSON file"] = "*.json";
+            vm.FileNames = new[] { "Colors.json" };
+            vm.OverwritePrompt = true;
+
+            if (vm.ShowSaveFileDialog() == DialogResult.Ok)
+            {
+                Theme.Export(vm.FileNames[0]);
+            }
+        }
+
+        public CommandBase ImportColorsCommand { get; private set; }
+        private void ImportColors()
+        {
+            var vm = new FileDialogViewModel();
+            vm.DialogTitle = "Import Colors";
+            vm.Filters["JSON file"] = "*.json";
+            vm.FileNames = new[] { "Colors.json" };
+            vm.CheckFileExists = true;
+
+            if (vm.ShowOpenFileDialog() == DialogResult.Ok)
+            {
+                Theme.Import(vm.FileNames[0]);
+            }
+        }
 
         public CommandBase DefaultColorsCommand { get; private set; }
         private void DefaultColors()

--- a/ViewModels/OptionsDialogViewModel.cs
+++ b/ViewModels/OptionsDialogViewModel.cs
@@ -60,6 +60,9 @@ namespace RATools.ViewModels
             colors.Add(new ColorViewModel(Theme.Color.DiffAdded, "Change Added"));
             colors.Add(new ColorViewModel(Theme.Color.DiffRemoved, "Change Removed"));
             Colors = colors;
+
+            DefaultColorsCommand = new DelegateCommand(DefaultColors);
+            DarkColorsCommand = new DelegateCommand(DarkColors);
         }
 
         private readonly ISettings _settings;
@@ -138,6 +141,11 @@ namespace RATools.ViewModels
                     Theme.SetColor(_themeColor, _originalColor);
             }
 
+            public void UpdateColor()
+            {
+                Color = Theme.GetColor(_themeColor);
+            }
+
             /// <summary>
             /// Gets or sets the item Label.
             /// </summary>
@@ -178,6 +186,24 @@ namespace RATools.ViewModels
         }
 
         public IEnumerable<ColorViewModel> Colors { get; private set; }
+
+        public CommandBase DefaultColorsCommand { get; private set; }
+        private void DefaultColors()
+        {
+            Theme.InitDefault();
+
+            foreach (var color in Colors)
+                color.UpdateColor();
+        }
+
+        public CommandBase DarkColorsCommand { get; private set; }
+        private void DarkColors()
+        {
+            Theme.InitDark();
+
+            foreach (var color in Colors)
+                color.UpdateColor();
+        }
 
         protected override void ExecuteCancelCommand()
         {

--- a/ViewModels/OptionsDialogViewModel.cs
+++ b/ViewModels/OptionsDialogViewModel.cs
@@ -57,7 +57,6 @@ namespace RATools.ViewModels
             colors.Add(new ColorViewModel(Theme.Color.EditorVariable, "Editor Variable"));
             colors.Add(new ColorViewModel(Theme.Color.EditorFunctionDefinition, "Editor Function Definition"));
             colors.Add(new ColorViewModel(Theme.Color.EditorFunctionCall, "Editor Function Call"));
-            colors.Add(new ColorViewModel(Theme.Color.EditorError, "Editor Error"));
             Colors = colors;
         }
 
@@ -90,6 +89,8 @@ namespace RATools.ViewModels
             settings.EmulatorDirectories.Clear();
             foreach (var directoryViewModel in Directories)
                 settings.EmulatorDirectories.Add(directoryViewModel.Path);
+
+            settings.Colors = Theme.Serialize();
 
             settings.Save();
         }

--- a/ViewModels/OptionsDialogViewModel.cs
+++ b/ViewModels/OptionsDialogViewModel.cs
@@ -46,8 +46,8 @@ namespace RATools.ViewModels
             RemoveDirectoryCommand = new DelegateCommand(RemoveDirectory);
 
             var colors = new List<ColorViewModel>();
-            colors.Add(new ColorViewModel(Theme.Color.EditorBackground, "Editor Background"));
-            colors.Add(new ColorViewModel(Theme.Color.EditorForeground, "Editor Foreground"));
+            colors.Add(new ColorViewModel(Theme.Color.Background, "Background"));
+            colors.Add(new ColorViewModel(Theme.Color.Foreground, "Foreground"));
             colors.Add(new ColorViewModel(Theme.Color.EditorSelection, "Editor Selection"));
             colors.Add(new ColorViewModel(Theme.Color.EditorLineNumbers, "Editor Line Numbers"));
             colors.Add(new ColorViewModel(Theme.Color.EditorKeyword, "Editor Keyword"));
@@ -57,6 +57,8 @@ namespace RATools.ViewModels
             colors.Add(new ColorViewModel(Theme.Color.EditorVariable, "Editor Variable"));
             colors.Add(new ColorViewModel(Theme.Color.EditorFunctionDefinition, "Editor Function Definition"));
             colors.Add(new ColorViewModel(Theme.Color.EditorFunctionCall, "Editor Function Call"));
+            colors.Add(new ColorViewModel(Theme.Color.DiffAdded, "Change Added"));
+            colors.Add(new ColorViewModel(Theme.Color.DiffRemoved, "Change Removed"));
             Colors = colors;
         }
 

--- a/Views/AchievementViewer.xaml
+++ b/Views/AchievementViewer.xaml
@@ -39,16 +39,16 @@
                         </Image>
                     </Grid>
                 </Border>
-                <TextBlock Grid.Column="1" FontSize="18" FontWeight="DemiBold" Text="{Binding Title.Text}" Style="{StaticResource themedTextBlock}" />
-                <TextBlock Grid.Row="1" Grid.Column="1" Margin="6,2,2,2" Text="{Binding Description.Text}" 
-                           Style="{StaticResource themedTextBlock}" VerticalAlignment="Top" />
-                <TextBlock Grid.Row="2" Grid.Column="1" Margin="6,0,2,2" FontSize="10" VerticalAlignment="Top" Style="{StaticResource themedTextBlock}">
+                <TextBlock Grid.Column="1" Text="{Binding Title.Text}" Style="{StaticResource editorTitle}" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Description.Text}" FontSize="12"
+                           Style="{StaticResource editorSubtitle}" />
+                <TextBlock Grid.Row="2" Grid.Column="1" Style="{StaticResource editorSubtitle}">
                     <TextBlock Text="{Binding Points.Value}" />
                     <Run Text="points" />
                 </TextBlock>
-                <TextBlock Grid.Row="3" Grid.Column="1" Margin="6,0,2,2" FontSize="10" VerticalAlignment="Top">
+                <TextBlock Grid.Row="3" Grid.Column="1">
                     <TextBlock.Style>
-                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
+                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource editorSubtitle}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding Id}" Value="0">
                                     <Setter Property="Visibility" Value="Collapsed" />
@@ -77,7 +77,7 @@
                                                         <ColumnDefinition Width="*" />
                                                     </Grid.ColumnDefinitions>
                                                     <TextBlock Text="{Binding Definition}" Margin="0,0,8,0" />
-                                                    <TextBlock Grid.Column="1" Text="{Binding Notes}" TextWrapping="Wrap" FontStyle="Italic" />
+                                                    <TextBlock Grid.Column="1" Text="{Binding Notes}" Style="{StaticResource notesTextBlock}" />
                                                 </Grid>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
@@ -153,7 +153,7 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="{Binding Definition}" Margin="0,0,8,0" Style="{StaticResource themedTextBlock}" />
-                            <TextBlock Grid.Column="1" Text="{Binding Notes}" TextWrapping="Wrap" FontStyle="Italic" Style="{StaticResource themedTextBlock}" />
+                            <TextBlock Grid.Column="1" Text="{Binding Notes}" Style="{StaticResource notesTextBlock}" />
                         </Grid>
                     </DataTemplate>
 
@@ -191,9 +191,9 @@
                 </Border>
 
                 <!-- Name -->
-                <TextBlock Grid.Column="1" FontSize="18" FontWeight="DemiBold" Text="{Binding Title}">
+                <TextBlock Grid.Column="1" Text="{Binding Title}">
                     <TextBlock.Style>
-                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
+                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource editorTitle}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsTitleModified}" Value="True">
                                     <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
@@ -204,9 +204,9 @@
                     </TextBlock.Style>
                 </TextBlock>
                 <!-- Description -->
-                <TextBlock Grid.Row="1" Grid.Column="1" Margin="6,2,2,2" Text="{Binding Description}" VerticalAlignment="Top">
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Description}" FontSize="12">
                     <TextBlock.Style>
-                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
+                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource editorSubtitle}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsDescriptionModified}" Value="True">
                                     <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
@@ -217,25 +217,24 @@
                     </TextBlock.Style>
                 </TextBlock>
                 <!-- Points -->
-                <TextBlock Grid.Row="2" Grid.Column="1" Margin="6,0,2,2" FontSize="10" VerticalAlignment="Top">
-                    <TextBlock Text="{Binding Points}">
-                        <TextBlock.Style>
-                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsPointsModified}" Value="True">
-                                        <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
-                                        <Setter Property="ToolTip" Value="{StaticResource modifiedPointsToolTip}" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>                
+                <TextBlock Grid.Row="2" Grid.Column="1">
+                    <TextBlock.Style>
+                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource editorSubtitle}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsPointsModified}" Value="True">
+                                    <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
+                                    <Setter Property="ToolTip" Value="{StaticResource modifiedPointsToolTip}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                    <TextBlock Text="{Binding Points}" />
                     <Run Text="points" />
                 </TextBlock>
                 <!-- ID -->
-                <TextBlock Grid.Row="3" Grid.Column="1" Margin="6,0,2,2" FontSize="10" VerticalAlignment="Top">
+                <TextBlock Grid.Row="3" Grid.Column="1">
                     <TextBlock.Style>
-                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
+                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource editorSubtitle}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding Id}" Value="0">
                                     <Setter Property="Visibility" Value="Collapsed" />

--- a/Views/AchievementViewer.xaml
+++ b/Views/AchievementViewer.xaml
@@ -39,15 +39,16 @@
                         </Image>
                     </Grid>
                 </Border>
-                <TextBlock Grid.Column="1" FontSize="18" FontWeight="DemiBold" Text="{Binding Title.Text}" />
-                <TextBlock Grid.Row="1" Grid.Column="1" Margin="6,2,2,2" Text="{Binding Description.Text}" VerticalAlignment="Top" />
-                <TextBlock Grid.Row="2" Grid.Column="1" Margin="6,0,2,2" FontSize="10" VerticalAlignment="Top">
+                <TextBlock Grid.Column="1" FontSize="18" FontWeight="DemiBold" Text="{Binding Title.Text}" Style="{StaticResource themedTextBlock}" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Margin="6,2,2,2" Text="{Binding Description.Text}" 
+                           Style="{StaticResource themedTextBlock}" VerticalAlignment="Top" />
+                <TextBlock Grid.Row="2" Grid.Column="1" Margin="6,0,2,2" FontSize="10" VerticalAlignment="Top" Style="{StaticResource themedTextBlock}">
                     <TextBlock Text="{Binding Points.Value}" />
                     <Run Text="points" />
                 </TextBlock>
                 <TextBlock Grid.Row="3" Grid.Column="1" Margin="6,0,2,2" FontSize="10" VerticalAlignment="Top">
                     <TextBlock.Style>
-                        <Style TargetType="{x:Type TextBlock}">
+                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding Id}" Value="0">
                                     <Setter Property="Visibility" Value="Collapsed" />
@@ -64,7 +65,8 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Vertical">
-                                    <TextBlock Text="{Binding Label}" Margin="4,4,0,0" FontSize="16" FontWeight="DemiBold" />
+                                    <TextBlock Text="{Binding Label}" Margin="4,4,0,0" FontSize="16" FontWeight="DemiBold"  
+                                               Style="{StaticResource themedTextBlock}" />
 
                                     <ItemsControl ItemsSource="{Binding Requirements}" Margin="6,0,0,4" Grid.IsSharedSizeScope="True">
                                         <ItemsControl.ItemTemplate>
@@ -90,7 +92,9 @@
     </DataTemplate>
 
     <DataTemplate DataType="{x:Type vm:GeneratedAchievementViewModel}">
-        <Border Background="White" BorderBrush="#808080" BorderThickness="1">
+        <Border Background="{Binding DataContext.Script.Editor.Resources.Background.Brush, ElementName=gameGrid}" 
+                BorderBrush="{Binding DataContext.Script.Editor.Resources.LineNumber.Brush, ElementName=gameGrid}" 
+                BorderThickness="1">
             <Grid VerticalAlignment="Stretch">
                 <Grid.Resources>
                     <TextBlock x:Key="modifiedTitleToolTip">
@@ -120,7 +124,7 @@
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="{Binding Definition}" Margin="0,0,8,0">
                                 <TextBlock.Style>
-                                    <Style TargetType="{x:Type TextBlock}">
+                                    <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsModified}" Value="True">
                                                 <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
@@ -131,7 +135,7 @@
                             </TextBlock>
                             <TextBlock Grid.Column="1"  Text="{Binding OtherDefinition}" Margin="0,0,8,0">
                                 <TextBlock.Style>
-                                    <Style TargetType="{x:Type TextBlock}">
+                                    <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsModified}" Value="True">
                                                 <Setter Property="Foreground" Value="{StaticResource oldValueColor}" />
@@ -140,7 +144,7 @@
                                     </Style>
                                 </TextBlock.Style>
                             </TextBlock>
-                            <TextBlock Grid.Column="2" Text="{Binding Notes}" TextWrapping="Wrap" FontStyle="Italic" />
+                            <TextBlock Grid.Column="2" Text="{Binding Notes}" TextWrapping="Wrap" FontStyle="Italic" Style="{StaticResource themedTextBlock}" />
                         </Grid>
                     </DataTemplate>
 
@@ -150,8 +154,8 @@
                                 <ColumnDefinition Width="Auto" MinWidth="200" SharedSizeGroup="definition" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="{Binding Definition}" Margin="0,0,8,0" />
-                            <TextBlock Grid.Column="1" Text="{Binding Notes}" TextWrapping="Wrap" FontStyle="Italic" />
+                            <TextBlock Text="{Binding Definition}" Margin="0,0,8,0" Style="{StaticResource themedTextBlock}" />
+                            <TextBlock Grid.Column="1" Text="{Binding Notes}" TextWrapping="Wrap" FontStyle="Italic" Style="{StaticResource themedTextBlock}" />
                         </Grid>
                     </DataTemplate>
 
@@ -191,7 +195,7 @@
                 <!-- Name -->
                 <TextBlock Grid.Column="1" FontSize="18" FontWeight="DemiBold" Text="{Binding Title}">
                     <TextBlock.Style>
-                        <Style TargetType="{x:Type TextBlock}">
+                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsTitleModified}" Value="True">
                                     <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
@@ -204,7 +208,7 @@
                 <!-- Description -->
                 <TextBlock Grid.Row="1" Grid.Column="1" Margin="6,2,2,2" Text="{Binding Description}" VerticalAlignment="Top">
                     <TextBlock.Style>
-                        <Style TargetType="{x:Type TextBlock}">
+                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsDescriptionModified}" Value="True">
                                     <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
@@ -218,7 +222,7 @@
                 <TextBlock Grid.Row="2" Grid.Column="1" Margin="6,0,2,2" FontSize="10" VerticalAlignment="Top">
                     <TextBlock Text="{Binding Points}">
                         <TextBlock.Style>
-                            <Style TargetType="{x:Type TextBlock}">
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsPointsModified}" Value="True">
                                         <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
@@ -233,7 +237,7 @@
                 <!-- ID -->
                 <TextBlock Grid.Row="3" Grid.Column="1" Margin="6,0,2,2" FontSize="10" VerticalAlignment="Top">
                     <TextBlock.Style>
-                        <Style TargetType="{x:Type TextBlock}">
+                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding Id}" Value="0">
                                     <Setter Property="Visibility" Value="Collapsed" />
@@ -269,7 +273,7 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Column="0" Margin="4,0,0,0" VerticalAlignment="Bottom">
+                        <TextBlock Grid.Column="0" Margin="4,0,0,0" VerticalAlignment="Bottom" Style="{StaticResource themedTextBlock}">
                             <TextBlock FontSize="12" FontStyle="Italic"  Text="{Binding RequirementSource}" />
                             <TextBlock FontSize="10">
                                 <TextBlock.Style>
@@ -287,9 +291,11 @@
                                 </Hyperlink>
                             </TextBlock>
                         </TextBlock>
-                        <TextBlock Grid.Column="1" Margin="4,0,0,0" FontSize="12" FontStyle="Italic" VerticalAlignment="Bottom" Text="{Binding Other.Source}" />
-                        <TextBlock Grid.Column="2" Margin="4,0,0,0" FontSize="12" FontStyle="Italic" VerticalAlignment="Bottom" Text="Code Notes" />
-
+                        <TextBlock Grid.Column="1" Margin="4,0,0,0" FontSize="12" FontStyle="Italic" VerticalAlignment="Bottom" Text="{Binding Other.Source}"
+                                   Style="{StaticResource themedTextBlock}" />
+                        <TextBlock Grid.Column="2" Margin="4,0,0,0" FontSize="12" FontStyle="Italic" VerticalAlignment="Bottom" Text="Code Notes"
+                                   Style="{StaticResource themedTextBlock}" />
+ 
                         <ItemsControl Grid.Row="1" Grid.ColumnSpan="3" ItemsSource="{Binding RequirementGroups}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
@@ -299,7 +305,8 @@
                                             <RowDefinition Height="*" />
                                         </Grid.RowDefinitions>
 
-                                        <TextBlock Text="{Binding Label}" Margin="4,4,0,0" FontSize="16" FontWeight="DemiBold" />
+                                        <TextBlock Text="{Binding Label}" Margin="4,4,0,0" FontSize="16" FontWeight="DemiBold"
+                                                   Style="{StaticResource themedTextBlock}" />
                                         <ItemsControl Grid.Row="1" ItemsSource="{Binding Requirements}" Margin="6,0,0,4" />
                                     </Grid>
                                 </DataTemplate>

--- a/Views/AchievementViewer.xaml
+++ b/Views/AchievementViewer.xaml
@@ -125,7 +125,7 @@
                                     <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsModified}" Value="True">
-                                                <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
+                                                <Setter Property="Foreground" Value="{Binding DataContext.Resources.DiffAddedBrush, ElementName=gameGrid}" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -136,7 +136,7 @@
                                     <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsModified}" Value="True">
-                                                <Setter Property="Foreground" Value="{StaticResource oldValueColor}" />
+                                                <Setter Property="Foreground" Value="{Binding DataContext.Resources.DiffRemovedBrush, ElementName=gameGrid}" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -196,7 +196,7 @@
                         <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource editorTitle}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsTitleModified}" Value="True">
-                                    <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
+                                    <Setter Property="Foreground" Value="{Binding DataContext.Resources.DiffAddedBrush, ElementName=gameGrid}" />
                                     <Setter Property="ToolTip" Value="{StaticResource modifiedTitleToolTip}" />
                                 </DataTrigger>
                             </Style.Triggers>
@@ -209,7 +209,7 @@
                         <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource editorSubtitle}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsDescriptionModified}" Value="True">
-                                    <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
+                                    <Setter Property="Foreground" Value="{Binding DataContext.Resources.DiffAddedBrush, ElementName=gameGrid}" />
                                     <Setter Property="ToolTip" Value="{StaticResource modifiedDescriptionToolTip}" />
                                 </DataTrigger>
                             </Style.Triggers>
@@ -222,7 +222,7 @@
                         <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource editorSubtitle}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsPointsModified}" Value="True">
-                                    <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
+                                    <Setter Property="Foreground" Value="{Binding DataContext.Resources.DiffAddedBrush, ElementName=gameGrid}" />
                                     <Setter Property="ToolTip" Value="{StaticResource modifiedPointsToolTip}" />
                                 </DataTrigger>
                             </Style.Triggers>

--- a/Views/AchievementViewer.xaml
+++ b/Views/AchievementViewer.xaml
@@ -60,7 +60,8 @@
                     <TextBlock Text="{Binding Id}" />
                 </TextBlock>
 
-                <ScrollViewer Grid.Row="4" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto">
+                <ScrollViewer Grid.Row="4" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto"
+                              Template="{StaticResource themedScrollViewerTemplate}">
                     <ItemsControl ItemsSource="{Binding RequirementGroups}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
@@ -258,7 +259,8 @@
                 </TextBlock>
 
                 <!-- Requirements -->
-                <ScrollViewer Grid.Row="5" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto">
+                <ScrollViewer Grid.Row="5" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto"
+                              Template="{StaticResource themedScrollViewerTemplate}">
                     <Grid Grid.IsSharedSizeScope="True">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />

--- a/Views/AchievementViewer.xaml
+++ b/Views/AchievementViewer.xaml
@@ -8,7 +8,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <DataTemplate DataType="{x:Type vm:AchievementViewModel}">
-        <Border Background="White" BorderBrush="Black" BorderThickness="1">
+        <Border Style="{StaticResource editorBorder}">
             <Grid VerticalAlignment="Stretch">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -92,9 +92,7 @@
     </DataTemplate>
 
     <DataTemplate DataType="{x:Type vm:GeneratedAchievementViewModel}">
-        <Border Background="{Binding DataContext.Script.Editor.Resources.Background.Brush, ElementName=gameGrid}" 
-                BorderBrush="{Binding DataContext.Script.Editor.Resources.LineNumber.Brush, ElementName=gameGrid}" 
-                BorderThickness="1">
+        <Border Style="{StaticResource editorBorder}">
             <Grid VerticalAlignment="Stretch">
                 <Grid.Resources>
                     <TextBlock x:Key="modifiedTitleToolTip">

--- a/Views/Common.xaml
+++ b/Views/Common.xaml
@@ -12,4 +12,21 @@
         <Setter Property="BorderBrush" Value="{Binding DataContext.Script.Editor.Resources.LineNumber.Brush, ElementName=gameGrid}" />
         <Setter Property="BorderThickness" Value="1" />
     </Style>
+
+    <Style TargetType="{x:Type TextBlock}" x:Key="editorTitle" BasedOn="{StaticResource themedTextBlock}">
+        <Setter Property="FontSize" Value="18" />
+        <Setter Property="FontWeight" Value="DemiBold" />
+        <Setter Property="Margin" Value="2,0,0,0" />
+    </Style>
+
+    <Style TargetType="{x:Type TextBlock}" x:Key="editorSubtitle" BasedOn="{StaticResource themedTextBlock}">
+        <Setter Property="FontSize" Value="10" />
+        <Setter Property="Margin" Value="6,0,2,0" />
+        <Setter Property="VerticalAlignment" Value="Top" />
+    </Style>
+
+    <Style TargetType="{x:Type TextBlock}" x:Key="notesTextBlock" BasedOn="{StaticResource themedTextBlock}">
+        <Setter Property="FontStyle" Value="Italic" />
+        <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
 </ResourceDictionary>

--- a/Views/Common.xaml
+++ b/Views/Common.xaml
@@ -2,4 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <SolidColorBrush x:Key="newValueColor" Color="#00D040" />
     <SolidColorBrush x:Key="oldValueColor" Color="#E04040" />
+
+    <Style TargetType="{x:Type TextBlock}" x:Key="themedTextBlock">
+        <Setter Property="Foreground" Value="{Binding DataContext.Script.Editor.Resources.Foreground.Brush, ElementName=gameGrid}" />
+    </Style>
 </ResourceDictionary>

--- a/Views/Common.xaml
+++ b/Views/Common.xaml
@@ -1,8 +1,5 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <SolidColorBrush x:Key="newValueColor" Color="#00D040" />
-    <SolidColorBrush x:Key="oldValueColor" Color="#E04040" />
-
     <Style TargetType="{x:Type TextBlock}" x:Key="themedTextBlock">
         <Setter Property="Foreground" Value="{Binding DataContext.Script.Editor.Resources.Foreground.Brush, ElementName=gameGrid}" />
     </Style>

--- a/Views/Common.xaml
+++ b/Views/Common.xaml
@@ -26,4 +26,191 @@
         <Setter Property="FontStyle" Value="Italic" />
         <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
+
+    <!-- http://msdn2.microsoft.com/en-us/library/ms742173(VS.85).aspx -->
+    <Style x:Key="themedScrollBarLineButton" TargetType="{x:Type RepeatButton}">
+        <Setter Property="SnapsToDevicePixels" Value="true" />
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="Focusable" Value="false" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type RepeatButton}">
+                    <Border x:Name="Border" Margin="1" CornerRadius="2" 
+                            Background="{TemplateBinding Background}"
+                            BorderThickness="1" BorderBrush="{TemplateBinding BorderBrush}">
+                        <Path x:Name="Arrow" HorizontalAlignment="Center" VerticalAlignment="Center" 
+                              Data="{Binding Content, RelativeSource={RelativeSource TemplatedParent}}"
+                              Fill="{TemplateBinding Foreground}" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
+    <Style x:Key="themedScrollBarPageButton" TargetType="{x:Type RepeatButton}">
+        <Setter Property="SnapsToDevicePixels" Value="true" />
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="IsTabStop" Value="false" />
+        <Setter Property="Focusable" Value="false" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type RepeatButton}">
+                    <Border Background="Transparent" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
+    <Style x:Key="themedScrollBarThumb" TargetType="{x:Type Thumb}">
+        <Setter Property="SnapsToDevicePixels" Value="true" />
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="IsTabStop" Value="false" />
+        <Setter Property="Focusable" Value="false" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Thumb}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="0" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <ControlTemplate x:Key="themedVerticalScrollBar" TargetType="{x:Type ScrollBar}">
+        <Grid>
+            <Grid.Resources>
+                <SolidColorBrush x:Key="ForegroundBrush" Color="{Binding DataContext.Resources.ScrollBarForegroundBrush.Color, ElementName=gameGrid}" />
+                <SolidColorBrush x:Key="BackgroundBrush" Color="{Binding DataContext.Resources.ScrollBarBackgroundBrush.Color, ElementName=gameGrid}" />
+            </Grid.Resources>
+            <Grid.RowDefinitions>
+                <RowDefinition MaxHeight="15" />
+                <RowDefinition Height="0.00001*" />
+                <RowDefinition MaxHeight="16" />
+            </Grid.RowDefinitions>
+            <Border Grid.RowSpan="3" Background="{StaticResource BackgroundBrush}" />
+            <RepeatButton Grid.Row="0" Style="{StaticResource themedScrollBarLineButton}"
+                          Foreground="{StaticResource ForegroundBrush}"
+                          Height="16" Command="ScrollBar.LineUpCommand"
+                          Content="M 0 4 L 8 4 L 4 0 Z" />
+            <Track Grid.Row="1" x:Name="PART_Track" IsDirectionReversed="true">
+                <Track.DecreaseRepeatButton>
+                    <RepeatButton Style="{StaticResource themedScrollBarPageButton}"
+                                  Command="ScrollBar.PageUpCommand" />
+                </Track.DecreaseRepeatButton>
+                <Track.Thumb>
+                    <Thumb Style="{StaticResource themedScrollBarThumb}" 
+                           Margin="3,0,3,0" Background="{StaticResource ForegroundBrush}"
+                           BorderBrush="{StaticResource ForegroundBrush}" />
+                </Track.Thumb>
+                <Track.IncreaseRepeatButton>
+                    <RepeatButton Style="{StaticResource themedScrollBarPageButton}"
+                                  Command="ScrollBar.PageDownCommand" />
+                </Track.IncreaseRepeatButton>
+            </Track>
+            <RepeatButton Grid.Row="2" Style="{StaticResource themedScrollBarLineButton}"
+                          Foreground="{StaticResource ForegroundBrush}"
+                          Height="16" Command="ScrollBar.LineDownCommand"
+                          Content="M 0 0 L 4 4 L 8 0 Z" />
+        </Grid>
+    </ControlTemplate>
+    
+    <ControlTemplate x:Key="themedHorizontalScrollBar" TargetType="{x:Type ScrollBar}">
+        <Grid>
+            <Grid.Resources>
+                <SolidColorBrush x:Key="ForegroundBrush" Color="{Binding DataContext.Resources.ScrollBarForegroundBrush.Color, ElementName=gameGrid}" />
+                <SolidColorBrush x:Key="BackgroundBrush" Color="{Binding DataContext.Resources.ScrollBarBackgroundBrush.Color, ElementName=gameGrid}" />
+            </Grid.Resources>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition MaxWidth="18"/>
+                <ColumnDefinition Width="0.00001*"/>
+                <ColumnDefinition MaxWidth="18"/>
+            </Grid.ColumnDefinitions>
+            <Border Grid.ColumnSpan="3" Background="{StaticResource BackgroundBrush}" />
+            <RepeatButton Grid.Column="0" Style="{StaticResource themedScrollBarLineButton}"
+                          Foreground="{StaticResource ForegroundBrush}"
+                          Width="18" Command="ScrollBar.LineLeftCommand"
+                          Content="M 4 0 L 4 8 L 0 4 Z" />
+            <Track Grid.Column="1" Name="PART_Track" IsDirectionReversed="False">
+                <Track.DecreaseRepeatButton>
+                    <RepeatButton Style="{StaticResource themedScrollBarPageButton}"
+                                  Command="ScrollBar.PageLeftCommand" />
+                </Track.DecreaseRepeatButton>
+                <Track.Thumb>
+                    <Thumb Style="{StaticResource themedScrollBarThumb}" 
+                           Margin="0,3,0,3" Background="{StaticResource ForegroundBrush}"
+                           BorderBrush="{StaticResource ForegroundBrush}" />
+                </Track.Thumb>
+                <Track.IncreaseRepeatButton>
+                    <RepeatButton Style="{StaticResource themedScrollBarPageButton}"
+                                  Command="ScrollBar.PageRightCommand" />
+                </Track.IncreaseRepeatButton>
+            </Track>
+            <RepeatButton Grid.Column="2" Style="{StaticResource themedScrollBarLineButton}"
+                          Foreground="{StaticResource ForegroundBrush}"
+                          Width="18" Command="ScrollBar.LineRightCommand"
+                          Content="M 0 0 L 4 4 L 0 8 Z"/>
+        </Grid>
+    </ControlTemplate>
+
+    <!-- http://msdn2.microsoft.com/en-us/library/aa970847(VS.85).aspx -->
+    <Style TargetType="{x:Type ScrollViewer}" x:Key="themedScrollViewer">
+        <Setter Property="OverridesDefaultStyle" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <ScrollContentPresenter />
+
+                        <ScrollBar Name="PART_VerticalScrollBar"
+                                   Grid.Column="1"
+                                   Template="{StaticResource themedVerticalScrollBar}"
+                                   Value="{TemplateBinding VerticalOffset}"
+                                   Maximum="{TemplateBinding ScrollableHeight}"
+                                   ViewportSize="{TemplateBinding ViewportHeight}"
+                                   Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}" />
+                        <ScrollBar Name="PART_HorizontalScrollBar"
+                                   Orientation="Horizontal"
+                                   Grid.Row="1"
+                                   Template="{StaticResource themedHorizontalScrollBar}"
+                                   Value="{TemplateBinding HorizontalOffset}"
+                                   Maximum="{TemplateBinding ScrollableWidth}"
+                                   ViewportSize="{TemplateBinding ViewportWidth}"
+                                   Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" />
+                        <Border Grid.Row="1" Grid.Column="1" Background="{Binding DataContext.Resources.ScrollBarBackgroundBrush, ElementName=gameGrid}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type ListBox}" x:Key="themedListBox">
+        <Setter Property="Background" Value="{Binding DataContext.Script.Editor.Resources.Background.Brush, ElementName=gameGrid}" />
+        <Setter Property="Foreground" Value="{Binding DataContext.Script.Editor.Resources.Foreground.Brush, ElementName=gameGrid}" />
+        <Setter Property="BorderBrush" Value="{Binding DataContext.Script.Editor.Resources.LineNumber.Brush, ElementName=gameGrid}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ListBox}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            BorderBrush="{TemplateBinding BorderBrush}">
+                        <ScrollViewer x:Name="ScrollViewer" 
+                                      Foreground="{TemplateBinding Foreground}"
+                                      Style="{StaticResource themedScrollViewer}">
+                            <ItemsPresenter />
+                        </ScrollViewer>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/Views/Common.xaml
+++ b/Views/Common.xaml
@@ -77,7 +77,7 @@
         </Setter>
     </Style>
 
-    <ControlTemplate x:Key="themedVerticalScrollBar" TargetType="{x:Type ScrollBar}">
+    <ControlTemplate x:Key="themedVerticalScrollBarTemplate" TargetType="{x:Type ScrollBar}">
         <Grid>
             <Grid.Resources>
                 <SolidColorBrush x:Key="ForegroundBrush" Color="{Binding DataContext.Resources.ScrollBarForegroundBrush.Color, ElementName=gameGrid}" />
@@ -115,7 +115,7 @@
         </Grid>
     </ControlTemplate>
     
-    <ControlTemplate x:Key="themedHorizontalScrollBar" TargetType="{x:Type ScrollBar}">
+    <ControlTemplate x:Key="themedHorizontalScrollBarTemplate" TargetType="{x:Type ScrollBar}">
         <Grid>
             <Grid.Resources>
                 <SolidColorBrush x:Key="ForegroundBrush" Color="{Binding DataContext.Resources.ScrollBarForegroundBrush.Color, ElementName=gameGrid}" />
@@ -154,44 +154,37 @@
     </ControlTemplate>
 
     <!-- http://msdn2.microsoft.com/en-us/library/aa970847(VS.85).aspx -->
-    <Style TargetType="{x:Type ScrollViewer}" x:Key="themedScrollViewer">
-        <Setter Property="OverridesDefaultStyle" Value="True"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ScrollViewer}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
+    <ControlTemplate x:Key="themedScrollViewerTemplate" TargetType="{x:Type ScrollViewer}">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
 
-                        <ScrollContentPresenter />
+            <ScrollContentPresenter CanContentScroll="{TemplateBinding CanContentScroll}" />
 
-                        <ScrollBar Name="PART_VerticalScrollBar"
-                                   Grid.Column="1"
-                                   Template="{StaticResource themedVerticalScrollBar}"
-                                   Value="{TemplateBinding VerticalOffset}"
-                                   Maximum="{TemplateBinding ScrollableHeight}"
-                                   ViewportSize="{TemplateBinding ViewportHeight}"
-                                   Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}" />
-                        <ScrollBar Name="PART_HorizontalScrollBar"
-                                   Orientation="Horizontal"
-                                   Grid.Row="1"
-                                   Template="{StaticResource themedHorizontalScrollBar}"
-                                   Value="{TemplateBinding HorizontalOffset}"
-                                   Maximum="{TemplateBinding ScrollableWidth}"
-                                   ViewportSize="{TemplateBinding ViewportWidth}"
-                                   Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" />
-                        <Border Grid.Row="1" Grid.Column="1" Background="{Binding DataContext.Resources.ScrollBarBackgroundBrush, ElementName=gameGrid}" />
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+            <ScrollBar Name="PART_VerticalScrollBar"
+                       Grid.Column="1"
+                       Template="{StaticResource themedVerticalScrollBarTemplate}"
+                       Value="{TemplateBinding VerticalOffset}"
+                       Maximum="{TemplateBinding ScrollableHeight}"
+                       ViewportSize="{TemplateBinding ViewportHeight}"
+                       Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}" />
+            <ScrollBar Name="PART_HorizontalScrollBar"
+                       Orientation="Horizontal"
+                       Grid.Row="1"
+                       Template="{StaticResource themedHorizontalScrollBarTemplate}"
+                       Value="{TemplateBinding HorizontalOffset}"
+                       Maximum="{TemplateBinding ScrollableWidth}"
+                       ViewportSize="{TemplateBinding ViewportWidth}"
+                       Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" />
+            <Border Grid.Row="1" Grid.Column="1" Background="{Binding DataContext.Resources.ScrollBarBackgroundBrush, ElementName=gameGrid}" />
+        </Grid>
+    </ControlTemplate>
 
     <Style TargetType="{x:Type ListBox}" x:Key="themedListBox">
         <Setter Property="Background" Value="{Binding DataContext.Script.Editor.Resources.Background.Brush, ElementName=gameGrid}" />
@@ -205,7 +198,81 @@
                             BorderBrush="{TemplateBinding BorderBrush}">
                         <ScrollViewer x:Name="ScrollViewer" 
                                       Foreground="{TemplateBinding Foreground}"
-                                      Style="{StaticResource themedScrollViewer}">
+                                      Template="{StaticResource themedScrollViewerTemplate}">
+                            <ItemsPresenter />
+                        </ScrollViewer>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type ListBox}" x:Key="themedListView">
+        <Setter Property="Background" Value="{Binding DataContext.Script.Editor.Resources.Background.Brush, ElementName=gameGrid}" />
+        <Setter Property="Foreground" Value="{Binding DataContext.Script.Editor.Resources.Foreground.Brush, ElementName=gameGrid}" />
+        <Setter Property="BorderBrush" Value="{Binding DataContext.Script.Editor.Resources.LineNumber.Brush, ElementName=gameGrid}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ListView}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            BorderBrush="{TemplateBinding BorderBrush}">
+                        <ScrollViewer x:Name="ScrollViewer" 
+                                      Foreground="{TemplateBinding Foreground}"
+                                      Style="{DynamicResource {x:Static GridView.GridViewScrollViewerStyleKey}}">
+                            <ScrollViewer.Template>
+                                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <DockPanel Margin="{TemplateBinding Control.Padding}">
+                                            <ScrollViewer DockPanel.Dock="Top" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" Focusable="false">
+                                                <GridViewHeaderRowPresenter Margin="2,0,2,0" SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}"
+                                                                            ColumnHeaderContainerStyle="{Binding Path=TemplatedParent.View.ColumnHeaderContainerStyle, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                            ColumnHeaderTemplate="{Binding Path=TemplatedParent.View.ColumnHeaderTemplate, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                            ColumnHeaderTemplateSelector="{Binding Path=TemplatedParent.View.ColumnHeaderTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                            ColumnHeaderStringFormat="{Binding Path=TemplatedParent.View.ColumnHeaderStringFormat, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                            AllowsColumnReorder="{Binding Path=TemplatedParent.View.AllowsColumnReorder, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                            ColumnHeaderContextMenu="{Binding Path=TemplatedParent.View.ColumnHeaderContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                            ColumnHeaderToolTip="{Binding Path=TemplatedParent.View.ColumnHeaderToolTip, RelativeSource={RelativeSource TemplatedParent}}">
+                                                    <GridViewRowPresenterBase.Columns>
+                                                        <Binding Path="TemplatedParent.View.Columns" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                                    </GridViewRowPresenterBase.Columns>
+                                                </GridViewHeaderRowPresenter>
+                                            </ScrollViewer>
+                                            <ScrollContentPresenter Name="PART_ScrollContentPresenter" KeyboardNavigation.DirectionalNavigation="Local"
+                                                                    Content="{TemplateBinding ContentControl.Content}"
+                                                                    ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}"
+                                                                    CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                                                                    SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}"/>
+                                        </DockPanel>
+
+                                        <ScrollBar Name="PART_VerticalScrollBar"
+                                                   Grid.Column="1"
+                                                   Template="{StaticResource themedVerticalScrollBarTemplate}"
+                                                   Value="{TemplateBinding VerticalOffset}"
+                                                   Maximum="{TemplateBinding ScrollableHeight}"
+                                                   ViewportSize="{TemplateBinding ViewportHeight}"
+                                                   Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}" />
+                                        <ScrollBar Name="PART_HorizontalScrollBar"
+                                                   Orientation="Horizontal"
+                                                   Grid.Row="1"
+                                                   Template="{StaticResource themedHorizontalScrollBarTemplate}"
+                                                   Value="{TemplateBinding HorizontalOffset}"
+                                                   Maximum="{TemplateBinding ScrollableWidth}"
+                                                   ViewportSize="{TemplateBinding ViewportWidth}"
+                                                   Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" />
+                                        <Border Grid.Row="1" Grid.Column="1" Background="{Binding DataContext.Resources.ScrollBarBackgroundBrush, ElementName=gameGrid}" />
+                                    </Grid>
+                                </ControlTemplate>
+                            </ScrollViewer.Template>
                             <ItemsPresenter />
                         </ScrollViewer>
                     </Border>

--- a/Views/Common.xaml
+++ b/Views/Common.xaml
@@ -6,4 +6,10 @@
     <Style TargetType="{x:Type TextBlock}" x:Key="themedTextBlock">
         <Setter Property="Foreground" Value="{Binding DataContext.Script.Editor.Resources.Foreground.Brush, ElementName=gameGrid}" />
     </Style>
+
+    <Style TargetType="{x:Type Border}" x:Key="editorBorder">
+        <Setter Property="Background" Value="{Binding DataContext.Script.Editor.Resources.Background.Brush, ElementName=gameGrid}" />
+        <Setter Property="BorderBrush" Value="{Binding DataContext.Script.Editor.Resources.LineNumber.Brush, ElementName=gameGrid}" />
+        <Setter Property="BorderThickness" Value="1" />
+    </Style>
 </ResourceDictionary>

--- a/Views/GameViewer.xaml
+++ b/Views/GameViewer.xaml
@@ -9,7 +9,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <DataTemplate x:Key="editorRowTemplate">
-        <Grid HorizontalAlignment="Left" Width="{Binding ActualWidth, ElementName=maxAchievementRowWidth}" Height="13" Margin="-2,0,0,0">
+        <Grid HorizontalAlignment="Left" Width="{Binding ActualWidth, ElementName=maxAchievementRowWidth}" Height="13" Margin="-1,0,0,0">
             <Grid.Resources>
                 <ContextMenu x:Key="updateLocalContextMenu" DataContext="{Binding PlacementTarget, RelativeSource={RelativeSource Self}}">
                     <MenuItem Header="Update Local" Command="{Binding DataContext.UpdateLocalCommand}" />
@@ -42,7 +42,7 @@
                 <ColumnDefinition Width="30" />
             </Grid.ColumnDefinitions>
 
-            <!-- Modified -->
+            <!-- Modified (explicitly gray to match images) -->
             <TextBlock FontSize="10" VerticalAlignment="Center" Foreground="Gray" 
                        ToolTip="{Binding ModificationMessage}" Margin="-2,-2,0,0">
                 <TextBlock.Style>
@@ -117,12 +117,22 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <Grid Margin="4" Background="Red" x:Name="maxAchievementRowWidth" Height="10" />
+                <Grid Margin="6" Background="Red" x:Name="maxAchievementRowWidth" Height="10" />
                 <ScrollBar Grid.Column="2" Orientation="Vertical" />
             </Grid>
 
             <ListBox ItemsSource="{Binding Editors}" SelectedItem="{Binding SelectedEditor}" HorizontalContentAlignment="Stretch"
-                     ItemTemplate="{StaticResource editorRowTemplate}" x:Name="achievementsGrid" BorderBrush="#808080" />
+                     ItemTemplate="{StaticResource editorRowTemplate}" x:Name="achievementsGrid" BorderBrush="#808080" 
+                     ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+                     Background="{Binding Script.Editor.Resources.Background.Brush}"
+                     Foreground="{Binding Script.Editor.Resources.Foreground.Brush}">
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="ListBoxItem">
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="Margin" Value="1" />
+                    </Style>
+                </ListBox.ItemContainerStyle>
+            </ListBox>
 
             <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" ResizeDirection="Columns" />
 

--- a/Views/GameViewer.xaml
+++ b/Views/GameViewer.xaml
@@ -100,7 +100,7 @@
     </DataTemplate>
 
     <DataTemplate DataType="{x:Type vm:GameViewModel}">
-        <Grid Background="#F0F0F0">
+        <Grid Background="#F0F0F0" x:Name="gameGrid">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="238" MinWidth="128" MaxWidth="400" />
                 <ColumnDefinition Width="4" />
@@ -122,7 +122,7 @@
             </Grid>
 
             <ListBox ItemsSource="{Binding Editors}" SelectedItem="{Binding SelectedEditor}" HorizontalContentAlignment="Stretch"
-                     ItemTemplate="{StaticResource editorRowTemplate}" x:Name="achievementsGrid" BorderBrush="#808080" 
+                     ItemTemplate="{StaticResource editorRowTemplate}" x:Name="achievementsList" BorderBrush="#808080" 
                      ScrollViewer.HorizontalScrollBarVisibility="Hidden"
                      Background="{Binding Script.Editor.Resources.Background.Brush}"
                      Foreground="{Binding Script.Editor.Resources.Foreground.Brush}">

--- a/Views/GameViewer.xaml
+++ b/Views/GameViewer.xaml
@@ -122,10 +122,9 @@
             </Grid>
 
             <ListBox ItemsSource="{Binding Editors}" SelectedItem="{Binding SelectedEditor}" HorizontalContentAlignment="Stretch"
-                     ItemTemplate="{StaticResource editorRowTemplate}" x:Name="achievementsList" BorderBrush="#808080" 
+                     ItemTemplate="{StaticResource editorRowTemplate}" x:Name="achievementsList" 
                      ScrollViewer.HorizontalScrollBarVisibility="Hidden"
-                     Background="{Binding Script.Editor.Resources.Background.Brush}"
-                     Foreground="{Binding Script.Editor.Resources.Foreground.Brush}">
+                     Style="{StaticResource themedListBox}">
                 <ListBox.ItemContainerStyle>
                     <Style TargetType="ListBoxItem">
                         <Setter Property="BorderThickness" Value="0" />

--- a/Views/LeaderboardViewer.xaml
+++ b/Views/LeaderboardViewer.xaml
@@ -4,11 +4,12 @@
                     xmlns:views="clr-namespace:RATools.Views">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Jamiras.Core;component/Controls/Styles/SubtleHyperlink.xaml" />
+        <ResourceDictionary Source="Common.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <DataTemplate DataType="{x:Type vm:LeaderboardViewModel}">
-        <Border BorderThickness="1" BorderBrush="Gray">
-            <Grid Background="White">
+        <Border Style="{StaticResource editorBorder}">
+            <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -22,8 +23,9 @@
 
                 <Image Width="48" Height="48" Grid.RowSpan="2" Source="/RATools;component/Resources/leaderboard.png" Margin="4,2,2,2" />
 
-                <TextBlock Grid.Column="1" FontSize="18" FontWeight="DemiBold" Text="{Binding Title}" Margin="2,0,0,0" />
-                <TextBlock Grid.Column="1" Grid.Row="1" Margin="6,2,2,2" Text="{Binding Description}" VerticalAlignment="Top" />
+                <TextBlock Grid.Column="1" Text="{Binding Title}" Style="{StaticResource editorTitle}" />
+                <TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding Description}" FontSize="12"
+                           Style="{StaticResource editorSubtitle}" />
 
                 <TextBlock Grid.Row="2" Margin="4,0,0,2" VerticalAlignment="Bottom" FontSize="10">
                     <TextBlock.Style>
@@ -58,7 +60,7 @@
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="{Binding Label}" Margin="4,4,0,0" FontWeight="DemiBold" VerticalAlignment="Bottom">
                                             <TextBlock.Style>
-                                                <Style TargetType="{x:Type TextBlock}">
+                                                <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                                     <Setter Property="FontSize" Value="16" />
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding CopyToClipboardCommand}" Value="{x:Null}">
@@ -70,7 +72,7 @@
                                         </TextBlock>
                                         <TextBlock FontSize="10" VerticalAlignment="Bottom" Margin="8,0,0,2">
                                             <TextBlock.Style>
-                                                <Style TargetType="{x:Type TextBlock}">
+                                                <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding CopyToClipboardCommand}" Value="{x:Null}">
                                                             <Setter Property="Visibility" Value="Collapsed" />
@@ -91,8 +93,8 @@
                                                         <ColumnDefinition Width="Auto" MinWidth="200" SharedSizeGroup="definition" />
                                                         <ColumnDefinition Width="*" />
                                                     </Grid.ColumnDefinitions>
-                                                    <TextBlock Text="{Binding Definition}" Margin="0,0,8,0" />
-                                                    <TextBlock Grid.Column="1" Text="{Binding Notes}" TextWrapping="Wrap" FontStyle="Italic" />
+                                                    <TextBlock Text="{Binding Definition}" Margin="0,0,8,0" Style="{StaticResource themedTextBlock}" />
+                                                    <TextBlock Grid.Column="1" Text="{Binding Notes}" Style="{StaticResource notesTextBlock}" />
                                                 </Grid>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>

--- a/Views/LeaderboardViewer.xaml
+++ b/Views/LeaderboardViewer.xaml
@@ -43,7 +43,8 @@
                     </Hyperlink>
                 </TextBlock>
                 
-                <ScrollViewer Grid.Row="3" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto">
+                <ScrollViewer Grid.Row="3" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto"
+                              Template="{StaticResource themedScrollViewerTemplate}">
                     <ItemsControl ItemsSource="{Binding Groups}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>

--- a/Views/OptionsDialog.xaml
+++ b/Views/OptionsDialog.xaml
@@ -4,8 +4,9 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:RATools"
+             xmlns:jamiras="clr-namespace:Jamiras.Controls;assembly=Jamiras.Core"
              mc:Ignorable="d" 
-             Width="600" Height="290">
+             Width="600" Height="312">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -13,74 +14,99 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Grid Margin="4">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-
-        <GroupBox Header="User Name">
-            <StackPanel>
-                <TextBlock Margin="2" FontSize="11" Text="Please enter your RetroAchievements.org user name here." />
-                <TextBox Text="{Binding UserName.Text}" Margin="2" MaxLength="{Binding UserName.MaxLength}" />
-            </StackPanel>
-        </GroupBox>
-
-        <GroupBox Grid.Row="1" Header="Emulator Directories">
-            <Grid>
+    <TabControl Margin="4,0,4,0">
+        <TabItem Header="General">
+            <Grid Margin="4">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-                <TextBlock TextWrapping="Wrap" FontSize="11" Margin="2"
-                           Text="Specifies the directories where RetroAchievements emulators are installed. Code notes are loaded from the emulator cache directories." />
-                <ListView Grid.Row="1" Margin="0,2,0,2" x:Name="directoriesList"
-                          ItemsSource="{Binding Directories}" SelectedItem="{Binding SelectedDirectory}">
+                <GroupBox Header="User Name">
+                    <StackPanel>
+                        <TextBlock Margin="2" FontSize="11" Text="Please enter your RetroAchievements.org user name here." />
+                        <TextBox Text="{Binding UserName.Text}" Margin="2" MaxLength="{Binding UserName.MaxLength}" />
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox Grid.Row="1" Header="Emulator Directories">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock TextWrapping="Wrap" FontSize="11" Margin="2"
+                                   Text="Specifies the directories where RetroAchievements emulators are installed. Code notes are loaded from the emulator cache directories." />
+                        <ListView Grid.Row="1" Margin="0,2,0,2" x:Name="directoriesList"
+                                  ItemsSource="{Binding Directories}" SelectedItem="{Binding SelectedDirectory}">
+                            <ListView.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="12" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10">
+                                            <TextBlock.Style>
+                                                <Style TargetType="{x:Type TextBlock}">
+                                                    <Setter Property="Foreground" Value="#00D040" />
+                                                    <Setter Property="Text" Value="&#10003;" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsValid}" Value="false">
+                                                            <Setter Property="Foreground" Value="#E04040" />
+                                                            <Setter Property="Text" Value="&#10008;" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                        <TextBlock Grid.Column="1" FontSize="11" Text="{Binding Path}" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+
+                        <Button Grid.Row="2" HorizontalAlignment="Left" Width="80" 
+                                Content="Remove" Command="{Binding RemoveDirectoryCommand}">
+                            <Button.Style>
+                                <Style TargetType="{x:Type Button}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding SelectedDirectory}" Value="{x:Null}">
+                                            <Setter Property="IsEnabled" Value="False" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                        </Button>
+
+                        <Button Grid.Row="2" HorizontalAlignment="Right" Width="80" 
+                                Content="Add" Command="{Binding AddDirectoryCommand}" />
+                    </Grid>
+                </GroupBox>
+            </Grid>
+        </TabItem>
+        <TabItem Header="Colors">
+            <Grid Margin="4">
+                <ListView Margin="0,2,0,2" x:Name="colorsList" ItemsSource="{Binding Colors}">
                     <ListView.ItemTemplate>
                         <DataTemplate>
-                            <Grid>
+                            <Grid jamiras:CommandBinding.DoubleClickCommand="{Binding ChangeColorCommand}">
+                                <Grid.Resources>
+                                    <SolidColorBrush x:Key="ColorBrush" Color="{Binding Color}" />
+                                </Grid.Resources>
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="12" />
+                                    <ColumnDefinition Width="20" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10">
-                                    <TextBlock.Style>
-                                        <Style TargetType="{x:Type TextBlock}">
-                                            <Setter Property="Foreground" Value="#00D040" />
-                                            <Setter Property="Text" Value="&#10003;" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsValid}" Value="false">
-                                                    <Setter Property="Foreground" Value="#E04040" />
-                                                    <Setter Property="Text" Value="&#10008;" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                                <TextBlock Grid.Column="1" FontSize="11" Text="{Binding Path}" />
+                                <Border Margin="2" Background="{StaticResource ColorBrush}" />
+                                <TextBlock Grid.Column="1" FontSize="11" Text="{Binding Label}" />
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>
                 </ListView>
-
-                <Button Grid.Row="2" HorizontalAlignment="Left" Width="80" 
-                        Content="Remove" Command="{Binding RemoveDirectoryCommand}">
-                    <Button.Style>
-                        <Style TargetType="{x:Type Button}">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding SelectedDirectory}" Value="{x:Null}">
-                                    <Setter Property="IsEnabled" Value="False" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Button.Style>
-                </Button>
-
-                <Button Grid.Row="2" HorizontalAlignment="Right" Width="80" 
-                        Content="Add" Command="{Binding AddDirectoryCommand}" />
             </Grid>
-        </GroupBox>
-    </Grid>
+        </TabItem>
+    </TabControl>
 </UserControl>

--- a/Views/OptionsDialog.xaml
+++ b/Views/OptionsDialog.xaml
@@ -90,6 +90,7 @@
         <TabItem Header="Colors">
             <Grid Margin="4">
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
@@ -100,7 +101,8 @@
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <ListView Grid.ColumnSpan="5" Margin="0,2,0,2" x:Name="colorsList" ItemsSource="{Binding Colors}">
+                <TextBlock Grid.ColumnSpan="5" Text="Double click on an entry to change it." />
+                <ListView Grid.Row="1" Grid.ColumnSpan="5" Margin="0,2,0,2" x:Name="colorsList" ItemsSource="{Binding Colors}">
                     <ListView.ItemTemplate>
                         <DataTemplate>
                             <Grid jamiras:CommandBinding.DoubleClickCommand="{Binding ChangeColorCommand}">
@@ -121,6 +123,10 @@
                         Content="Default Theme" Command="{Binding DefaultColorsCommand}" />
                 <Button Grid.Row="2" Grid.Column="1" Margin="2,0,2,0" Width="100"
                         Content="Dark Theme" Command="{Binding DarkColorsCommand}" />
+                <Button Grid.Row="2" Grid.Column="3" Margin="0,0,2,0" Width="100"
+                        Content="Import..." Command="{Binding ImportColorsCommand}" />
+                <Button Grid.Row="2" Grid.Column="4" Margin="2,0,2,0" Width="100"
+                        Content="Export..." Command="{Binding ExportColorsCommand}" />
             </Grid>
         </TabItem>
     </TabControl>

--- a/Views/OptionsDialog.xaml
+++ b/Views/OptionsDialog.xaml
@@ -89,7 +89,18 @@
         </TabItem>
         <TabItem Header="Colors">
             <Grid Margin="4">
-                <ListView Margin="0,2,0,2" x:Name="colorsList" ItemsSource="{Binding Colors}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <ListView Grid.ColumnSpan="5" Margin="0,2,0,2" x:Name="colorsList" ItemsSource="{Binding Colors}">
                     <ListView.ItemTemplate>
                         <DataTemplate>
                             <Grid jamiras:CommandBinding.DoubleClickCommand="{Binding ChangeColorCommand}">
@@ -106,6 +117,10 @@
                         </DataTemplate>
                     </ListView.ItemTemplate>
                 </ListView>
+                <Button Grid.Row="2" Grid.Column="0" Margin="0,0,2,0" Width="100"
+                        Content="Default Theme" Command="{Binding DefaultColorsCommand}" />
+                <Button Grid.Row="2" Grid.Column="1" Margin="2,0,2,0" Width="100"
+                        Content="Dark Theme" Command="{Binding DarkColorsCommand}" />
             </Grid>
         </TabItem>
     </TabControl>

--- a/Views/RichPresenceViewer.xaml
+++ b/Views/RichPresenceViewer.xaml
@@ -36,7 +36,8 @@
                     </Hyperlink>
                 </TextBlock>
 
-                <ScrollViewer Grid.Row="4" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto" HorizontalContentAlignment="Stretch" Margin="4,0,0,0">
+                <ScrollViewer Grid.Row="4" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto" HorizontalContentAlignment="Stretch" Margin="4,0,0,0"
+                              Template="{StaticResource themedScrollViewerTemplate}">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />

--- a/Views/RichPresenceViewer.xaml
+++ b/Views/RichPresenceViewer.xaml
@@ -8,8 +8,8 @@
     </ResourceDictionary.MergedDictionaries>
 
     <DataTemplate DataType="{x:Type vm:RichPresenceViewModel}">
-        <Border BorderThickness="1" BorderBrush="Gray">
-            <Grid Background="White">
+        <Border Style="{StaticResource editorBorder}">
+            <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -22,8 +22,8 @@
                 </Grid.ColumnDefinitions>
 
                 <Image Width="48" Height="48" Grid.RowSpan="3" Source="/RATools;component/Resources/rich_presence.png" Margin="4,2,2,2" />
-                <TextBlock Grid.Column="1" FontSize="18" FontWeight="DemiBold" Text="Rich Presence" />
-                <TextBlock Grid.Column="1" Grid.Row="1" FontSize="10" VerticalAlignment="Top" Margin="8,4,0,0">
+                <TextBlock Grid.Column="1" FontSize="18" FontWeight="DemiBold" Text="Rich Presence" Style="{StaticResource themedTextBlock}" />
+                <TextBlock Grid.Column="1" Grid.Row="1" FontSize="10" VerticalAlignment="Top" Margin="8,4,0,0" Style="{StaticResource themedTextBlock}">
                     <TextBlock Text="{Binding RichPresenceLength}" />
                     <TextBlock Text="/" />
                     <TextBlock Text="{Binding RichPresenceMaxLength}" />
@@ -47,7 +47,7 @@
                         </Grid.ColumnDefinitions>
 
 
-                        <TextBlock Grid.Column="0" Margin="0,0,0,6" VerticalAlignment="Bottom">
+                        <TextBlock Grid.Column="0" Margin="0,0,0,6" VerticalAlignment="Bottom" Style="{StaticResource themedTextBlock}">
                             <TextBlock FontSize="12" FontStyle="Italic"  Text="{Binding GeneratedSource}" />
                             <TextBlock FontSize="10">
                                 <TextBlock.Style>
@@ -65,7 +65,8 @@
                                 </Hyperlink>
                             </TextBlock>
                         </TextBlock>
-                        <TextBlock Grid.Column="1" Margin="0,0,0,6" FontSize="12" FontStyle="Italic" VerticalAlignment="Bottom" Text="{Binding CompareSource}" />
+                        <TextBlock Grid.Column="1" Margin="0,0,0,6" FontSize="12" FontStyle="Italic" VerticalAlignment="Bottom"
+                                   Text="{Binding CompareSource}" Style="{StaticResource themedTextBlock}" />
 
                         <ItemsControl Grid.Row="1" Grid.ColumnSpan="2" ItemsSource="{Binding Lines}" HorizontalAlignment="Stretch">
                             <ItemsControl.Resources>
@@ -77,7 +78,7 @@
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Text="{Binding Generated}" TextWrapping="Wrap" Margin="0,0,4,0">
                                             <TextBlock.Style>
-                                                <Style TargetType="{x:Type TextBlock}">
+                                                <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding IsModified}" Value="True">
                                                             <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
@@ -88,7 +89,7 @@
                                         </TextBlock>
                                         <TextBlock Grid.Column="1" Text="{Binding Current}" TextWrapping="Wrap" Margin="4,0,8,0">
                                             <TextBlock.Style>
-                                                <Style TargetType="{x:Type TextBlock}">
+                                                <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding IsModified}" Value="True">
                                                             <Setter Property="Foreground" Value="{StaticResource oldValueColor}" />
@@ -100,10 +101,11 @@
                                     </Grid>
                                 </DataTemplate>
                                 <DataTemplate x:Key="unmodifiedRichPresenceLine">
-                                    <TextBlock Text="{Binding Current}" TextWrapping="Wrap" Margin="4,0,4,0" />
+                                    <TextBlock Text="{Binding Current}" TextWrapping="Wrap" Margin="4,0,4,0" Style="{StaticResource themedTextBlock}" />
                                 </DataTemplate>
                                 <DataTemplate x:Key="generatedOnlyRichPresenceLine">
-                                    <TextBlock Text="{Binding Generated}" Foreground="{StaticResource newValueColor}" TextWrapping="Wrap" Margin="4,0,4,0" />
+                                    <TextBlock Text="{Binding Generated}" Foreground="{StaticResource newValueColor}" 
+                                               TextWrapping="Wrap" Margin="4,0,4,0" Style="{StaticResource themedTextBlock}" />
                                 </DataTemplate>
                             </ItemsControl.Resources>
                             <ItemsControl.Style>

--- a/Views/RichPresenceViewer.xaml
+++ b/Views/RichPresenceViewer.xaml
@@ -93,7 +93,7 @@
                                                 <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding IsModified}" Value="True">
-                                                            <Setter Property="Foreground" Value="{StaticResource oldValueColor}" />
+                                                            <Setter Property="Foreground" Value="{Binding DataContext.Resources.DiffRemovedBrush, ElementName=gameGrid}" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
@@ -105,7 +105,7 @@
                                     <TextBlock Text="{Binding Current}" TextWrapping="Wrap" Margin="4,0,4,0" Style="{StaticResource themedTextBlock}" />
                                 </DataTemplate>
                                 <DataTemplate x:Key="generatedOnlyRichPresenceLine">
-                                    <TextBlock Text="{Binding Generated}" Foreground="{StaticResource newValueColor}" 
+                                    <TextBlock Text="{Binding Generated}" Foreground="{Binding DataContext.Resources.DiffAddedBrush, ElementName=gameGrid}" 
                                                TextWrapping="Wrap" Margin="4,0,4,0" Style="{StaticResource themedTextBlock}" />
                                 </DataTemplate>
                             </ItemsControl.Resources>

--- a/Views/RichPresenceViewer.xaml
+++ b/Views/RichPresenceViewer.xaml
@@ -14,6 +14,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
@@ -21,21 +22,21 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <Image Width="48" Height="48" Grid.RowSpan="3" Source="/RATools;component/Resources/rich_presence.png" Margin="4,2,2,2" />
-                <TextBlock Grid.Column="1" FontSize="18" FontWeight="DemiBold" Text="Rich Presence" Style="{StaticResource themedTextBlock}" />
-                <TextBlock Grid.Column="1" Grid.Row="1" FontSize="10" VerticalAlignment="Top" Margin="8,4,0,0" Style="{StaticResource themedTextBlock}">
+                <Image Width="48" Height="48" Grid.RowSpan="4" Source="/RATools;component/Resources/rich_presence.png" Margin="4,2,2,2" />
+                <TextBlock Grid.Column="1" Text="Rich Presence" Style="{StaticResource editorTitle}" />
+                <TextBlock Grid.Column="1" Grid.Row="1" Style="{StaticResource editorSubtitle}">
                     <TextBlock Text="{Binding RichPresenceLength}" />
                     <TextBlock Text="/" />
                     <TextBlock Text="{Binding RichPresenceMaxLength}" />
                     <TextBlock Text="characters" />
                 </TextBlock>
-                <TextBlock Grid.Column="1" Grid.Row="2" FontSize="10" VerticalAlignment="Top" Margin="8,0,0,2">
+                <TextBlock Grid.Column="1" Grid.Row="2" Style="{StaticResource editorSubtitle}">
                     <Hyperlink Style="{StaticResource subtleHyperlink}" Command="{Binding CopyToClipboardCommand}">
                         <TextBlock Text="Copy to Clipboard" />
                     </Hyperlink>
                 </TextBlock>
 
-                <ScrollViewer Grid.Row="3" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto" HorizontalContentAlignment="Stretch" Margin="4,0,0,0">
+                <ScrollViewer Grid.Row="4" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto" HorizontalContentAlignment="Stretch" Margin="4,0,0,0">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />

--- a/Views/RichPresenceViewer.xaml
+++ b/Views/RichPresenceViewer.xaml
@@ -82,7 +82,7 @@
                                                 <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding IsModified}" Value="True">
-                                                            <Setter Property="Foreground" Value="{StaticResource newValueColor}" />
+                                                            <Setter Property="Foreground" Value="{Binding DataContext.Resources.DiffAddedBrush, ElementName=gameGrid}" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>

--- a/Views/ScriptViewer.xaml
+++ b/Views/ScriptViewer.xaml
@@ -11,13 +11,29 @@
 
     <DataTemplate DataType="{x:Type toolwindows:CodeReferencesToolWindowViewModel}">
         <ListView ItemsSource="{Binding References}" x:Name="referencesList" BorderThickness="0" jamiras:ListViewUtils.HasAutoSizeColumns="True"
-                  Background="{Binding DataContext.Script.Editor.Resources.Background.Brush, ElementName=gameGrid}"
-                  Foreground="{Binding DataContext.Script.Editor.Resources.Foreground.Brush, ElementName=gameGrid}"
+                  Style="{StaticResource themedListView}"
                   SelectedIndex="{Binding SelectedReferenceIndex}">
             <ListView.ItemContainerStyle>
                 <Style TargetType="{x:Type ListViewItem}">
                     <Setter Property="jamiras:CommandBinding.DoubleClickCommand" Value="{Binding DataContext.GotoReferenceCommand, ElementName=referencesList}" />
                     <Setter Property="jamiras:CommandBinding.DoubleClickCommandParameter" Value="{Binding}" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                <Border x:Name="Bd" Background="Transparent"
+                                        SnapsToDevicePixels="true">
+                                    <GridViewRowPresenter Content="{TemplateBinding Content}"
+                                                          Columns="{TemplateBinding GridView.ColumnCollection}" />
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="IsSelected" Value="true">
+                                        <Setter Property="Background" TargetName="Bd"
+                                                Value="{Binding DataContext.Script.Editor.Resources.Selection.Brush, ElementName=gameGrid}" />
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
                 </Style>
             </ListView.ItemContainerStyle>
             <ListView.View>
@@ -27,7 +43,15 @@
                             <Setter Property="Background" Value="{Binding DataContext.Script.Editor.Resources.Background.Brush, ElementName=gameGrid}" />
                             <Setter Property="Foreground" Value="{Binding DataContext.Script.Editor.Resources.Foreground.Brush, ElementName=gameGrid}" />
                             <Setter Property="BorderBrush" Value="{Binding DataContext.Script.Editor.Resources.LineNumber.Brush, ElementName=gameGrid}" />
-                            <Setter Property="HorizontalContentAlignment" Value="Left" />
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type GridViewColumnHeader}">
+                                        <Border BorderThickness="0,0,0,1" BorderBrush="{TemplateBinding BorderBrush}" Background="Transparent">
+                                            <TextBlock x:Name="ContentHeader" Text="{TemplateBinding Content}" Padding="5,5,5,0" Width="{TemplateBinding Width}" TextAlignment="Left" />
+                                        </Border>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
                         </Style>
                     </GridView.ColumnHeaderContainerStyle>
                     <GridViewColumn Header="Line" Width="60" DisplayMemberBinding="{Binding StartLine}" />
@@ -47,12 +71,14 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="104" />
+                <RowDefinition Height="110" />
             </Grid.RowDefinitions>
 
             <jamiras:CodeEditorView DataContext="{Binding Editor}">
                 <jamiras:CodeEditorView.Resources>
-                    <Style TargetType="{x:Type ScrollViewer}" BasedOn="{StaticResource themedScrollViewer}" />
+                    <Style TargetType="{x:Type ScrollViewer}">
+                        <Setter Property="Template" Value="{StaticResource themedScrollViewerTemplate}" />
+                    </Style>
                 </jamiras:CodeEditorView.Resources>
             </jamiras:CodeEditorView>
 

--- a/Views/ScriptViewer.xaml
+++ b/Views/ScriptViewer.xaml
@@ -6,10 +6,13 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Jamiras.Core;component/Controls/Styles/NoBorderButtonStyle.xaml" />
+        <ResourceDictionary Source="Common.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <DataTemplate DataType="{x:Type toolwindows:CodeReferencesToolWindowViewModel}">
         <ListView ItemsSource="{Binding References}" x:Name="referencesList" BorderThickness="0" jamiras:ListViewUtils.HasAutoSizeColumns="True"
+                  Background="{Binding DataContext.Script.Editor.Resources.Background.Brush, ElementName=gameGrid}"
+                  Foreground="{Binding DataContext.Script.Editor.Resources.Foreground.Brush, ElementName=gameGrid}"
                   SelectedIndex="{Binding SelectedReferenceIndex}">
             <ListView.ItemContainerStyle>
                 <Style TargetType="{x:Type ListViewItem}">
@@ -21,6 +24,9 @@
                 <GridView>
                     <GridView.ColumnHeaderContainerStyle>
                         <Style TargetType="{x:Type GridViewColumnHeader}">
+                            <Setter Property="Background" Value="{Binding DataContext.Script.Editor.Resources.Background.Brush, ElementName=gameGrid}" />
+                            <Setter Property="Foreground" Value="{Binding DataContext.Script.Editor.Resources.Foreground.Brush, ElementName=gameGrid}" />
+                            <Setter Property="BorderBrush" Value="{Binding DataContext.Script.Editor.Resources.LineNumber.Brush, ElementName=gameGrid}" />
                             <Setter Property="HorizontalContentAlignment" Value="Left" />
                         </Style>
                     </GridView.ColumnHeaderContainerStyle>
@@ -43,8 +49,12 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="104" />
             </Grid.RowDefinitions>
-            
-            <jamiras:CodeEditorView DataContext="{Binding Editor}" />
+
+            <jamiras:CodeEditorView DataContext="{Binding Editor}">
+                <jamiras:CodeEditorView.Resources>
+                    <Style TargetType="{x:Type ScrollViewer}" BasedOn="{StaticResource themedScrollViewer}" />
+                </jamiras:CodeEditorView.Resources>
+            </jamiras:CodeEditorView>
 
             <GridSplitter Grid.Row="1" ResizeDirection="Rows" Height="4" HorizontalAlignment="Stretch" 
                           Visibility="{Binding Editor.ErrorsToolWindow.IsVisible, Converter={StaticResource boolToVisConverter}}"


### PR DESCRIPTION
Adds a new tab to the Settings dialog for changing colors used by the primary editors (has no effect on any of the existing dialogs).

![image](https://user-images.githubusercontent.com/32680403/87120230-3703a200-c23d-11ea-8e34-1a06e16547fa.png)

In addition to changing each color individually, buttons are provided for quickly switching to the default theme and dark theme (implements #138). 

![image](https://user-images.githubusercontent.com/32680403/87120451-ac6f7280-c23d-11ea-823a-8cd4b5076512.png)

Users can also import/export their custom color choices. Here's a [blue theme](https://github.com/Jamiras/RATools/files/4901186/RATools-BlueTheme.zip) that I made.