### PR TITLE
Improve error message when unable to generate a memory accessor

### DIFF
--- a/Parser/Functions/ComparisonModificationFunction.cs
+++ b/Parser/Functions/ComparisonModificationFunction.cs
@@ -37,7 +37,19 @@ namespace RATools.Parser.Functions
             var builder = new ScriptInterpreterAchievementBuilder();
             ExpressionBase result;
             if (!TriggerBuilderContext.ProcessAchievementConditions(builder, condition, scope, out result))
-                return new ParseErrorExpression("comparison did not evaluate to a valid comparison", condition) { InnerError = (ParseErrorExpression)result };
+            {
+                switch (condition.Type)
+                {
+                    case ExpressionType.Conditional:
+                    case ExpressionType.Comparison:
+                        // allowed constructs should only report the inner error
+                        return (ParseErrorExpression)result;
+
+                    default:
+                        // non-allowed construct
+                        return new ParseErrorExpression("comparison did not evaluate to a valid comparison", condition) { InnerError = (ParseErrorExpression)result };
+                }
+            }
 
             var error = builder.CollapseForSubClause();
             if (error != null)

--- a/Parser/Functions/MemoryAccessorFunction.cs
+++ b/Parser/Functions/MemoryAccessorFunction.cs
@@ -1,6 +1,7 @@
 ﻿using RATools.Data;
 using RATools.Parser.Internal;
 using System.Linq;
+using System.Text;
 
 namespace RATools.Parser.Functions
 {
@@ -30,6 +31,49 @@ namespace RATools.Parser.Functions
             return true;
         }
 
+        public static bool ContainsMemoryAccessor(ExpressionBase expression)
+        {
+            var funcCall = expression as FunctionCallExpression;
+            if (funcCall != null)
+            {
+                var func = AchievementScriptInterpreter.GetGlobalScope().GetFunction(funcCall.FunctionName.Name);
+                if (func is MemoryAccessorFunction)
+                    return true;
+
+                foreach (var parameter in funcCall.Parameters)
+                {
+                    if (ContainsMemoryAccessor(parameter))
+                        return true;
+                }
+
+                return false;
+            }
+
+            var leftRightExpression = expression as LeftRightExpressionBase;
+            if (leftRightExpression != null)
+                return ContainsMemoryAccessor(leftRightExpression.Left) || ContainsMemoryAccessor(leftRightExpression.Right);
+
+            return false;
+        }
+
+        private static int CountMathematicMemoryAccessors(ExpressionBase expression, int limit)
+        {
+            var mathematic = expression as MathematicExpression;
+            if (mathematic != null)
+            {
+                var count = CountMathematicMemoryAccessors(mathematic.Left, limit);
+                if (count < limit)
+                    count += CountMathematicMemoryAccessors(mathematic.Right, limit);
+
+                return count;
+            }
+
+            if (ContainsMemoryAccessor(expression))
+                return 1;
+
+            return 0;
+        }
+
         public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var requirement = new Requirement();
@@ -52,8 +96,12 @@ namespace RATools.Parser.Functions
             else
             {
                 var mathematic = address as MathematicExpression;
-                if (mathematic != null && mathematic.Operation == MathematicOperation.Add)
+                if (mathematic != null &&
+                    (mathematic.Operation == MathematicOperation.Add || mathematic.Operation == MathematicOperation.Subtract))
                 {
+                    if (CountMathematicMemoryAccessors(mathematic, 2) >= 2)
+                        return new ParseErrorExpression("Cannot construct single address lookup from multiple memory references", address);
+
                     integerConstant = mathematic.Right as IntegerConstantExpression;
                     if (integerConstant != null)
                     {
@@ -64,6 +112,20 @@ namespace RATools.Parser.Functions
                         integerConstant = mathematic.Left as IntegerConstantExpression;
                         if (integerConstant != null)
                             funcCall = mathematic.Right as FunctionCallExpression;
+                    }
+
+                    if (integerConstant != null)
+                    {
+                        if (mathematic.Operation == MathematicOperation.Subtract)
+                            integerConstant = new IntegerConstantExpression(-integerConstant.Value);
+
+                        if (integerConstant.Value < 0)
+                        {
+                            // Negative relative offsets can actually be handled by the runtime through overflow
+                            // addition, but the editor generates an error if the offset is larger than the
+                            // available memory space for the current system.
+                            return new ParseErrorExpression("Negative relative offset not supported", address);
+                        }
                     }
                 }
             }
@@ -88,7 +150,11 @@ namespace RATools.Parser.Functions
                 }
             }
 
-            return new ParseErrorExpression("Cannot convert to an address", address);
+            var builder = new StringBuilder();
+            builder.Append("Cannot convert to an address: ");
+            address.AppendString(builder);
+
+            return new ParseErrorExpression(builder.ToString(), address);
         }
     }
 }

--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -84,7 +84,7 @@ namespace RATools.Parser.Internal
             if (!functionDefinition.ReplaceVariables(functionScope, out result))
             {
                 var error = result as ParseErrorExpression;
-                result = new ParseErrorExpression(FunctionName.Name + " call failed", FunctionName) { InnerError = error };
+                result = ParseErrorExpression.WrapError(error, FunctionName.Name + " call failed", FunctionName);
                 return false;
             }
 
@@ -125,7 +125,7 @@ namespace RATools.Parser.Internal
                 var error = result as ParseErrorExpression;
                 if (error.Line == 0)
                     this.CopyLocation(error);
-                result = new ParseErrorExpression(FunctionName.Name + " call failed", FunctionName) { InnerError = error };
+                result = ParseErrorExpression.WrapError(error, FunctionName.Name + " call failed", FunctionName);
                 return false;
             }
 

--- a/Parser/Internal/ParseErrorExpression.cs
+++ b/Parser/Internal/ParseErrorExpression.cs
@@ -52,6 +52,17 @@ namespace RATools.Parser.Internal
             }
         }
 
+        public static ParseErrorExpression WrapError(ParseErrorExpression error, string message, ExpressionBase expression)
+        {
+            if (error.EndColumn == expression.EndColumn && error.Column == expression.Column &&
+                error.EndLine == expression.EndLine && error.Line == expression.Line)
+            {
+                return error;
+            }
+
+            return new ParseErrorExpression(message, expression) { InnerError = error };
+        }
+
         /// <summary>
         /// Gets the message.
         /// </summary>

--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -402,8 +402,16 @@ namespace RATools.Parser
 
                 if (error != null)
                 {
-                    if (error.InnerError != null)
-                        error = new ParseErrorExpression(error.InnermostError.Message, error.Line, error.Column, error.EndLine, error.EndColumn);
+                    switch (condition.Type)
+                    {
+                        case ExpressionType.Comparison:
+                        case ExpressionType.Conditional:
+                            break;
+
+                        default:
+                            error = ParseErrorExpression.WrapError(error, "Invalid condition", condition);
+                            break;
+                    }
                     return false;
                 }
             }
@@ -659,7 +667,7 @@ namespace RATools.Parser
 
             var error = ExecuteAchievementExpression(left, scope);
             if (error != null)
-                return error;
+                return ParseErrorExpression.WrapError(error, "Invalid value", left);
 
             var integerRight = right as IntegerConstantExpression;
             if (integerRight != null)
@@ -674,7 +682,7 @@ namespace RATools.Parser
             {
                 error = ExecuteAchievementExpression(right, scope);
                 if (error != null)
-                    return error;
+                    return ParseErrorExpression.WrapError(error, "Invalid value", right);
 
                 var extraRequirement = context.LastRequirement;
                 ((IList<Requirement>)context.Trigger).RemoveAt(context.Trigger.Count - 1);

--- a/Parser/TriggerBuilderContext.cs
+++ b/Parser/TriggerBuilderContext.cs
@@ -272,7 +272,7 @@ namespace RATools.Parser
 
             var error = triggerBuilderFunction.BuildTrigger(this, scope, functionCall);
             if (error != null)
-                return new ParseErrorExpression(error, functionCall);
+                return ParseErrorExpression.WrapError(error, "Function call failed.", functionCall);
 
             return null;
         }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,22 @@
 A script interpreter for writing achievements for retroachievements.org
 Also contains some analysis tools for examining site data
 
+### Build instructions (RATools only):
+This is the setup most users should be using.
+1) Run `git submodule init` and `git submodule update` to initialize the `Core` repository submodule.
+2) Download the [nUnit and Moq dlls](https://github.com/Jamiras/Core/wiki/files/nUnit.3.11.zip) and extract them to a "lib" subdirectory under the `RATools` checkout.
+3) Open the "RATools.sln" project.
+4) Compile.
 
-The 'RATools.sln' solution requires the Core submodule to be initialized, and is the solution most users should be using.
+### Build instructions (RATools + Core):
+This is an advanced setup for users who want to share the Core and/or libs with other projects.
+1) Clone the [Core](https://github.com/Jamiras/Core) repository in a directory beside the `RATools` checkout.
+2) Download the [nUnit and Moq dlls](https://github.com/Jamiras/Core/wiki/files/nUnit.3.11.zip) and extract them to a "libs" directory beside the RATools checkout.
+    * you should now have three directories at the top level: Core, libs, and RATools
+3) Open the "RATools + Core.sln" project.
+4) Compile.
 
-The 'RATools + Core.sln' solution looks for the Core repository to be checked out next to the RATools repository and is used when making changes to both projects.
+## Unit Tests
+To run the unit tests (using either configuration above), you need to install the "NUnit 3 Test Adapter" from the Online Marketplace within the Tools > Extensions and Updates dialog. You'll need to close all instances of Visual Studio for it to install.
+
+Then open the Test > Windows > Test Explorer tool window and press the Run All button. Individual tests (or groups of tests) can be run by right clicking on them and selecting Run Selected Tests.

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -172,10 +172,6 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Core\Tests\Jamiras.Core.Tests.csproj">
-      <Project>{8f415f4b-4184-429f-80a2-58da15afb26e}</Project>
-      <Name>Jamiras.Core.Tests</Name>
-    </ProjectReference>
     <ProjectReference Include="..\RATools.csproj">
       <Project>{965d9b5a-9070-40e5-9eaa-edc581f0f000}</Project>
       <Name>RATools</Name>

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -117,7 +117,7 @@
     <Compile Include="Parser\Functions\LengthFunctionTests.cs" />
     <Compile Include="Parser\Functions\ArrayPopFunctionTests.cs" />
     <Compile Include="Parser\Functions\MeasuredFunctionTests.cs" />
-    <Compile Include="Parser\Functions\MemoryAccessFunctionTests.cs" />
+    <Compile Include="Parser\Functions\MemoryAccessorFunctionTests.cs" />
     <Compile Include="Parser\Functions\FormatFunctionTests.cs" />
     <Compile Include="Parser\Functions\BitCountFunctionTests.cs" />
     <Compile Include="Parser\Functions\ArrayPushFunctionTests.cs" />


### PR DESCRIPTION
Fixes #182

Modified the code that tries to report the most relevant error to include both the originating error and the causative error. This allows for more informative locating of the problematic issue. I've also expanded the error to report the expression it's having issue converting.