### PR TITLE
don't remove duplicate PauseIf from alt if it's guarding something

### DIFF
--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -1829,8 +1829,20 @@ namespace RATools.Parser
                     {
                         if (group[j] == coreGroup[i])
                         {
-                            // always_true has special meaning and shouldn't be eliminated if present in the core group
-                            if (group[j].Requirements.Count > 1 || group[j].Requirements[0].Evaluate() != true)
+                            bool remove = true;
+
+                            if (group[j].Requirements.Count == 1 && group[j].Requirements[0].Evaluate() == true)
+                            {
+                                // always_true has special meaning and shouldn't be eliminated if present in the core group
+                                remove = false;
+                            }
+                            else if (group[j].Requirements.Last().Type == RequirementType.PauseIf)
+                            {
+                                // if the PauseIf wasn't eliminated by NormalizeNonHitCountResetAndPauseIfs, it's protecting something. Keep it.
+                                remove = false;
+                            }
+
+                            if (remove)
                                 group.RemoveAt(j);
                         }
                     }

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -443,6 +443,8 @@ namespace RATools.Test.Parser
         [TestCase("once(byte(0x002345) == 1 && byte(0x001234) == 1) && once(byte(0x002345) == 1 && byte(0x001234) == 1)", "once(byte(0x002345) == 1 && byte(0x001234) == 1)")] // complete AndNext duplicate should be elimiated
         [TestCase("byte(0x001234) == 2 && ((byte(0x001234) == 2 && byte(0x004567) == 3) || (byte(0x001234) == 2 && byte(0x004567) == 4))",
                   "byte(0x001234) == 2 && (byte(0x004567) == 3 || byte(0x004567) == 4)")] // alts in core are redundant
+        [TestCase("unless(byte(0x001234) == 1) && never(byte(0x002345) == 1) && ((unless(byte(0x001234) == 1) && once(byte(0x002345) == 2)) || (unless(byte(0x001234) == 1) && never(byte(0x002345) == 3)))", // PauseIf guarding once or never should not be promoted even if duplicated
+                  "unless(byte(0x001234) == 1) && never(byte(0x002345) == 1) && ((unless(byte(0x001234) == 1) && once(byte(0x002345) == 2)) || (unless(byte(0x001234) == 1) && never(byte(0x002345) == 3)))")]
         // ==== RemoveRedundancies ====
         [TestCase("byte(0x001234) > 1 && byte(0x001234) > 2", "byte(0x001234) > 2")] // >1 && >2 is only >2
         [TestCase("byte(0x001234) > 1 && byte(0x001235) > 2", "byte(0x001234) > 1 && byte(0x001235) > 2")] // different addresses


### PR DESCRIPTION
Since PauseIf only applies to the group it's in, it shouldn't be automatically deleted if both the core and an alt contain the same PauseIf clause.
