### PR TITLE
optimize evaluation of constant dictionaries

### DIFF
--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -418,8 +418,8 @@ namespace RATools.Parser
                         return false;
                     }
 
-                    scope.AssignVariable(assignment.Variable, result);
-                    return true;
+                    Error = scope.AssignVariable(assignment.Variable, result);
+                    return (Error == null);
 
                 case ExpressionType.FunctionCall:
                     return CallFunction((FunctionCallExpression)expression, scope);
@@ -498,12 +498,12 @@ namespace RATools.Parser
                 var iteratorScope = new InterpreterScope(scope);
                 var iteratorVariable = new VariableExpression(iterator.Name);
 
-                foreach (var entry in dict.Entries)
+                foreach (var entry in dict.Keys)
                 {
-                    iteratorScope.Context = new AssignmentExpression(iteratorVariable, entry.Key);
+                    iteratorScope.Context = new AssignmentExpression(iteratorVariable, entry);
 
                     ExpressionBase key;
-                    if (!entry.Key.ReplaceVariables(iteratorScope, out key))
+                    if (!entry.ReplaceVariables(iteratorScope, out key))
                     {
                         Error = key as ParseErrorExpression;
                         return false;

--- a/Parser/Functions/LengthFunction.cs
+++ b/Parser/Functions/LengthFunction.cs
@@ -23,7 +23,7 @@ namespace RATools.Parser.Functions
                     return true;
 
                 case ExpressionType.Dictionary:
-                    result = new IntegerConstantExpression(((DictionaryExpression)obj).Entries.Count);
+                    result = new IntegerConstantExpression(((DictionaryExpression)obj).Count);
                     return true;
 
                 case ExpressionType.StringConstant:

--- a/Parser/Internal/InterpreterScope.cs
+++ b/Parser/Internal/InterpreterScope.cs
@@ -126,17 +126,11 @@ namespace RATools.Parser.Internal
         /// </summary>
         /// <param name="variable">The variable.</param>
         /// <param name="value">The value.</param>
-        public void AssignVariable(VariableExpression variable, ExpressionBase value)
+        public ParseErrorExpression AssignVariable(VariableExpression variable, ExpressionBase value)
         {
             var indexedVariable = variable as IndexedVariableExpression;
             if (indexedVariable != null)
-            {
-                ExpressionBase result;
-                var entry = indexedVariable.GetDictionaryEntry(this, out result, true);
-                if (entry != null)
-                    entry.Value = value;
-                return;
-            }
+                return indexedVariable.Assign(this, value);
 
             // find the scope where the variable is defined and update it there.
             var scope = this;
@@ -145,7 +139,7 @@ namespace RATools.Parser.Internal
                 if (scope._variables.ContainsKey(variable.Name))
                 {
                     scope.DefineVariable(new VariableDefinitionExpression(variable), value);
-                    return;
+                    return null;
                 }
 
                 scope = GetParentScope(scope);
@@ -153,6 +147,7 @@ namespace RATools.Parser.Internal
 
             // variable not defined, store in the current scope.
             DefineVariable(new VariableDefinitionExpression(variable), value);
+            return null;
         }
 
         /// <summary>

--- a/Tests/Parser/Functions/ArrayPopFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayPopFunctionTests.cs
@@ -94,7 +94,7 @@ namespace RATools.Test.Parser.Functions
         {
             var scope = new InterpreterScope();
             var dict = new DictionaryExpression();
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = new IntegerConstantExpression(1), Value = new StringConstantExpression("One") });
+            dict.Add(new IntegerConstantExpression(1), new StringConstantExpression("One"));
             scope.DefineVariable(new VariableDefinitionExpression("dict"), dict);
 
             Evaluate("array_push(dict)", scope, "array did not evaluate to an array");

--- a/Tests/Parser/Functions/LengthFunctionTests.cs
+++ b/Tests/Parser/Functions/LengthFunctionTests.cs
@@ -85,13 +85,13 @@ namespace RATools.Test.Parser.Functions
         {
             var scope = new InterpreterScope();
             var dict = new DictionaryExpression();
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = new IntegerConstantExpression(1), Value = new StringConstantExpression("One") });
+            dict.Add(new IntegerConstantExpression(1), new StringConstantExpression("One"));
             scope.DefineVariable(new VariableDefinitionExpression("dict"), dict);
 
             Assert.That(Evaluate("length(dict)", scope), Is.EqualTo(1));
 
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = new IntegerConstantExpression(5), Value = new StringConstantExpression("Five") });
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = new IntegerConstantExpression(9), Value = new StringConstantExpression("Nine") });
+            dict.Add(new IntegerConstantExpression(5), new StringConstantExpression("Five"));
+            dict.Add(new IntegerConstantExpression(9), new StringConstantExpression("Nine"));
 
             Assert.That(Evaluate("length(dict)", scope), Is.EqualTo(3));
         }

--- a/Tests/Parser/Internal/DictionaryExpressionTests.cs
+++ b/Tests/Parser/Internal/DictionaryExpressionTests.cs
@@ -15,17 +15,8 @@ namespace RATools.Test.Parser.Internal
         public void TestAppendString()
         {
             var expr = new DictionaryExpression();
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry
-            {
-                Key = new VariableExpression("a"),
-                Value = new IntegerConstantExpression(1)
-            });
-
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry
-            {
-                Key = new IntegerConstantExpression(2),
-                Value = new StringConstantExpression("banana")
-            });
+            expr.Add(new VariableExpression("a"), new IntegerConstantExpression(1));
+            expr.Add(new IntegerConstantExpression(2), new StringConstantExpression("banana"));
 
             var builder = new StringBuilder();
             expr.AppendString(builder);
@@ -58,7 +49,7 @@ namespace RATools.Test.Parser.Internal
             var expression = DictionaryExpression.Parse(tokenizer);
             Assert.That(expression, Is.InstanceOf<DictionaryExpression>());
             var dict = (DictionaryExpression)expression;
-            Assert.That(dict.Entries.Count, Is.EqualTo(2));
+            Assert.That(dict.Count, Is.EqualTo(2));
         }
 
         [Test]
@@ -70,7 +61,7 @@ namespace RATools.Test.Parser.Internal
             var expression = DictionaryExpression.Parse(tokenizer);
             Assert.That(expression, Is.InstanceOf<DictionaryExpression>());
             var dict = (DictionaryExpression)expression;
-            Assert.That(dict.Entries.Count, Is.EqualTo(0));
+            Assert.That(dict.Count, Is.EqualTo(0));
             Assert.That(group.ParseErrors.Count(), Is.GreaterThan(0));
             Assert.That(group.ParseErrors.ElementAt(0).Message, Is.EqualTo("Expecting colon following key expression"));
             Assert.That(group.ParseErrors.ElementAt(0).Line, Is.EqualTo(1));
@@ -102,8 +93,8 @@ namespace RATools.Test.Parser.Internal
             var value3 = new IntegerConstantExpression(1);
             var value4 = new IntegerConstantExpression(2);
             var expr = new DictionaryExpression();
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = variable1, Value = value3 });
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = value4, Value = variable2 });
+            expr.Add(variable1, value3);
+            expr.Add(value4, variable2);
 
             var scope = new InterpreterScope();
             scope.AssignVariable(variable1, value1);
@@ -113,13 +104,13 @@ namespace RATools.Test.Parser.Internal
             Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
             Assert.That(result, Is.InstanceOf<DictionaryExpression>());
             var dictResult = (DictionaryExpression)result;
-            Assert.That(dictResult.Entries.Count, Is.EqualTo(2));
+            Assert.That(dictResult.Count, Is.EqualTo(2));
 
             // resulting list will be sorted for quicker lookups
-            Assert.That(dictResult.Entries[0].Key, Is.EqualTo(value4));
-            Assert.That(dictResult.Entries[0].Value, Is.EqualTo(value2));
-            Assert.That(dictResult.Entries[1].Key, Is.EqualTo(value1));
-            Assert.That(dictResult.Entries[1].Value, Is.EqualTo(value3));
+            Assert.That(dictResult[0].Key, Is.EqualTo(value4));
+            Assert.That(dictResult[0].Value, Is.EqualTo(value2));
+            Assert.That(dictResult[1].Key, Is.EqualTo(value1));
+            Assert.That(dictResult[1].Value, Is.EqualTo(value3));
         }
 
         [Test]
@@ -133,7 +124,7 @@ namespace RATools.Test.Parser.Internal
             var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { new IntegerConstantExpression(2) });
             var value1 = new IntegerConstantExpression(98);
             var expr = new DictionaryExpression();
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = functionCall, Value = value1 });
+            expr.Add(functionCall, value1);
 
             var scope = new InterpreterScope();
             scope.AddFunction(functionDefinition);
@@ -142,9 +133,9 @@ namespace RATools.Test.Parser.Internal
             Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
             Assert.That(result, Is.InstanceOf<DictionaryExpression>());
             var dictResult = (DictionaryExpression)result;
-            Assert.That(dictResult.Entries.Count, Is.EqualTo(1));
-            Assert.That(dictResult.Entries[0].Key, Is.EqualTo(new IntegerConstantExpression(6)));
-            Assert.That(dictResult.Entries[0].Value, Is.EqualTo(value1));
+            Assert.That(dictResult.Count, Is.EqualTo(1));
+            Assert.That(dictResult[0].Key, Is.EqualTo(new IntegerConstantExpression(6)));
+            Assert.That(dictResult[0].Value, Is.EqualTo(value1));
         }
 
         [Test]
@@ -158,7 +149,7 @@ namespace RATools.Test.Parser.Internal
             var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { new IntegerConstantExpression(2) });
             var value1 = new IntegerConstantExpression(98);
             var expr = new DictionaryExpression();
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = functionCall, Value = value1 });
+            expr.Add(functionCall, value1);
 
             var scope = new InterpreterScope();
             scope.AddFunction(functionDefinition);
@@ -180,7 +171,7 @@ namespace RATools.Test.Parser.Internal
             var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { new IntegerConstantExpression(2) });
             var value1 = new IntegerConstantExpression(98);
             var expr = new DictionaryExpression();
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = functionCall, Value = value1 });
+            expr.Add(functionCall, value1);
 
             var scope = new InterpreterScope();
             scope.AddFunction(functionDefinition);
@@ -201,8 +192,8 @@ namespace RATools.Test.Parser.Internal
             var value3 = new IntegerConstantExpression(3);
             var value4 = new IntegerConstantExpression(4);
             var expr = new DictionaryExpression();
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = value1, Value = value3 });
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = value1, Value = value4 });
+            expr.Add(value1, value3);
+            expr.Add(value1, value4);
 
             var scope = new InterpreterScope();
 
@@ -221,8 +212,8 @@ namespace RATools.Test.Parser.Internal
             var value3 = new IntegerConstantExpression(3);
             var value4 = new IntegerConstantExpression(4);
             var expr = new DictionaryExpression();
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = variable1, Value = value3 });
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = variable2, Value = value4 });
+            expr.Add(variable1, value3);
+            expr.Add(variable2, value4);
 
             var scope = new InterpreterScope();
             scope.AssignVariable(variable1, value1);
@@ -240,7 +231,7 @@ namespace RATools.Test.Parser.Internal
             var key = new IntegerConstantExpression(6);
             var value = new FunctionCallExpression("byte", new[] { new IntegerConstantExpression(1) });
             var expr = new DictionaryExpression();
-            expr.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = key, Value = value });
+            expr.Add(key, value);
 
             var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
 
@@ -249,8 +240,47 @@ namespace RATools.Test.Parser.Internal
 
             Assert.That(result, Is.InstanceOf<DictionaryExpression>());
             var arrayResult = (DictionaryExpression)result;
-            Assert.That(arrayResult.Entries.Count, Is.EqualTo(1));
-            Assert.That(arrayResult.Entries[0].Value.ToString(), Is.EqualTo(value.ToString()));
+            Assert.That(arrayResult.Count, Is.EqualTo(1));
+            Assert.That(arrayResult[0].Value.ToString(), Is.EqualTo(value.ToString()));
+        }
+
+        [Test]
+        public void TestReplaceVariablesCreatesCopy()
+        {
+            var key1 = new IntegerConstantExpression(1);
+            var key2 = new IntegerConstantExpression(2);
+            var value1 = new StringConstantExpression("One");
+            var value2 = new StringConstantExpression("Two");
+            var dict1 = new DictionaryExpression();
+            dict1.Add(key1, value1);
+            dict1.Add(key2, value2);
+
+            var scope = new InterpreterScope();
+
+            ExpressionBase result;
+            Assert.That(dict1.ReplaceVariables(scope, out result), Is.True);
+            Assert.That(result, Is.InstanceOf<DictionaryExpression>());
+            var dict2 = (DictionaryExpression)result;
+            Assert.That(dict2.Count, Is.EqualTo(2));
+
+            // item added to original dictionary does not appear in evaluated dictionary
+            var key3 = new IntegerConstantExpression(3);
+            var value3 = new StringConstantExpression("Three");
+            dict1.Add(key3, value3);
+            Assert.That(dict1.Count, Is.EqualTo(3));
+            Assert.That(dict2.Count, Is.EqualTo(2));
+
+            // item added to evaluated dictionary does not appear in original dictionary
+            var key4 = new IntegerConstantExpression(4);
+            var value4 = new StringConstantExpression("Four");
+            dict2.Add(key4, value4);
+            Assert.That(dict1.Count, Is.EqualTo(3));
+            Assert.That(dict2.Count, Is.EqualTo(3));
+
+            Assert.That(dict1.Keys.Contains(key3));
+            Assert.That(!dict2.Keys.Contains(key3));
+            Assert.That(!dict1.Keys.Contains(key4));
+            Assert.That(dict2.Keys.Contains(key4));
         }
 
         [Test]

--- a/Tests/Parser/Internal/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Internal/FunctionCallExpressionTests.cs
@@ -532,11 +532,7 @@ namespace RATools.Test.Parser.Internal
             scope.AddFunction(functionDefinition);
 
             var dict = new DictionaryExpression();
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry()
-            {
-                Key = new StringConstantExpression("key"),
-                Value = new IntegerConstantExpression(1)
-            });
+            dict.Add(new StringConstantExpression("key"), new IntegerConstantExpression(1));
             scope.AssignVariable(new VariableExpression("dict"), dict);
 
             var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { new VariableExpression("dict") });
@@ -545,9 +541,9 @@ namespace RATools.Test.Parser.Internal
             Assert.That(functionCall.Evaluate(scope, out result), Is.True);
             Assert.That(result, Is.Null);
 
-            Assert.That(dict.Entries.Count(), Is.EqualTo(1));
-            Assert.That(dict.Entries[0].Value, Is.InstanceOf<IntegerConstantExpression>());
-            Assert.That(((IntegerConstantExpression)dict.Entries[0].Value).Value, Is.EqualTo(2));
+            Assert.That(dict.Count, Is.EqualTo(1));
+            Assert.That(dict[0].Value, Is.InstanceOf<IntegerConstantExpression>());
+            Assert.That(((IntegerConstantExpression)dict[0].Value).Value, Is.EqualTo(2));
         }
 
         [Test]
@@ -559,11 +555,7 @@ namespace RATools.Test.Parser.Internal
             scope.AddFunction(functionDefinition);
 
             var dict = new DictionaryExpression();
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry()
-            {
-                Key = new StringConstantExpression("key"),
-                Value = new VariableExpression("variable")
-            });
+            dict.Add(new StringConstantExpression("key"), new VariableExpression("variable"));
             scope.AssignVariable(new VariableExpression("variable"), new IntegerConstantExpression(123));
 
             var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { dict });

--- a/Tests/Parser/Internal/IndexedVariableExpressionTests.cs
+++ b/Tests/Parser/Internal/IndexedVariableExpressionTests.cs
@@ -38,7 +38,7 @@ namespace RATools.Test.Parser.Internal
             var key = new StringConstantExpression("key");
             var value = new IntegerConstantExpression(99);
             var dict = new DictionaryExpression();
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = key, Value = value });
+            dict.Add(key, value);
             var expr = new IndexedVariableExpression(variable, key);
 
             var scope = new InterpreterScope();
@@ -57,9 +57,9 @@ namespace RATools.Test.Parser.Internal
             var key = new StringConstantExpression("key");
             var value = new IntegerConstantExpression(99);
             var dict2 = new DictionaryExpression();
-            dict2.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = key, Value = value });
+            dict2.Add(key, value);
             var dict1 = new DictionaryExpression();
-            dict1.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = key, Value = dict2 });
+            dict1.Add(key, dict2);
             var expr2 = new IndexedVariableExpression(variable, key);
             var expr = new IndexedVariableExpression(expr2, key);
 
@@ -80,7 +80,7 @@ namespace RATools.Test.Parser.Internal
             var index = new VariableExpression("index");
             var value = new IntegerConstantExpression(99);
             var dict = new DictionaryExpression();
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = key, Value = value });
+            dict.Add(key, value);
             var expr = new IndexedVariableExpression(variable, index);
 
             var scope = new InterpreterScope();
@@ -135,7 +135,7 @@ namespace RATools.Test.Parser.Internal
             var index = new MathematicExpression(new IntegerConstantExpression(2), MathematicOperation.Add, new IntegerConstantExpression(4));
             var value = new IntegerConstantExpression(99);
             var dict = new DictionaryExpression();
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = key, Value = value });
+            dict.Add(key, value);
             var expr = new IndexedVariableExpression(variable, index);
 
             var scope = new InterpreterScope();
@@ -160,7 +160,7 @@ namespace RATools.Test.Parser.Internal
 
             var variable = new VariableExpression("variable");
             var dict = new DictionaryExpression();
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = new IntegerConstantExpression(6), Value = value });
+            dict.Add(new IntegerConstantExpression(6), value);
 
             var scope = new InterpreterScope();
             scope.AssignVariable(variable, dict);

--- a/Tests/Parser/Internal/InterpreterScopeTests.cs
+++ b/Tests/Parser/Internal/InterpreterScopeTests.cs
@@ -114,8 +114,8 @@ namespace RATools.Test.Parser.Internal
             var index = new IndexedVariableExpression(variable, key);
             scope.AssignVariable(index, value);
 
-            Assert.That(dict.Entries.Count, Is.EqualTo(1));
-            Assert.That(dict.Entries[0].Value, Is.SameAs(value));
+            Assert.That(dict.Count, Is.EqualTo(1));
+            Assert.That(dict[0].Value, Is.SameAs(value));
         }
 
         [Test]
@@ -126,14 +126,14 @@ namespace RATools.Test.Parser.Internal
             var value2 = new IntegerConstantExpression(98);
             var dict = new DictionaryExpression();
             var key = new IntegerConstantExpression(6);
-            dict.Entries.Add(new DictionaryExpression.DictionaryEntry { Key = key, Value = value });
+            dict.Add(key, value);
             var scope = new InterpreterScope();
             scope.AssignVariable(variable, dict);
 
             var index = new IndexedVariableExpression(variable, key);
             scope.AssignVariable(index, value2);
 
-            Assert.That(dict.Entries[0].Value, Is.SameAs(value2));
+            Assert.That(dict[0].Value, Is.SameAs(value2));
         }
 
         [Test]


### PR DESCRIPTION
Every time a dictionary is referenced, it's scanned to see if any of the keys or values changed. This PR adds a flag to the dictionary to indicate when this has happened so a dictionary that isn't changing can be used more efficiently.

This provides large performance gains on scripts that heavily rely on dictionaries.