### PR TITLE
use TextRange for ExpressionBase

### DIFF
--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -130,12 +130,12 @@ namespace RATools.Parser
                     return null;
 
                 var builder = new StringBuilder();
-                builder.AppendFormat("{0}:{1} {2}", Error.Line, Error.Column, Error.Message);
+                builder.AppendFormat("{0}:{1} {2}", Error.Location.Start.Line, Error.Location.Start.Column, Error.Message);
                 var error = Error.InnerError;
                 while (error != null)
                 {
                     builder.AppendLine();
-                    builder.AppendFormat("- {0}:{1} {2}", error.Line, error.Column, error.Message);
+                    builder.AppendFormat("- {0}:{1} {2}", error.Location.Start.Line, error.Location.Start.Column, error.Message);
                     error = error.InnerError;
                 }
                 return builder.ToString();
@@ -150,7 +150,7 @@ namespace RATools.Parser
             var error = Error;
             while (error != null)
             {
-                for (int i = error.Line; i <= error.EndLine; i++)
+                for (int i = error.Location.Start.Line; i <= error.Location.End.Line; i++)
                 {
                     if (!neededLines.Contains(i))
                         neededLines.Add(i);
@@ -180,31 +180,31 @@ namespace RATools.Parser
             error = Error;
             while (error != null)
             {
-                builder.AppendFormat("{0}:{1} {2}", error.Line, error.Column, error.Message);
+                builder.AppendFormat("{0}:{1} {2}", error.Location.Start.Line, error.Location.Start.Column, error.Message);
                 builder.AppendLine();
                 //for (int i = error.Line; i <= error.EndLine; i++)
-                int i = error.Line; // TODO: show all lines associated to error?
+                int i = error.Location.Start.Line; // TODO: show all lines associated to error?
                 {
-                    var line = lineDictionary[error.Line];
+                    var line = lineDictionary[error.Location.Start.Line];
 
                     builder.Append(":: ");
                     var startColumn = 0;
                     while (Char.IsWhiteSpace(line[startColumn]))
                         startColumn++;
 
-                    if (i == error.Line)
+                    if (i == error.Location.Start.Line)
                     {
                         builder.Append("{{color|#C0C0C0|");
-                        builder.Append(line.Substring(startColumn, error.Column - startColumn - 1));
+                        builder.Append(line.Substring(startColumn, error.Location.Start.Column - startColumn - 1));
                         builder.Append("}}");
-                        startColumn = error.Column - 1;
+                        startColumn = error.Location.Start.Column - 1;
                     }
 
-                    if (i == error.EndLine)
+                    if (i == error.Location.End.Line)
                     {
-                        builder.Append(line.Substring(startColumn, error.EndColumn - startColumn));
+                        builder.Append(line.Substring(startColumn, error.Location.End.Column - startColumn));
                         builder.Append("{{color|#C0C0C0|");
-                        builder.Append(line.Substring(error.EndColumn));
+                        builder.Append(line.Substring(error.Location.End.Column));
                         builder.Append("}}");
                     }
                     else
@@ -388,7 +388,7 @@ namespace RATools.Parser
 
                     int progress = (i * 100 / count);
                     if (progress > 0)
-                        callback.UpdateProgress(progress, expression.Line);
+                        callback.UpdateProgress(progress, expression.Location.Start.Line);
 
                     i++;
                 }

--- a/Parser/Functions/AchievementFunction.cs
+++ b/Parser/Functions/AchievementFunction.cs
@@ -60,7 +60,7 @@ namespace RATools.Parser.Functions
 
             if (!TriggerBuilderContext.ProcessAchievementConditions(achievement, trigger, scope, out result))
             {
-                if (result.Column != trigger.Column || result.EndColumn != trigger.EndColumn || result.Line != trigger.Line || result.EndLine != trigger.EndLine)
+                if (result.Location.Start != trigger.Location.Start || result.Location.End != trigger.Location.End)
                 {
                     var error = (ParseErrorExpression)result;
                     result = new ParseErrorExpression(error.Message, trigger) { InnerError = error };
@@ -72,7 +72,7 @@ namespace RATools.Parser.Functions
             var newAchievement = achievement.ToAchievement();
             var functionCall = scope.GetOutermostContext<FunctionCallExpression>();
             if (functionCall != null)
-                newAchievement.SourceLine = functionCall.Line;
+                newAchievement.SourceLine = functionCall.Location.Start.Line;
 
             var context = scope.GetContext<AchievementScriptContext>();
             Debug.Assert(context != null);

--- a/Parser/Functions/FormatFunction.cs
+++ b/Parser/Functions/FormatFunction.cs
@@ -49,16 +49,16 @@ namespace RATools.Parser.Functions
                 if (tokenizer.NextChar == '}')
                 {
                     result = new ParseErrorExpression("Empty parameter index",
-                                                      stringExpression.Line, stringExpression.Column + positionalTokenColumn,
-                                                      stringExpression.Line, stringExpression.Column + tokenizer.Column - 1);
+                                                      stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + positionalTokenColumn,
+                                                      stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + tokenizer.Column - 1);
                     return false;
                 }
                 var index = tokenizer.ReadNumber();
                 if (tokenizer.NextChar != '}')
                 {
                     result = new ParseErrorExpression("Invalid positional token",
-                                                      stringExpression.Line, stringExpression.Column + positionalTokenColumn,
-                                                      stringExpression.Line, stringExpression.Column + tokenizer.Column - 1);
+                                                      stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + positionalTokenColumn,
+                                                      stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + tokenizer.Column - 1);
                     return false;
                 }
                 tokenizer.Advance();
@@ -68,8 +68,8 @@ namespace RATools.Parser.Functions
                     || parameterIndex < 0 || parameterIndex >= varargs.Entries.Count)
                 {
                     result = new ParseErrorExpression("Invalid parameter index: " + index.ToString(),
-                                                      stringExpression.Line, stringExpression.Column + positionalTokenColumn,
-                                                      stringExpression.Line, stringExpression.Column + tokenizer.Column - 1);
+                                                      stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + positionalTokenColumn,
+                                                      stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + tokenizer.Column - 1);
                     return false;
                 }
 

--- a/Parser/Functions/LeaderboardFunction.cs
+++ b/Parser/Functions/LeaderboardFunction.cs
@@ -63,7 +63,7 @@ namespace RATools.Parser.Functions
 
             var functionCall = scope.GetContext<FunctionCallExpression>();
             if (functionCall != null && functionCall.FunctionName.Name == this.Name.Name)
-                leaderboard.SourceLine = functionCall.Line;
+                leaderboard.SourceLine = functionCall.Location.Start.Line;
 
             var context = scope.GetContext<AchievementScriptContext>();
             Debug.Assert(context != null);

--- a/Parser/Functions/RangeFunction.cs
+++ b/Parser/Functions/RangeFunction.cs
@@ -42,7 +42,7 @@ namespace RATools.Parser.Functions
             {
                 if (step.Value > 0)
                 {
-                    result = new ParseErrorExpression("step must be negative if start is after stop", step.Line > 0 ? step : stop);
+                    result = new ParseErrorExpression("step must be negative if start is after stop", step.Location.Start.Line > 0 ? step : stop);
                     return false;
                 }
 

--- a/Parser/Functions/RichPresenceDisplayFunction.cs
+++ b/Parser/Functions/RichPresenceDisplayFunction.cs
@@ -44,7 +44,7 @@ namespace RATools.Parser.Functions
             richPresence.DisplayString = displayString;
             var functionCall = scope.GetContext<FunctionCallExpression>();
             if (functionCall != null && functionCall.FunctionName.Name == this.Name.Name)
-                richPresence.Line = functionCall.Line;
+                richPresence.Line = functionCall.Location.Start.Line;
             return true;
         }
 

--- a/Parser/Internal/AssignmentExpression.cs
+++ b/Parser/Internal/AssignmentExpression.cs
@@ -17,10 +17,7 @@ namespace RATools.Parser.Internal
             Variable = variable;
             Value = value;
 
-            Line = Variable.Line;
-            Column = Variable.Column;
-            EndLine = value.EndLine;
-            EndColumn = value.EndColumn;
+            Location = new Jamiras.Components.TextRange(Variable.Location.Start, value.Location.End);
         }
 
         /// <summary>

--- a/Parser/Internal/ExpressionGroup.cs
+++ b/Parser/Internal/ExpressionGroup.cs
@@ -95,9 +95,11 @@ namespace RATools.Parser.Internal
             while (insertAt > 0)
             {
                 var previous = _expressions[insertAt - 1];
-                if (previous.Line < expression.Line)
+                if (previous.Location.Start.Line < expression.Location.Start.Line)
                     break;
-                if (previous.Line == expression.Line && previous.Column < expression.Column)
+
+                if (previous.Location.Start.Line == expression.Location.Start.Line &&
+                    previous.Location.Start.Column < expression.Location.Start.Column)
                     break;
 
                 --insertAt;
@@ -110,7 +112,7 @@ namespace RATools.Parser.Internal
         {
             if (_expression != null)
             {
-                if (_expression.Line < expression.EndLine)
+                if (_expression.Location.Start.Line < expression.Location.End.Line)
                     return null;
                 // ASSERT: comment must be the last thing on a line, so we don't have to check columns
 
@@ -124,7 +126,7 @@ namespace RATools.Parser.Internal
                 return null;
 
             int index = _expressions.Count;
-            while (index > 0 && _expressions[index - 1].Line >= expression.EndLine)
+            while (index > 0 && _expressions[index - 1].Location.Start.Line >= expression.Location.End.Line)
                 --index;
 
             if (index != _expressions.Count)
@@ -230,19 +232,19 @@ namespace RATools.Parser.Internal
             var enumerator = Expressions.GetEnumerator();
             while (enumerator.MoveNext())
             {
-                if (enumerator.Current.Line < FirstLine)
-                    FirstLine = enumerator.Current.Line;
-                if (enumerator.Current.EndLine > LastLine)
-                    LastLine = enumerator.Current.EndLine;
+                if (enumerator.Current.Location.Start.Line < FirstLine)
+                    FirstLine = enumerator.Current.Location.Start.Line;
+                if (enumerator.Current.Location.End.Line > LastLine)
+                    LastLine = enumerator.Current.Location.End.Line;
             }
 
             enumerator = ParseErrors.GetEnumerator();
             while (enumerator.MoveNext())
             {
-                if (enumerator.Current.Line < FirstLine)
-                    FirstLine = enumerator.Current.Line;
-                if (enumerator.Current.EndLine > LastLine)
-                    LastLine = enumerator.Current.EndLine;
+                if (enumerator.Current.Location.Start.Line < FirstLine)
+                    FirstLine = enumerator.Current.Location.Start.Line;
+                if (enumerator.Current.Location.End.Line > LastLine)
+                    LastLine = enumerator.Current.Location.End.Line;
             }
         }
 
@@ -253,7 +255,7 @@ namespace RATools.Parser.Internal
             foreach (var error in ParseErrors)
             {
                 var innerError = error.InnermostError ?? error;
-                if (innerError.Line <= line && innerError.EndLine >= line)
+                if (innerError.Location.Start.Line <= line && innerError.Location.End.Line >= line)
                    expressions.Add(innerError);
             }
 
@@ -264,10 +266,10 @@ namespace RATools.Parser.Internal
         { 
             foreach (var expression in expressions)
             {
-                if (expression.EndLine < line)
+                if (expression.Location.End.Line < line)
                     continue;
 
-                if (expression.Line > line)
+                if (expression.Location.Start.Line > line)
                     break;
 
                 var nested = expression as INestedExpressions;

--- a/Parser/Internal/ExpressionGroupCollection.cs
+++ b/Parser/Internal/ExpressionGroupCollection.cs
@@ -157,14 +157,14 @@ namespace RATools.Parser.Internal
                 for (int j = _evaluationErrors.Count - 1; j >= 0; j--)
                 {
                     var error = _evaluationErrors[j];
-                    if (error.EndLine >= group.FirstLine && error.Line <= group.LastLine)
+                    if (error.Location.End.Line >= group.FirstLine && error.Location.Start.Line <= group.LastLine)
                     {
                         _evaluationErrors.RemoveAt(j);
                     }
                     else if (error.InnerError != null)
                     {
                         error = error.InnermostError;
-                        if (error.EndLine >= group.FirstLine && error.Line <= group.LastLine)
+                        if (error.Location.End.Line >= group.FirstLine && error.Location.Start.Line <= group.LastLine)
                             _evaluationErrors.RemoveAt(j);
                     }
                 }
@@ -338,7 +338,8 @@ namespace RATools.Parser.Internal
             foreach (var error in _evaluationErrors)
             {
                 var unknownVariableError = error.InnermostError as UnknownVariableParseErrorExpression;
-                if (unknownVariableError != null && unknownVariableError.Line <= line && unknownVariableError.EndLine >= line)
+                if (unknownVariableError != null && unknownVariableError.Location.Start.Line <= line &&
+                    unknownVariableError.Location.End.Line >= line)
                 {
                     if (!expressions.Contains(unknownVariableError))
                         expressions.Add(unknownVariableError);
@@ -350,12 +351,14 @@ namespace RATools.Parser.Internal
                 var scan = error;
                 do
                 {
-                    if (scan.Line <= line && scan.EndLine >= line)
+                    if (scan.Location.Start.Line <= line && scan.Location.End.Line >= line)
                     {
                         // scan is more significant than current error, use it
                         mostSignificantError = scan;
                     }
-                    else if (mostSignificantError != null && scan.Line >= mostSignificantError.Line && scan.EndLine < mostSignificantError.EndLine)
+                    else if (mostSignificantError != null &&
+                        scan.Location.Start.Line >= mostSignificantError.Location.Start.Line &&
+                        scan.Location.End.Line < mostSignificantError.Location.End.Line)
                     {
                         // scan is more significant than current error, but not part of line, ignore it
                         mostSignificantError = null;

--- a/Parser/Internal/ForExpression.cs
+++ b/Parser/Internal/ForExpression.cs
@@ -80,10 +80,7 @@ namespace RATools.Parser.Internal
 
             loop._keywordFor = keywordFor;
             loop._keywordIn = keywordIn;
-            loop.Line = keywordFor.Line;
-            loop.Column = keywordFor.Column;
-            loop.EndLine = tokenizer.Line;
-            loop.EndColumn = tokenizer.Column;
+            loop.Location = new TextRange(keywordFor.Location.Start, tokenizer.Location);
 
             return loop;
         }

--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -18,8 +18,7 @@ namespace RATools.Parser.Internal
             FunctionName = functionName;
             Parameters = parameters;
 
-            Line = functionName.Line;
-            Column = functionName.Column;            
+            Location = new Jamiras.Components.TextRange(functionName.Location.Start.Line, functionName.Location.Start.Column, 0, 0);
         }
 
         /// <summary>
@@ -130,7 +129,7 @@ namespace RATools.Parser.Internal
             if (!functionDefinition.Evaluate(functionScope, out result))
             {
                 var error = result as ParseErrorExpression;
-                if (error.Line == 0)
+                if (error.Location.Start.Line == 0)
                     this.CopyLocation(error);
                 result = ParseErrorExpression.WrapError(error, FunctionName.Name + " call failed", FunctionName);
                 return false;
@@ -153,7 +152,7 @@ namespace RATools.Parser.Internal
             if (Evaluate(scope, out result))
                 return true;
 
-            if (result.Line == 0)
+            if (result.Location.Start.Line == 0)
                 result = new ParseErrorExpression(result, FunctionName);
 
             return false;
@@ -419,10 +418,9 @@ namespace RATools.Parser.Internal
         }
 
         internal FunctionNameExpression(VariableExpression variable)
-            : base(variable.Name, variable.Line, variable.Column)
+            : base(variable.Name)
         {
-            EndLine = variable.EndLine;
-            EndColumn = variable.EndColumn;
+            Location = variable.Location;
         }
 
         public override string ToString()

--- a/Parser/Internal/FunctionDefinitionExpression.cs
+++ b/Parser/Internal/FunctionDefinitionExpression.cs
@@ -84,8 +84,7 @@ namespace RATools.Parser.Internal
         {
             var function = new FunctionDefinitionExpression();
             function._keyword = new KeywordExpression("function", line, column);
-            function.Line = line;
-            function.Column = column;
+            function.Location = new TextRange(line, column, 0, 0);
 
             ExpressionBase.SkipWhitespace(tokenizer);
 
@@ -158,8 +157,7 @@ namespace RATools.Parser.Internal
 
                 var returnExpression = new ReturnExpression(expression);
                 function.Expressions.Add(returnExpression);
-                function.EndLine = expression.EndLine;
-                function.EndColumn = expression.EndColumn;
+                function.Location = new TextRange(function.Location.Start, expression.Location.End);
                 return function;
             }
 
@@ -198,8 +196,7 @@ namespace RATools.Parser.Internal
                 ExpressionBase.SkipWhitespace(tokenizer);
             }
 
-            function.EndLine = tokenizer.Line;
-            function.EndColumn = tokenizer.Column;
+            function.Location = new TextRange(function.Location.Start, tokenizer.Location);
             tokenizer.Advance();
             return function;
         }

--- a/Parser/Internal/KeywordExpression.cs
+++ b/Parser/Internal/KeywordExpression.cs
@@ -13,10 +13,7 @@ namespace RATools.Parser.Internal
         internal KeywordExpression(string keyword, int line, int column)
             : this(keyword)
         {
-            Line = line;
-            EndLine = line;
-            Column = column;
-            EndColumn = column + keyword.Length - 1;
+            Location = new Jamiras.Components.TextRange(line, column, line, column + keyword.Length - 1);
         }
 
         /// <summary>

--- a/Parser/Internal/LeftRightExpressionBase.cs
+++ b/Parser/Internal/LeftRightExpressionBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
+using Jamiras.Components;
 
 namespace RATools.Parser.Internal
 {
@@ -12,18 +13,9 @@ namespace RATools.Parser.Internal
             Right = right;
 
             if (left != null)
-            {
-                Line = left.Line;
-                Column = left.Column;
-            }
+                Location = new TextRange(left.Location.Start, right.Location.End);
             else
-            {
-                Line = right.Line;
-                Column = right.Column;
-            }
-
-            EndLine = right.EndLine;
-            EndColumn = right.EndColumn;
+                Location = right.Location;
         }
 
         /// <summary>
@@ -50,12 +42,10 @@ namespace RATools.Parser.Internal
             //   B   C    >    A   E          B = Left              E = Right.Right
             //      D E       B D             C = Right (newRoot)
             Right = newRoot.Left;
-            EndLine = Right.EndLine;
-            EndColumn = Right.EndColumn;
+            Location = new TextRange(Location.Start, Right.Location.End);
 
             newRoot.Left = this.Rebalance();
-            newRoot.Line = newRoot.Left.Line;
-            newRoot.Column = newRoot.Left.Column;
+            newRoot.Location = new TextRange(newRoot.Left.Location.Start, newRoot.Location.End);
 
             return newRoot;
         }

--- a/Parser/Internal/ParseErrorExpression.cs
+++ b/Parser/Internal/ParseErrorExpression.cs
@@ -13,24 +13,19 @@ namespace RATools.Parser.Internal
         public ParseErrorExpression(string message, int line, int column, int endLine, int endColumn)
             : this(message)
         {
-            Line = line;
-            Column = column;
-            EndLine = endLine;
-            EndColumn = endColumn;
+            Location = new Jamiras.Components.TextRange(line, column, endLine, endColumn);
         }
 
         public ParseErrorExpression(string message, ExpressionBase expression)
-            : this(message, expression.Line, expression.Column, expression.EndLine, expression.EndColumn)
+            : this(message)
         {
+            Location = expression.Location;
         }
 
         public ParseErrorExpression(ExpressionBase error, ExpressionBase expression)
             : base(ExpressionType.ParseError)
         {
-            Line = expression.Line;
-            Column = expression.Column;
-            EndLine = expression.EndLine;
-            EndColumn = expression.EndColumn;
+            Location = expression.Location;
 
             var parseError = error as ParseErrorExpression;
             if (parseError != null)
@@ -38,12 +33,9 @@ namespace RATools.Parser.Internal
                 Message = parseError.Message;
                 InnerError = parseError.InnerError;
 
-                if (parseError.Line != 0)
+                if (parseError.Location.Start.Line != 0)
                 {
-                    Line = parseError.Line;
-                    Column = parseError.Column;
-                    EndLine = parseError.EndLine;
-                    EndColumn = parseError.EndColumn;
+                    Location = parseError.Location;
                 }
             }
             else
@@ -54,8 +46,7 @@ namespace RATools.Parser.Internal
 
         public static ParseErrorExpression WrapError(ParseErrorExpression error, string message, ExpressionBase expression)
         {
-            if (error.EndColumn == expression.EndColumn && error.Column == expression.Column &&
-                error.EndLine == expression.EndLine && error.Line == expression.Line)
+            if (error.Location.End == expression.Location.End && error.Location.Start == expression.Location.Start)
             {
                 return error;
             }

--- a/Parser/Internal/ReturnExpression.cs
+++ b/Parser/Internal/ReturnExpression.cs
@@ -9,19 +9,14 @@ namespace RATools.Parser.Internal
             : base(ExpressionType.Return)
         {
             Value = value;
-
-            Line = value.Line;
-            Column = value.Column;
-            EndLine = value.EndLine;
-            EndColumn = value.EndColumn;
+            Location = value.Location;
         }
 
         public ReturnExpression(KeywordExpression keyword, ExpressionBase value)
             : this(value)
         {
             _keyword = keyword;
-            Line = keyword.Line;
-            Column = keyword.Column;
+            Location = new Jamiras.Components.TextRange(keyword.Location.Start, value.Location.End);
         }
 
         internal KeywordExpression Keyword

--- a/Parser/Internal/VariableExpression.cs
+++ b/Parser/Internal/VariableExpression.cs
@@ -15,10 +15,7 @@ namespace RATools.Parser.Internal
         internal VariableExpressionBase(string name, int line, int column)
             : this(name)
         {
-            Line = line;
-            EndLine = line;
-            Column = column;
-            EndColumn = column + name.Length - 1;
+            Location = new Jamiras.Components.TextRange(line, column, line, column + name.Length - 1);
         }
 
         /// <summary>
@@ -116,10 +113,9 @@ namespace RATools.Parser.Internal
         }
 
         internal VariableDefinitionExpression(VariableExpression variable)
-            : base(variable.Name, variable.Line, variable.Column)
+            : base(variable.Name)
         {
-            EndLine = variable.EndLine;
-            EndColumn = variable.EndColumn;
+            Location = variable.Location;
         }
 
         IEnumerable<ExpressionBase> INestedExpressions.NestedExpressions

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -40,7 +40,7 @@ namespace RATools.Test.Parser
             while (err.InnerError != null)
                 err = err.InnerError;
 
-            return string.Format("{0}:{1} {2}", err.Line, err.Column, err.Message);
+            return string.Format("{0}:{1} {2}", err.Location.Start.Line, err.Location.Start.Column, err.Message);
         }
 
         private static string GetRequirements(Achievement achievement)

--- a/Tests/Parser/Internal/DictionaryExpressionTests.cs
+++ b/Tests/Parser/Internal/DictionaryExpressionTests.cs
@@ -64,8 +64,8 @@ namespace RATools.Test.Parser.Internal
             Assert.That(dict.Count, Is.EqualTo(0));
             Assert.That(group.ParseErrors.Count(), Is.GreaterThan(0));
             Assert.That(group.ParseErrors.ElementAt(0).Message, Is.EqualTo("Expecting colon following key expression"));
-            Assert.That(group.ParseErrors.ElementAt(0).Line, Is.EqualTo(1));
-            Assert.That(group.ParseErrors.ElementAt(0).Column, Is.EqualTo(4));
+            Assert.That(group.ParseErrors.ElementAt(0).Location.Start.Line, Is.EqualTo(1));
+            Assert.That(group.ParseErrors.ElementAt(0).Location.Start.Column, Is.EqualTo(4));
         }
 
         [Test]
@@ -79,8 +79,8 @@ namespace RATools.Test.Parser.Internal
             var dict = (DictionaryExpression)expression;
             Assert.That(group.ParseErrors.Count(), Is.GreaterThan(0));
             Assert.That(group.ParseErrors.ElementAt(0).Message, Is.EqualTo("Expecting comma between entries"));
-            Assert.That(group.ParseErrors.ElementAt(0).Line, Is.EqualTo(2));
-            Assert.That(group.ParseErrors.ElementAt(0).Column, Is.EqualTo(2));
+            Assert.That(group.ParseErrors.ElementAt(0).Location.Start.Line, Is.EqualTo(2));
+            Assert.That(group.ParseErrors.ElementAt(0).Location.Start.Column, Is.EqualTo(2));
         }
 
         [Test]

--- a/Tests/Parser/Internal/ExpressionBaseTests.cs
+++ b/Tests/Parser/Internal/ExpressionBaseTests.cs
@@ -407,38 +407,38 @@ namespace RATools.Test.Parser.Internal
                 );
             var expression = ExpressionBase.Parse(tokenizer);
             Assert.That(expression, Is.InstanceOf<AssignmentExpression>());
-            Assert.That(expression.Line, Is.EqualTo(4));
-            Assert.That(expression.Column, Is.EqualTo(1));
-            Assert.That(expression.EndLine, Is.EqualTo(4));
-            Assert.That(expression.EndColumn, Is.EqualTo(5));
+            Assert.That(expression.Location.Start.Line, Is.EqualTo(4));
+            Assert.That(expression.Location.Start.Column, Is.EqualTo(1));
+            Assert.That(expression.Location.End.Line, Is.EqualTo(4));
+            Assert.That(expression.Location.End.Column, Is.EqualTo(5));
 
             expression = ExpressionBase.Parse(tokenizer);
             Assert.That(expression, Is.InstanceOf<AssignmentExpression>());
-            Assert.That(expression.Line, Is.EqualTo(5));
-            Assert.That(expression.Column, Is.EqualTo(3));
-            Assert.That(expression.EndLine, Is.EqualTo(5));
-            Assert.That(expression.EndColumn, Is.EqualTo(11));
+            Assert.That(expression.Location.Start.Line, Is.EqualTo(5));
+            Assert.That(expression.Location.Start.Column, Is.EqualTo(3));
+            Assert.That(expression.Location.End.Line, Is.EqualTo(5));
+            Assert.That(expression.Location.End.Column, Is.EqualTo(11));
 
             expression = ((AssignmentExpression)expression).Value;
             Assert.That(expression, Is.InstanceOf<MathematicExpression>());
-            Assert.That(expression.Line, Is.EqualTo(5));
-            Assert.That(expression.Column, Is.EqualTo(7));
-            Assert.That(expression.EndLine, Is.EqualTo(5));
-            Assert.That(expression.EndColumn, Is.EqualTo(11));
+            Assert.That(expression.Location.Start.Line, Is.EqualTo(5));
+            Assert.That(expression.Location.Start.Column, Is.EqualTo(7));
+            Assert.That(expression.Location.End.Line, Is.EqualTo(5));
+            Assert.That(expression.Location.End.Column, Is.EqualTo(11));
 
             expression = ((MathematicExpression)expression).Right;
             Assert.That(expression, Is.InstanceOf<IntegerConstantExpression>());
-            Assert.That(expression.Line, Is.EqualTo(5));
-            Assert.That(expression.Column, Is.EqualTo(11));
-            Assert.That(expression.EndLine, Is.EqualTo(5));
-            Assert.That(expression.EndColumn, Is.EqualTo(11));
+            Assert.That(expression.Location.Start.Line, Is.EqualTo(5));
+            Assert.That(expression.Location.Start.Column, Is.EqualTo(11));
+            Assert.That(expression.Location.End.Line, Is.EqualTo(5));
+            Assert.That(expression.Location.End.Column, Is.EqualTo(11));
 
             expression = ExpressionBase.Parse(tokenizer);
             Assert.That(expression, Is.InstanceOf<ReturnExpression>());
-            Assert.That(expression.Line, Is.EqualTo(7));
-            Assert.That(expression.Column, Is.EqualTo(1));
-            Assert.That(expression.EndLine, Is.EqualTo(7));
-            Assert.That(expression.EndColumn, Is.EqualTo(8));
+            Assert.That(expression.Location.Start.Line, Is.EqualTo(7));
+            Assert.That(expression.Location.Start.Column, Is.EqualTo(1));
+            Assert.That(expression.Location.End.Line, Is.EqualTo(7));
+            Assert.That(expression.Location.End.Column, Is.EqualTo(8));
         }
     }
 }

--- a/Tests/Parser/Internal/ExpressionGroupTests.cs
+++ b/Tests/Parser/Internal/ExpressionGroupTests.cs
@@ -149,23 +149,23 @@ namespace RATools.Test.Parser.Internal
             Assert.That(group.LastLine, Is.EqualTo(1));
             var assignment = group.Expressions.First() as AssignmentExpression;
             Assert.That(assignment, Is.Not.Null);
-            Assert.That(assignment.Line, Is.EqualTo(1));
-            Assert.That(assignment.Variable.Line, Is.EqualTo(1));
-            Assert.That(assignment.Value.Line, Is.EqualTo(1));
+            Assert.That(assignment.Location.Start.Line, Is.EqualTo(1));
+            Assert.That(assignment.Variable.Location.Start.Line, Is.EqualTo(1));
+            Assert.That(assignment.Value.Location.Start.Line, Is.EqualTo(1));
 
             group.AdjustLines(6);
             Assert.That(group.FirstLine, Is.EqualTo(7));
             Assert.That(group.LastLine, Is.EqualTo(7));
-            Assert.That(assignment.Line, Is.EqualTo(7));
-            Assert.That(assignment.Variable.Line, Is.EqualTo(7));
-            Assert.That(assignment.Value.Line, Is.EqualTo(7));
+            Assert.That(assignment.Location.Start.Line, Is.EqualTo(7));
+            Assert.That(assignment.Variable.Location.Start.Line, Is.EqualTo(7));
+            Assert.That(assignment.Value.Location.Start.Line, Is.EqualTo(7));
 
             group.AdjustLines(-2);
             Assert.That(group.FirstLine, Is.EqualTo(5));
             Assert.That(group.LastLine, Is.EqualTo(5));
-            Assert.That(assignment.Line, Is.EqualTo(5));
-            Assert.That(assignment.Variable.Line, Is.EqualTo(5));
-            Assert.That(assignment.Value.Line, Is.EqualTo(5));
+            Assert.That(assignment.Location.Start.Line, Is.EqualTo(5));
+            Assert.That(assignment.Variable.Location.Start.Line, Is.EqualTo(5));
+            Assert.That(assignment.Value.Location.Start.Line, Is.EqualTo(5));
         }
 
         [Test]

--- a/Tests/Parser/Internal/LeftRightExpressionBaseTests.cs
+++ b/Tests/Parser/Internal/LeftRightExpressionBaseTests.cs
@@ -35,10 +35,7 @@ namespace RATools.Test.Parser.Internal
         {
             public TestExpression(int value, int column) : base(value)
             {
-                Line = column;
-                Column = column;
-                EndLine = column + 1;
-                EndColumn = column + 1;
+                Location = new Jamiras.Components.TextRange(column, column, column + 1, column + 1);
             }
         }
 
@@ -48,10 +45,10 @@ namespace RATools.Test.Parser.Internal
             var left = new TestExpression(1, 1);
             var right = new TestExpression(2, 3);
             var node = new LeftRightExpression(left, right);
-            Assert.That(node.Line, Is.EqualTo(left.Line));
-            Assert.That(node.Column, Is.EqualTo(left.Column));
-            Assert.That(node.EndLine, Is.EqualTo(right.EndLine));
-            Assert.That(node.EndColumn, Is.EqualTo(right.EndColumn));
+            Assert.That(node.Location.Start.Line, Is.EqualTo(left.Location.Start.Line));
+            Assert.That(node.Location.Start.Column, Is.EqualTo(left.Location.Start.Column));
+            Assert.That(node.Location.End.Line, Is.EqualTo(right.Location.End.Line));
+            Assert.That(node.Location.End.Column, Is.EqualTo(right.Location.End.Column));
         }
 
         [Test]
@@ -59,10 +56,10 @@ namespace RATools.Test.Parser.Internal
         {
             var right = new TestExpression(2, 3);
             var node = new LeftRightExpression(null, right);
-            Assert.That(node.Line, Is.EqualTo(right.Line));
-            Assert.That(node.Column, Is.EqualTo(right.Column));
-            Assert.That(node.EndLine, Is.EqualTo(right.EndLine));
-            Assert.That(node.EndColumn, Is.EqualTo(right.EndColumn));
+            Assert.That(node.Location.Start.Line, Is.EqualTo(right.Location.Start.Line));
+            Assert.That(node.Location.Start.Column, Is.EqualTo(right.Location.Start.Column));
+            Assert.That(node.Location.End.Line, Is.EqualTo(right.Location.End.Line));
+            Assert.That(node.Location.End.Column, Is.EqualTo(right.Location.End.Column));
         }
 
         [Test]
@@ -79,10 +76,10 @@ namespace RATools.Test.Parser.Internal
             var newNode = node.DoRebalance() as LeftRightExpression;
 
             Assert.That(newNode, Is.SameAs(right));
-            Assert.That(newNode.Line, Is.EqualTo(one.Line));
-            Assert.That(newNode.Column, Is.EqualTo(one.Column));
-            Assert.That(newNode.EndLine, Is.EqualTo(three.EndLine));
-            Assert.That(newNode.EndColumn, Is.EqualTo(three.EndColumn));
+            Assert.That(newNode.Location.Start.Line, Is.EqualTo(one.Location.Start.Line));
+            Assert.That(newNode.Location.Start.Column, Is.EqualTo(one.Location.Start.Column));
+            Assert.That(newNode.Location.End.Line, Is.EqualTo(three.Location.End.Line));
+            Assert.That(newNode.Location.End.Column, Is.EqualTo(three.Location.End.Column));
 
             Assert.That(newNode.Right, Is.SameAs(three));
 
@@ -91,10 +88,10 @@ namespace RATools.Test.Parser.Internal
             Assert.That(newLeft.Left, Is.SameAs(one));
             Assert.That(newLeft.Right, Is.SameAs(two));
 
-            Assert.That(newLeft.Line, Is.EqualTo(one.Line));
-            Assert.That(newLeft.Column, Is.EqualTo(one.Column));
-            Assert.That(newLeft.EndLine, Is.EqualTo(two.EndLine));
-            Assert.That(newLeft.EndColumn, Is.EqualTo(two.EndColumn));
+            Assert.That(newLeft.Location.Start.Line, Is.EqualTo(one.Location.Start.Line));
+            Assert.That(newLeft.Location.Start.Column, Is.EqualTo(one.Location.Start.Column));
+            Assert.That(newLeft.Location.End.Line, Is.EqualTo(two.Location.End.Line));
+            Assert.That(newLeft.Location.End.Column, Is.EqualTo(two.Location.End.Column));
         }
 
         [Test]

--- a/ViewModels/EditorViewModel.cs
+++ b/ViewModels/EditorViewModel.cs
@@ -210,10 +210,10 @@ namespace RATools.ViewModels
                     {
                         errors.Push(new CodeReferenceViewModel
                         {
-                            StartLine = innerError.Line,
-                            StartColumn = innerError.Column,
-                            EndLine = innerError.EndLine,
-                            EndColumn = innerError.EndColumn,
+                            StartLine = innerError.Location.Start.Line,
+                            StartColumn = innerError.Location.Start.Column,
+                            EndLine = innerError.Location.End.Line,
+                            EndColumn = innerError.Location.End.Column,
                             Message = innerError.Message
                         });
 
@@ -280,9 +280,10 @@ namespace RATools.ViewModels
 
         private string BuildTooltip(ExpressionBase expression)
         {
-            if (expression.Line > 0 && expression.EndLine > 0)
+            if (expression.Location.Start.Line > 0 && expression.Location.End.Line > 0)
             {
-                var text = GetText(expression.Line, expression.Column, expression.EndLine, expression.EndColumn + 1);
+                var text = GetText(expression.Location.Start.Line, expression.Location.Start.Column,
+                    expression.Location.End.Line, expression.Location.End.Column + 1);
                 var builder = new StringBuilder();
                 bool lastCharWasWhitespace = true;
                 bool inComment = false;
@@ -361,8 +362,8 @@ namespace RATools.ViewModels
                     }
                 }
 
-                var expressionStart = (expression.Line == line) ? expression.Column : 1;
-                var expressionEnd = (expression.EndLine == line) ? expression.EndColumn : e.Line.Text.Length + 1;
+                var expressionStart = (expression.Location.Start.Line == line) ? expression.Location.Start.Column : 1;
+                var expressionEnd = (expression.Location.End.Line == line) ? expression.Location.End.Column : e.Line.Text.Length + 1;
 
                 var parseError = expression as ParseErrorExpression;
                 if (parseError != null)
@@ -412,18 +413,18 @@ namespace RATools.ViewModels
             var column = CursorColumn;
             foreach (var expression in expressions)
             {
-                if (column < expression.Column || column > expression.EndColumn + 1)
+                if (column < expression.Location.Start.Column || column > expression.Location.End.Column + 1)
                     continue;
 
                 var functionCall = expression as FunctionNameExpression;
                 if (functionCall != null)
                 {
                     var function = _parsedContent.Scope.GetFunction(functionCall.Name);
-                    if (function != null && function.Line != 0)
+                    if (function != null && function.Location.Start.Line != 0)
                     {
-                        GotoLine(function.Name.Line);
-                        MoveCursorTo(function.Name.Line, function.Name.Column, MoveCursorFlags.None);
-                        MoveCursorTo(function.Name.EndLine, function.Name.EndColumn + 1, MoveCursorFlags.Highlighting);
+                        GotoLine(function.Name.Location.Start.Line);
+                        MoveCursorTo(function.Name.Location.Start.Line, function.Name.Location.Start.Column, MoveCursorFlags.None);
+                        MoveCursorTo(function.Name.Location.End.Line, function.Name.Location.End.Column + 1, MoveCursorFlags.Highlighting);
                     }
 
                     break;
@@ -433,10 +434,10 @@ namespace RATools.ViewModels
                 if (variableReference != null)
                 {
                     var variable = _parsedContent.Scope.GetVariableDefinition(variableReference.Name);
-                    if (variable != null && variable.Line != 0)
+                    if (variable != null && variable.Location.Start.Line != 0)
                     {
-                        MoveCursorTo(variable.Line, variable.Column, MoveCursorFlags.None);
-                        MoveCursorTo(variable.EndLine, variable.EndColumn + 1, MoveCursorFlags.Highlighting);
+                        MoveCursorTo(variable.Location.Start.Line, variable.Location.Start.Column, MoveCursorFlags.None);
+                        MoveCursorTo(variable.Location.End.Line, variable.Location.End.Column + 1, MoveCursorFlags.Highlighting);
                     }
 
                     break;


### PR DESCRIPTION
simplifies debugging by merging `Line`, `Column`, `EndLine` and `EndColumn` into a single `Location` property.