### PR TITLE
highlight variable (not definition of variable) when variable type is incorrect

### DIFF
--- a/Parser/Functions/RichPresenceLookupFunction.cs
+++ b/Parser/Functions/RichPresenceLookupFunction.cs
@@ -29,18 +29,11 @@ namespace RATools.Parser.Functions
             if (expression == null)
                 return false;
 
-            var parameter = GetParameter(scope, "dictionary", out result);
-            if (parameter == null)
-                return false;
-
-            var dictionary = parameter as DictionaryExpression;
+            var dictionary = GetDictionaryParameter(scope, "dictionary", out result);
             if (dictionary == null)
-            {
-                result = new ParseErrorExpression("dictionary is not a dictionary", parameter);
                 return false;
-            }
 
-            var fallback = GetParameter(scope, "fallback", out result);
+            var fallback = GetStringParameter(scope, "fallback", out result);
             if (fallback == null)
                 return false;
 
@@ -59,11 +52,11 @@ namespace RATools.Parser.Functions
             if (expression == null)
                 return false;
 
-            var dictionary = GetParameter(scope, "dictionary", out result) as DictionaryExpression;
+            var dictionary = GetDictionaryParameter(scope, "dictionary", out result);
             if (dictionary == null)
                 return false;
 
-            var fallback = GetParameter(scope, "fallback", out result);
+            var fallback = GetStringParameter(scope, "fallback", out result);
             if (fallback == null)
                 return false;
 

--- a/Parser/Internal/FunctionDefinitionExpression.cs
+++ b/Parser/Internal/FunctionDefinitionExpression.cs
@@ -271,6 +271,23 @@ namespace RATools.Parser.Internal
             return parameter;
         }
 
+        private ExpressionBase LocateParameter(InterpreterScope scope, string name)
+        {
+            var functionCall = scope.GetContext<FunctionCallExpression>();
+            if (functionCall != null)
+            {
+                var nameEnumerator = Parameters.GetEnumerator();
+                var valueEnumerator = functionCall.Parameters.GetEnumerator();
+                while (nameEnumerator.MoveNext() && valueEnumerator.MoveNext())
+                {
+                    if (nameEnumerator.Current.Name == name)
+                        return valueEnumerator.Current;
+                }
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Gets the integer parameter from the <paramref name="scope"/> or <see cref="DefaultParameters"/> collections.
         /// </summary>
@@ -287,6 +304,10 @@ namespace RATools.Parser.Internal
             var typedParameter = parameter as IntegerConstantExpression;
             if (typedParameter == null)
             {
+                var originalParameter = LocateParameter(scope, name);
+                if (originalParameter != null)
+                    parameter = originalParameter;
+
                 parseError = new ParseErrorExpression(name + " is not an integer", parameter);
                 return null;
             }
@@ -311,7 +332,39 @@ namespace RATools.Parser.Internal
             var typedParameter = parameter as StringConstantExpression;
             if (typedParameter == null)
             {
+                var originalParameter = LocateParameter(scope, name);
+                if (originalParameter != null)
+                    parameter = originalParameter;
+
                 parseError = new ParseErrorExpression(name + " is not a string", parameter);
+                return null;
+            }
+
+            parseError = null;
+            return typedParameter;
+        }
+
+        /// <summary>
+        /// Gets the dictionary parameter from the <paramref name="scope"/> or <see cref="DefaultParameters"/> collections.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="name">The name of the parameter.</param>
+        /// <param name="parseError">[out] The error that occurred.</param>
+        /// <returns>The parameter value, or <c>null</c> if an error occurred.</b></returns>
+        protected DictionaryExpression GetDictionaryParameter(InterpreterScope scope, string name, out ExpressionBase parseError)
+        {
+            var parameter = GetParameter(scope, name, out parseError);
+            if (parameter == null)
+                return null;
+
+            var typedParameter = parameter as DictionaryExpression;
+            if (typedParameter == null)
+            {
+                var originalParameter = LocateParameter(scope, name);
+                if (originalParameter != null)
+                    parameter = originalParameter;
+
+                parseError = new ParseErrorExpression(name + " is not a dictionary", parameter);
                 return null;
             }
 

--- a/Parser/RichPresenceBuilder.cs
+++ b/Parser/RichPresenceBuilder.cs
@@ -52,7 +52,7 @@ namespace RATools.Parser
             };
         }
 
-        public ParseErrorExpression AddLookupField(ExpressionBase func, string name, DictionaryExpression dict, ExpressionBase fallback)
+        public ParseErrorExpression AddLookupField(ExpressionBase func, string name, DictionaryExpression dict, StringConstantExpression fallback)
         {
             var tinyDict = new TinyDictionary<int, string>();
             foreach (var entry in dict.Entries)
@@ -68,15 +68,11 @@ namespace RATools.Parser
                 tinyDict[key.Value] = value.Value;
             }
 
-            var fallbackValue = fallback as StringConstantExpression;
-            if (fallbackValue == null)
-                return new ParseErrorExpression("Fallback value is not a string", fallback);
-
             _lookupFields[name] = new Lookup
             {
                 Func = func,
                 Entries = tinyDict,
-                Fallback = fallbackValue
+                Fallback = fallback
             };
 
             return null;

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -875,7 +875,15 @@ namespace RATools.Test.Parser
         {
             var parser = Parse("dict = { 1:\"Yes\", 2:\"No\" }\n" +
                                "rich_presence_display(\"value {0} here\", rich_presence_lookup(\"Test\", byte(0x1234), dict, 1))", false);
-            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("2:90 Fallback value is not a string"));
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("2:90 fallback is not a string"));
+        }
+
+        [Test]
+        public void TestRichPresenceLookupInvalidFallbackVariable()
+        {
+            var parser = Parse("dict = { 1:\"Yes\", 2:\"No\" }\n" +
+                               "rich_presence_display(\"value {0} here\", rich_presence_lookup(\"Test\", byte(0x1234), dict, dict))", false);
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("2:90 fallback is not a string"));
         }
 
         [Test]


### PR DESCRIPTION
fixes a weird visual error where the dictionary definition gets highlighted when the dictionary is passed to a built-in function expecting a string or integer.