### PR TITLE
support for hex constants in rich presence

### DIFF
--- a/Data/Field.cs
+++ b/Data/Field.cs
@@ -309,6 +309,11 @@ namespace RATools.Data
                 fieldType = FieldType.BinaryCodedDecimal;
                 tokenizer.Advance();
             }
+            else if (tokenizer.NextChar == 'h')
+            {
+                tokenizer.Advance();
+                return new Field { Type = FieldType.Value, Value = ReadHexNumber(tokenizer) };
+            }
 
             if (!tokenizer.Match("0x"))
                 return new Field { Type = FieldType.Value, Value = ReadNumber(tokenizer) };
@@ -369,10 +374,15 @@ namespace RATools.Data
                 case ' ': size = FieldSize.Word; tokenizer.Advance(); break;
             }
 
-            uint address = 0;
+            return new Field { Size = size, Type = fieldType, Value = ReadHexNumber(tokenizer) };
+        }
+
+        private static uint ReadHexNumber(Tokenizer tokenizer)
+        {
+            uint value = 0;
             do
             {
-                uint charValue = 255;
+                uint charValue;
                 switch (tokenizer.NextChar)
                 {
                     case '0': charValue = 0; break;
@@ -397,17 +407,15 @@ namespace RATools.Data
                     case 'E': charValue = 14; break;
                     case 'f':
                     case 'F': charValue = 15; break;
+                    default:
+                        return value;
                 }
 
-                if (charValue == 255)
-                    break;
-
                 tokenizer.Advance();
-                address <<= 4;
-                address += charValue;
-            } while (true);
 
-            return new Field { Size = size, Type = fieldType, Value = address };
+                value <<= 4;
+                value += charValue;
+            } while (true);
         }
 
         private static uint ReadNumber(Tokenizer tokenizer)

--- a/Tests/Data/FieldTests.cs
+++ b/Tests/Data/FieldTests.cs
@@ -117,6 +117,7 @@ namespace RATools.Tests.Data
         [TestCase("p0xH001234", FieldSize.Byte, FieldType.PriorValue, 0x1234)]
         [TestCase("b0xH001234", FieldSize.Byte, FieldType.BinaryCodedDecimal, 0x1234)]
         [TestCase("4660", FieldSize.None, FieldType.Value, 0x1234)]
+        [TestCase("h4660", FieldSize.None, FieldType.Value, 0x4660)]
         [TestCase("0xH123456", FieldSize.Byte, FieldType.MemoryAddress, 0x123456)]
         public void TestDeserialize(string serialized, FieldSize fieldSize, FieldType fieldType, int value)
         {


### PR DESCRIPTION
`hXXXX` is a valid representation of a hex constant, but since neither RATools nor the DLL generate hex constants, it hasn't been previously supported.

As it's entirely possible for the user to write rich presence or leaderboards using the syntax, it should be supported for the dumping feature.