### PR TITLE
replace recursive NormalizeNots algorithm with queue

### DIFF
--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -27,127 +27,6 @@ namespace RATools.Parser
             }
         }
 
-        private static bool NormalizeNots(ref ExpressionBase expression, out ParseErrorExpression error)
-        {
-            error = null;
-
-            // not a condition - don't need to worry about it
-            var condition = expression as ConditionalExpression;
-            if (condition == null)
-                return true;
-
-            var parent = new KeyValuePair<ConditionalExpression, ConditionalExpression>();
-            var queue = new Queue<KeyValuePair<ConditionalExpression, ConditionalExpression>>();
-            do
-            {
-                if (condition.Operation == ConditionalOperation.Not)
-                {
-                    // found a not - eliminate it
-                    var invertedExpression = condition.Right;
-                    if (!InvertExpression(ref invertedExpression, out error))
-                        return false;
-
-                    if (parent.Key == null) // root item
-                        expression = invertedExpression;
-                    else if (ReferenceEquals(parent.Key.Left, condition))
-                        parent.Key.Left = invertedExpression;
-                    else
-                        parent.Key.Right = invertedExpression;
-                }
-                else
-                {
-                    // not a not, check for nested conditions
-                    var left = condition.Left as ConditionalExpression;
-                    if (left != null)
-                        queue.Enqueue(new KeyValuePair<ConditionalExpression, ConditionalExpression>(condition, left));
-
-                    var right = condition.Right as ConditionalExpression;
-                    if (right != null)
-                        queue.Enqueue(new KeyValuePair<ConditionalExpression, ConditionalExpression>(condition, right));
-                }
-
-                if (queue.Count == 0)
-                    break;
-
-                parent = queue.Dequeue();
-                condition = parent.Value;
-            } while (true);
-
-            return true;
-        }
-
-        private static bool InvertExpression(ref ExpressionBase expression, out ParseErrorExpression error)
-        {
-            // logical inversion
-            var condition = expression as ConditionalExpression;
-            if (condition != null)
-            {
-                switch (condition.Operation)
-                {
-                    case ConditionalOperation.Not:
-                        // !(!A) => A
-                        expression = condition.Right;
-                        break;
-
-                    case ConditionalOperation.And:
-                        // !(A && B) => !A || !B
-                        expression = new ConditionalExpression(
-                            new ConditionalExpression(null, ConditionalOperation.Not, condition.Left),
-                            ConditionalOperation.Or,
-                            new ConditionalExpression(null, ConditionalOperation.Not, condition.Right));
-                        break;
-
-                    case ConditionalOperation.Or:
-                        // !(A || B) => !A && !B
-                        expression = new ConditionalExpression(
-                            new ConditionalExpression(null, ConditionalOperation.Not, condition.Left),
-                            ConditionalOperation.And,
-                            new ConditionalExpression(null, ConditionalOperation.Not, condition.Right));
-                        break;
-
-                    default:
-                        throw new NotImplementedException("Unsupported condition operation");
-                }
-
-                return NormalizeNots(ref expression, out error);
-            }
-
-            // comparative inversion
-            var comparison = expression as ComparisonExpression;
-            if (comparison != null)
-            {
-                // !(A == B) => A != B, !(A < B) => A >= B, ...
-                expression = new ComparisonExpression(
-                    comparison.Left,
-                    ComparisonExpression.GetOppositeComparisonOperation(comparison.Operation),
-                    comparison.Right);
-
-                return NormalizeNots(ref expression, out error);
-            }
-
-            var function = expression as FunctionCallExpression;
-            if (function != null)
-            {
-                if (function.FunctionName.Name == "always_true")
-                {
-                    expression = new FunctionCallExpression("always_false", function.Parameters);
-                    error = null;
-                    return true;
-                }
-
-                if (function.FunctionName.Name == "always_false")
-                {
-                    expression = new FunctionCallExpression("always_true", function.Parameters);
-                    error = null;
-                    return true;
-                }
-            }
-
-            // unsupported inversion
-            error = new ParseErrorExpression("! operator cannot be applied to " + expression.Type, expression);
-            return false;
-        }
-
         private static void FlattenOrClause(ExpressionBase clause, List<ExpressionBase> flattened)
         {
             var condition = clause as ConditionalExpression;
@@ -393,9 +272,6 @@ namespace RATools.Parser
 
         internal bool PopulateFromExpression(ExpressionBase expression, InterpreterScope scope, out ParseErrorExpression error)
         {
-            if (!NormalizeNots(ref expression, out error))
-                return false;
-
             var andedConditions = new List<ExpressionBase>();
             var orConditions = new List<ExpressionBase>();
             if (!SortConditions(expression, andedConditions, orConditions, out error))

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -525,33 +525,6 @@ namespace RATools.Test.Parser
         }
 
         [Test]
-        [TestCase("A == B", "A == B")]
-        [TestCase("!(A == B)", "A != B")]
-        [TestCase("!(A != B)", "A == B")]
-        [TestCase("!(A < B)", "A >= B")]
-        [TestCase("!(A <= B)", "A > B")]
-        [TestCase("!(A > B)", "A <= B")]
-        [TestCase("!(A >= B)", "A < B")]
-        [TestCase("!(A == 1 || B == 1)", "A != 1 && B != 1")]
-        [TestCase("!(A == 1 && B == 1)", "A != 1 || B != 1")]
-        [TestCase("!(!(A == B))", "A == B")]
-        [TestCase("!(A == 1 || !(B == 1 && C == 1))", "A != 1 && B == 1 && C == 1")]
-        public void TestNormalizeNots(string input, string expected)
-        {
-            input = input.Replace("A", "byte(0x00000A)");
-            input = input.Replace("B", "byte(0x00000B)");
-            input = input.Replace("C", "byte(0x00000C)");
-
-            expected = expected.Replace("A", "byte(0x00000A)");
-            expected = expected.Replace("B", "byte(0x00000B)");
-            expected = expected.Replace("C", "byte(0x00000C)");
-
-            var achievement = CreateAchievement(input);
-            // NOTE: not optimized - that's tested separately in TestOptimize
-            Assert.That(achievement.RequirementsDebugString, Is.EqualTo(expected));
-        }
-
-        [Test]
         // ==== CrossMultiplyOrConditions ====
         [TestCase("(A || B) && (C || D)", "(A && C) || (A && D) || (B && C) || (B && D)")]
         [TestCase("(A || B) && (A || D)", "(A && A) || (A && D) || (B && A) || (B && D)")]


### PR DESCRIPTION
fixes #210 

The problematic trigger has 2756 ANDed conditions. This is stored in a very sparse expression tree. When traversing the tree, somewhere around 2500 recursive calls are made, which is apparently enough to cause a stack overflow.

I've modified the `NormalizeNots` function to use a queue instead of recursion. This eliminates the recursive aspect, preventing the stack overflow.

The resulting achievement has 8550 conditions, and will probably need to be trimmed down.