### PR TITLE
add deduct() helper function for tally() function

### DIFF
--- a/Data/Requirement.cs
+++ b/Data/Requirement.cs
@@ -32,6 +32,7 @@ namespace RATools.Data
                 switch (Type)
                 {
                     case RequirementType.AddHits:
+                    case RequirementType.SubHits:
                     case RequirementType.AddSource:
                     case RequirementType.SubSource:
                     case RequirementType.AndNext:
@@ -585,6 +586,11 @@ namespace RATools.Data
         /// Adds the HitsCounts from this requirement to the next requirement.
         /// </summary>
         AddHits,
+
+        /// <summary>
+        /// Subtracts the HitsCounts from this requirement from the next requirement.
+        /// </summary>
+        SubHits,
 
         /// <summary>
         /// This requirement must also be true for the next requirement to be true.

--- a/Data/RequirementEx.cs
+++ b/Data/RequirementEx.cs
@@ -158,7 +158,7 @@ namespace RATools.Data
                 // precedence is AddAddress
                 //             > AddSource/SubSource
                 //             > AndNext/OrNext
-                //             > AddHits/ResetNextIf
+                //             > AddHits/SubHits/ResetNextIf
                 //             > ResetIf/PauseIf/Measured/MeasuredIf/Trigger
                 switch (requirement.Type)
                 {
@@ -183,6 +183,7 @@ namespace RATools.Data
                         break;
 
                     case RequirementType.AddHits:
+                    case RequirementType.SubHits:
                         AppendModifyHits(addHits, requirement, numberFormat, addSources, subSources, addAddress, andNext, resetNextIf);
                         addHits.Append(", ");
                         break;
@@ -352,6 +353,7 @@ namespace RATools.Data
                 switch (requirement.Type)
                 {
                     case RequirementType.AddHits:
+                    case RequirementType.SubHits:
                         // an always_false() condition will never generate a hit
                         if (requirement.Evaluate() == false)
                             continue;

--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -119,6 +119,8 @@ namespace RATools.Parser
                         requirement.Type = RequirementType.SubSource;
                     else if (tokenizer.Match("C:"))
                         requirement.Type = RequirementType.AddHits;
+                    else if (tokenizer.Match("D:"))
+                        requirement.Type = RequirementType.SubHits;
                     else if (tokenizer.Match("N:"))
                         requirement.Type = RequirementType.AndNext;
                     else if (tokenizer.Match("O:"))
@@ -411,6 +413,7 @@ namespace RATools.Parser
                 case RequirementType.AddSource: builder.Append("A:"); break;
                 case RequirementType.SubSource: builder.Append("B:"); break;
                 case RequirementType.AddHits: builder.Append("C:"); break;
+                case RequirementType.SubHits: builder.Append("D:"); break;
                 case RequirementType.AndNext: builder.Append("N:"); break;
                 case RequirementType.OrNext: builder.Append("O:"); break;
                 case RequirementType.Measured: builder.Append("M:"); break;

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -93,6 +93,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new OnceFunction());
                 _globalScope.AddFunction(new RepeatedFunction());
                 _globalScope.AddFunction(new TallyFunction());
+                _globalScope.AddFunction(new DeductFunction());
                 _globalScope.AddFunction(new FlagConditionFunction("never", RequirementType.ResetIf, ConditionalOperation.Or));
                 _globalScope.AddFunction(new FlagConditionFunction("unless", RequirementType.PauseIf, ConditionalOperation.Or));
                 _globalScope.AddFunction(new FlagConditionFunction("trigger_when", RequirementType.Trigger, ConditionalOperation.And));

--- a/Parser/Functions/RepeatedFunction.cs
+++ b/Parser/Functions/RepeatedFunction.cs
@@ -45,6 +45,8 @@ namespace RATools.Parser.Functions
             {
                 if (requirement.Type == RequirementType.AddHits)
                     return new ParseErrorExpression("tally not allowed in subclause");
+                if (requirement.Type == RequirementType.SubHits)
+                    return new ParseErrorExpression("tally not allowed in subclause");
             }
 
             return null;

--- a/Tests/Parser/Functions/TallyFunctionTests.cs
+++ b/Tests/Parser/Functions/TallyFunctionTests.cs
@@ -413,5 +413,88 @@ namespace RATools.Test.Parser.Functions
             Evaluate("tally(4, unless(byte(0x1234) == 5) || once(byte(0x1234) == 34))", errorMessage);
             Evaluate("tally(4, measured(repeated(6, byte(0x1234) == 5)) || byte(0x1234) == 34)", errorMessage);
         }
+
+        [Test]
+        public void TestSimpleDeduct()
+        {
+            var requirements = Evaluate("tally(4, byte(0x1234) == 56, deduct(byte(0x2345) == 99))");
+            Assert.That(requirements.Count, Is.EqualTo(3));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.AddHits));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("99"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.SubHits));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("0"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void TestMultipleDeduct()
+        {
+            var requirements = Evaluate("tally(10, byte(0x1234) == 56, deduct(byte(0x2345) == 99), byte(0x5555) == 0, deduct(byte(0x5555) == 1))");
+            Assert.That(requirements.Count, Is.EqualTo(5));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.AddHits));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("99"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.SubHits));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("byte(0x005555)"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("0"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.AddHits));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[3].Left.ToString(), Is.EqualTo("byte(0x005555)"));
+            Assert.That(requirements[3].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[3].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[3].Type, Is.EqualTo(RequirementType.SubHits));
+            Assert.That(requirements[3].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[4].Left.ToString(), Is.EqualTo("0"));
+            Assert.That(requirements[4].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[4].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[4].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[4].HitCount, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void TestRepeatedDeduct()
+        {
+            var requirements = Evaluate("tally(4, byte(0x1234) == 56, deduct(repeated(10, byte(0x2345) == 99)))");
+            Assert.That(requirements.Count, Is.EqualTo(3));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.AddHits));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("99"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.SubHits));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(10));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("0"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void TestOnlyDeduct()
+        {
+            Evaluate("tally(4, deduct(byte(0x2345) == 99), deduct(byte(0x2345) == 99))",
+                "tally requires at least one non-deducted item");
+        }
     }
 }

--- a/ViewModels/RequirementViewModel.cs
+++ b/ViewModels/RequirementViewModel.cs
@@ -123,6 +123,10 @@ namespace RATools.ViewModels
                     builder.Append("AddHits ");
                     break;
 
+                case RequirementType.SubHits:
+                    builder.Append("SubHits ");
+                    break;
+
                 case RequirementType.AndNext:
                     builder.Append("AndNext ");
                     break;


### PR DESCRIPTION
Allows marking conditions in a `tally()` call so they get turned into `SubHits` instead of `AddHits`.
```
tally(4, byte(0x1234) == 56, deduct(repeated(10, byte(0x2345) == 99)))
```
becomes:
```
AddHits 8-bit Mem 0x1234 == 56
SubHits 8-bit Mem 0x2345 == 99 (10)
                       0 == 1 (4)
```
Which says count how many times $1234 was 56, deduct how many times $2345 was 99 (maximum 10). If the total is at least 4, the logic is true.

If a `deduct` is present in a `tally()` call, the tally target will always be assigned to an `always_false` condition after the `AddHits` and `SubHits` are evaluated. This ensures that whatever other condition ended up being the final condition isn't artificially limited by the tally target.