### PR TITLE
add copy to clipboard commands for leaderboard title/description

### DIFF
--- a/ViewModels/LeaderboardViewModel.cs
+++ b/ViewModels/LeaderboardViewModel.cs
@@ -19,6 +19,9 @@ namespace RATools.ViewModels
             Title = leaderboard.Title;
             Description = leaderboard.Description;
 
+            CopyTitleToClipboardCommand = new DelegateCommand(() => _clipboard.SetData(_leaderboard.Title));
+            CopyDescriptionToClipboardCommand = new DelegateCommand(() => _clipboard.SetData(_leaderboard.Description));
+
             var groups = new List<LeaderboardGroupViewModel>();
 
             var achievementBuilder = new AchievementBuilder();
@@ -106,6 +109,9 @@ namespace RATools.ViewModels
         {
             get { return _leaderboard.SourceLine; }
         }
+
+        public CommandBase CopyTitleToClipboardCommand { get; private set; }
+        public CommandBase CopyDescriptionToClipboardCommand { get; private set; }
 
         public class LeaderboardGroupViewModel
         {

--- a/Views/LeaderboardViewer.xaml
+++ b/Views/LeaderboardViewer.xaml
@@ -27,21 +27,35 @@
                 <TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding Description}" FontSize="12"
                            Style="{StaticResource editorSubtitle}" />
 
-                <TextBlock Grid.Row="2" Margin="4,0,0,2" VerticalAlignment="Bottom" FontSize="10">
-                    <TextBlock.Style>
-                        <Style TargetType="{x:Type TextBlock}">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding SourceLine}" Value="0">
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                    <Hyperlink Command="{Binding Path=DataContext.Game.GoToSourceCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type views:MainWindow}}}" 
-                                CommandParameter="{Binding SourceLine}" Style="{StaticResource subtleHyperlink}">
-                        <TextBlock Text="Source" />
-                    </Hyperlink>
-                </TextBlock>
+                <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Margin="4,0,0,2" VerticalAlignment="Bottom" Orientation="Horizontal">
+                    <TextBlock FontSize="10" Margin="0,0,25,0">
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SourceLine}" Value="0">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                        <Hyperlink Command="{Binding Path=DataContext.Game.GoToSourceCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type views:MainWindow}}}"
+                                    CommandParameter="{Binding SourceLine}" Style="{StaticResource subtleHyperlink}">
+                            <TextBlock Text="Source" />
+                        </Hyperlink>
+                    </TextBlock>
+
+                    <TextBlock FontSize="10" Margin="0,0,25,0">
+                        <Hyperlink Style="{StaticResource subtleHyperlink}" Command="{Binding CopyTitleToClipboardCommand}">
+                            <TextBlock Text="Copy Title to Clipboard" />
+                        </Hyperlink>
+                    </TextBlock>
+
+                    <TextBlock FontSize="10">
+                        <Hyperlink Style="{StaticResource subtleHyperlink}" Command="{Binding CopyDescriptionToClipboardCommand}">
+                            <TextBlock Text="Copy Description to Clipboard" />
+                        </Hyperlink>
+                    </TextBlock>
+                </StackPanel>
                 
                 <ScrollViewer Grid.Row="3" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto"
                               Template="{StaticResource themedScrollViewerTemplate}">


### PR DESCRIPTION
closes #200

appear as secondary links next to the Source link below the header and above the conditions.

![image](https://user-images.githubusercontent.com/32680403/117022934-e373b080-acb5-11eb-801e-7db8db06aa09.png)
