### PR TITLE
use minimum version in XXX-User.txt metadata

### DIFF
--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -250,6 +250,19 @@ namespace RATools.Parser
             return RequirementOperator.None;
         }
 
+        public static string GetMinimumVersion(Achievement achievement)
+        {
+            int minimumVersion = MinimumVersion(achievement.CoreRequirements);
+            foreach (var group in achievement.AlternateRequirements)
+            {
+                int altMinimumVersion = MinimumVersion(group);
+                if (altMinimumVersion > minimumVersion)
+                    minimumVersion = altMinimumVersion;
+            }
+
+            return String.Format("0.{0}", minimumVersion);
+        }
+
         private static int MinimumVersion(IEnumerable<Requirement> requirements)
         {
             int minVer = 0;

--- a/Parser/LocalAchievements.cs
+++ b/Parser/LocalAchievements.cs
@@ -202,6 +202,15 @@ namespace RATools.Parser
         /// </summary>
         public void Commit(string author, StringBuilder warning, Achievement achievementToValidate)
         {
+            double version = 0.30;
+
+            foreach (var achievement in _achievements)
+            {
+                var achievementMinimumVersion = AchievementBuilder.GetMinimumVersion(achievement);
+                if (Double.Parse(achievementMinimumVersion) > version)
+                    _version = achievementMinimumVersion;
+            }
+
             using (var writer = new StreamWriter(_fileSystemService.CreateFile(_filename)))
             {
                 writer.WriteLine(_version);

--- a/Tests/Parser/RegressionTests.cs
+++ b/Tests/Parser/RegressionTests.cs
@@ -47,21 +47,42 @@ namespace RATools.Test.Parser
             }
         }
 
+        static void GetFiles(List<string> files, string dir)
+        {
+            foreach (var file in Directory.EnumerateFiles(dir, "*.rascript"))
+                files.Add(file);
+
+            foreach (var subdir in Directory.EnumerateDirectories(dir))
+                GetFiles(files, Path.Combine(dir, subdir));
+        }
+
         class RegressionTestFactory
         {
-            public static IEnumerable<string> Files
+            public static IEnumerable<string[]> Files
             {
                 get
                 {
                     var dir = RegressionDir;
                     if (dir == NoScriptsError)
                     {
-                        yield return NoScriptsError;
+                        yield return new string [] { NoScriptsError, "" };
                     }
                     else
                     {
-                        foreach (var file in Directory.EnumerateFiles(dir, "*.rascript"))
-                            yield return Path.GetFileNameWithoutExtension(file);
+                        var files = new List<string>();
+                        GetFiles(files, dir);
+
+                        if (!dir.EndsWith("\\"))
+                            dir += "\\";
+
+                        foreach (var file in files)
+                        {
+                            yield return new string[]
+                            {
+                                Path.GetFileNameWithoutExtension(file),
+                                Path.GetFullPath(file).Replace(dir, "")
+                            };
+                        }
                     }
                 }
             }
@@ -69,75 +90,142 @@ namespace RATools.Test.Parser
 
         [Test]
         [TestCaseSource(typeof(RegressionTestFactory), "Files")]
-        public void RegressionTest(string scriptFileName)
+        public void RegressionTest(string scriptFileName, string scriptPath)
         {
             if (scriptFileName == NoScriptsError)
                 return;
 
-            scriptFileName = Path.Combine(RegressionDir, scriptFileName + ".rascript");
-            var outputFileName = scriptFileName.Substring(0, scriptFileName.Length - 9) + ".updated.txt";
-            var expectedFileName = scriptFileName.Substring(0, scriptFileName.Length - 9) + ".txt";
+            var parts = scriptPath.Split('\\');
+            int i = 0;
+
+            if (!Path.IsPathRooted(scriptPath))
+            {
+                scriptPath = Path.Combine(RegressionDir, scriptPath);
+            }
+            else
+            {
+                while (parts[i] != "Regressions")
+                {
+                    ++i;
+                    Assert.That(i < parts.Length);
+                }
+
+                ++i;
+                Assert.That(i < parts.Length);
+            }
+
+            if (parts[i] == "scripts")
+                ++i;
+
+            var expectedFileName = Path.GetFileNameWithoutExtension(scriptPath);
+            while (i < parts.Length - 1)
+            {
+                expectedFileName += "-" + parts[i];
+                ++i;
+            }
+
+            expectedFileName = Path.Combine(RegressionDir, "results",  expectedFileName + ".txt");
+            var outputFileName = Path.ChangeExtension(expectedFileName, ".updated.txt");
 
             var interpreter = new AchievementScriptInterpreter();
-            interpreter.Run(Tokenizer.CreateTokenizer(File.Open(scriptFileName, FileMode.Open)));
+            interpreter.Run(Tokenizer.CreateTokenizer(File.Open(scriptPath, FileMode.Open)));
 
-            Assert.IsNull(interpreter.ErrorMessage);
-
-            var mockFileSystemService = new Mock<IFileSystemService>();
-            mockFileSystemService.Setup(s => s.CreateFile(It.IsAny<string>())).Returns((string path) => File.Create(path));
-
-            var localAchievements = new LocalAchievements(outputFileName, mockFileSystemService.Object);
-            localAchievements.Title = Path.GetFileNameWithoutExtension(scriptFileName);
-            foreach (var achievement in interpreter.Achievements)
-                localAchievements.Replace(null, achievement);
-            localAchievements.Commit("Author", null, null);
-
-            if (interpreter.Leaderboards.Any())
+            if (!String.IsNullOrEmpty(interpreter.ErrorMessage))
             {
-                using (var file = File.Open(outputFileName, FileMode.Append))
+                using (var file = File.Open(outputFileName, FileMode.Create))
                 {
                     using (var fileWriter = new StreamWriter(file))
+                        fileWriter.Write(interpreter.ErrorMessage);
+                }
+
+                if (!File.Exists(expectedFileName))
+                    Assert.IsNull(interpreter.ErrorMessage);
+            }
+            else
+            {
+                var mockFileSystemService = new Mock<IFileSystemService>();
+                mockFileSystemService.Setup(s => s.CreateFile(It.IsAny<string>())).Returns((string path) => File.Create(path));
+
+                var localAchievements = new LocalAchievements(outputFileName, mockFileSystemService.Object);
+                localAchievements.Title = Path.GetFileNameWithoutExtension(scriptFileName);
+                foreach (var achievement in interpreter.Achievements)
+                    localAchievements.Replace(null, achievement);
+                localAchievements.Commit("Author", null, null);
+
+                if (interpreter.Leaderboards.Any())
+                {
+                    using (var file = File.Open(outputFileName, FileMode.Append))
                     {
-                        fileWriter.WriteLine("=== Leaderboards ===");
-                        foreach (var leaderboard in interpreter.Leaderboards)
+                        using (var fileWriter = new StreamWriter(file))
                         {
-                            fileWriter.Write("0:");
-                            fileWriter.Write("\"STA:");
-                            fileWriter.Write(leaderboard.Start);
-                            fileWriter.Write("::CAN:");
-                            fileWriter.Write(leaderboard.Cancel);
-                            fileWriter.Write("::SUB:");
-                            fileWriter.Write(leaderboard.Submit);
-                            fileWriter.Write("::VAL:");
-                            fileWriter.Write(leaderboard.Value);
-                            fileWriter.Write("\":");
-                            fileWriter.Write(leaderboard.Format);
-                            fileWriter.Write(":\"");
-                            fileWriter.Write(leaderboard.Title);
-                            fileWriter.Write("\":\"");
-                            fileWriter.Write(leaderboard.Description);
-                            fileWriter.WriteLine("\"");
+                            fileWriter.WriteLine("=== Leaderboards ===");
+                            foreach (var leaderboard in interpreter.Leaderboards)
+                            {
+                                fileWriter.Write("0:");
+                                fileWriter.Write("\"STA:");
+                                fileWriter.Write(leaderboard.Start);
+                                fileWriter.Write("::CAN:");
+                                fileWriter.Write(leaderboard.Cancel);
+                                fileWriter.Write("::SUB:");
+                                fileWriter.Write(leaderboard.Submit);
+                                fileWriter.Write("::VAL:");
+                                fileWriter.Write(leaderboard.Value);
+                                fileWriter.Write("\":");
+                                fileWriter.Write(leaderboard.Format);
+                                fileWriter.Write(":\"");
+                                fileWriter.Write(leaderboard.Title);
+                                fileWriter.Write("\":\"");
+                                fileWriter.Write(leaderboard.Description);
+                                fileWriter.WriteLine("\"");
+                            }
                         }
                     }
                 }
-            }
 
-            if (!String.IsNullOrEmpty(interpreter.RichPresence))
-            {
-                using (var file = File.Open(outputFileName, FileMode.Append))
+                if (!String.IsNullOrEmpty(interpreter.RichPresence))
                 {
-                    using (var fileWriter = new StreamWriter(file))
+                    using (var file = File.Open(outputFileName, FileMode.Append))
                     {
-                        fileWriter.WriteLine("=== Rich Presence ===");
-                        fileWriter.WriteLine(interpreter.RichPresence);
+                        using (var fileWriter = new StreamWriter(file))
+                        {
+                            fileWriter.WriteLine("=== Rich Presence ===");
+                            fileWriter.WriteLine(interpreter.RichPresence);
+                        }
                     }
                 }
+
+                Assert.IsTrue(File.Exists(expectedFileName), expectedFileName + " not found");
             }
 
-            Assert.IsTrue(File.Exists(expectedFileName), expectedFileName + " not found");
+            var expectedFileContents = File.ReadAllText(expectedFileName);
+            var outputFileContents = File.ReadAllText(outputFileName);
 
-            FileAssert.AreEqual(expectedFileName, outputFileName);
+            // file didn't match, report first difference
+            if (expectedFileContents != outputFileContents)
+            {
+                var expectedFileTokenizer = Tokenizer.CreateTokenizer(expectedFileContents);
+                var outputFileTokenizer = Tokenizer.CreateTokenizer(outputFileContents);
 
+                var line = 1;
+                do
+                {
+                    var expectedFileLine = expectedFileTokenizer.ReadTo('\n').TrimRight();
+                    var outputFileLine = outputFileTokenizer.ReadTo('\n').TrimRight();
+
+                    if (expectedFileLine != outputFileLine)
+                        Assert.AreEqual(expectedFileLine.ToString(), outputFileLine.ToString(), "Line " + line);
+
+                    expectedFileTokenizer.Advance();
+                    outputFileTokenizer.Advance();
+
+                    ++line;
+                } while (expectedFileTokenizer.NextChar != '\0' || outputFileTokenizer.NextChar != '\0');
+
+                // failed to find differing line, fallback to nunit assertion
+                FileAssert.AreEqual(expectedFileName, outputFileName);
+            }
+
+            // file matched, delete temporary file
             File.Delete(outputFileName);
         }
     }


### PR DESCRIPTION
The first two lines of the `XXX-User.txt` file are metadata. The first is the version of the toolkit that generated the file, and the second is the name of the game retrieved from the server.

When the `XXX-User.txt` file is generated by RATools, the toolkit version is unknown, so a default value (`0.030`) is used. This PR will cause the version metadata to be the minimum version of the toolkit required for the generated logic. As I'm not sure of what changes were introduced before 0.76, anything that doesn't require at least 0.76 functionality will continue to output the default 0.30.

Note that this is purely meta-information and is not currently used by RATools or the RA_Integration.dll.