### PR TITLE
add disable_when function

### DIFF
--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -98,6 +98,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new FlagConditionFunction("unless", RequirementType.PauseIf, ConditionalOperation.Or));
                 _globalScope.AddFunction(new FlagConditionFunction("trigger_when", RequirementType.Trigger, ConditionalOperation.And));
                 _globalScope.AddFunction(new MeasuredFunction());
+                _globalScope.AddFunction(new DisableWhenFunction());
 
                 _globalScope.AddFunction(new AchievementFunction());
                 _globalScope.AddFunction(new LeaderboardFunction());

--- a/Parser/Functions/DisableWhenFunction.cs
+++ b/Parser/Functions/DisableWhenFunction.cs
@@ -1,0 +1,69 @@
+﻿using RATools.Data;
+using RATools.Parser.Internal;
+using System.Linq;
+
+namespace RATools.Parser.Functions
+{
+    internal class DisableWhenFunction : FlagConditionFunction
+    {
+        public DisableWhenFunction()
+            : base("disable_when", RequirementType.PauseIf, ConditionalOperation.None)
+        {
+            Parameters.Add(new VariableDefinitionExpression("until"));
+
+            DefaultParameters["until"] = new FunctionCallExpression("always_false", new ExpressionBase[0]);
+        }
+
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            if (!base.ReplaceVariables(scope, out result))
+                return false;
+
+            var func = result as FunctionCallExpression;
+            if (func == null)
+                return true;
+
+            var until = GetParameter(scope, "until", out result);
+            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { func.Parameters.First(), until });
+            CopyLocation(result);
+
+            return true;
+        }
+
+        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        {
+            var until = functionCall.Parameters.ElementAt(1);
+
+            var builder = new ScriptInterpreterAchievementBuilder();
+            ExpressionBase result;
+            if (!TriggerBuilderContext.ProcessAchievementConditions(builder, until, scope, out result))
+                return new ParseErrorExpression("until did not evaluate to a valid comparison", until) { InnerError = (ParseErrorExpression)result };
+
+            var error = builder.CollapseForSubClause();
+            if (error != null)
+                return new ParseErrorExpression(error.Message, until);
+
+            if (builder.CoreRequirements.Count > 0 && builder.CoreRequirements.First().Evaluate() != false)
+            {
+                foreach (var requirement in builder.CoreRequirements)
+                {
+                    if (requirement.Type == RequirementType.None)
+                        requirement.Type = RequirementType.AndNext;
+
+                    context.Trigger.Add(requirement);
+                }
+
+                context.LastRequirement.Type = RequirementType.ResetNextIf;
+            }
+
+            error = base.BuildTrigger(context, scope, functionCall);
+            if (error != null)
+                return error;
+
+            if (context.LastRequirement.HitCount == 0)
+                context.LastRequirement.HitCount = 1;
+
+            return null;
+        }
+    }
+}

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Parser\Functions\AlwaysFalseFunction.cs" />
     <Compile Include="Parser\Functions\BitFunction.cs" />
     <Compile Include="Parser\Functions\ComparisonModificationFunction.cs" />
+    <Compile Include="Parser\Functions\DisableWhenFunction.cs" />
     <Compile Include="Parser\Functions\MeasuredFunction.cs" />
     <Compile Include="Parser\Functions\FlagConditionFunction.cs" />
     <Compile Include="Parser\Functions\AlwaysTrueFunction.cs" />

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -1008,42 +1008,22 @@ namespace RATools.Test.Parser
         [Test]
         public void TestRepeatedNever()
         {
-            var parser = Parse("achievement(\"T\", \"D\", 5, repeated(2, byte(0x1234) == 1 && never(byte(0x2345) == 2)))");
+            var parser = Parse("achievement(\"T\", \"D\", 5, once(byte(0x2222) == 0) && " +
+                "repeated(2, byte(0x1234) == 1 && never(byte(0x2345) == 2)))");
             Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
 
             var achievement = parser.Achievements.First();
-            Assert.That(achievement.CoreRequirements.ElementAt(0).Type, Is.EqualTo(RequirementType.ResetNextIf));
-            Assert.That(achievement.CoreRequirements.ElementAt(0).HitCount, Is.EqualTo(0));
-            Assert.That(achievement.CoreRequirements.ElementAt(1).Type, Is.EqualTo(RequirementType.None));
-            Assert.That(achievement.CoreRequirements.ElementAt(1).HitCount, Is.EqualTo(2));
-            Assert.That(GetRequirements(achievement), Is.EqualTo("repeated(2, byte(0x001234) == 1 && never(byte(0x002345) == 2))"));
+            Assert.That(GetRequirements(achievement),
+                Is.EqualTo("once(byte(0x002222) == 0) && repeated(2, byte(0x001234) == 1 && never(byte(0x002345) == 2))"));
 
             // reverse the order - never should still appear first in the definition, but be displayed last
-            parser = Parse("achievement(\"T\", \"D\", 5, repeated(2, never(byte(0x2345) == 2) && byte(0x1234) == 1))");
+            parser = Parse("achievement(\"T\", \"D\", 5, once(byte(0x2222) == 0) && " +
+                "repeated(2, never(byte(0x2345) == 2) && byte(0x1234) == 1))");
             Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
 
             achievement = parser.Achievements.First();
-            Assert.That(achievement.CoreRequirements.ElementAt(0).Type, Is.EqualTo(RequirementType.ResetNextIf));
-            Assert.That(achievement.CoreRequirements.ElementAt(0).HitCount, Is.EqualTo(0));
-            Assert.That(achievement.CoreRequirements.ElementAt(1).Type, Is.EqualTo(RequirementType.None));
-            Assert.That(achievement.CoreRequirements.ElementAt(1).HitCount, Is.EqualTo(2));
-            Assert.That(GetRequirements(achievement), Is.EqualTo("repeated(2, byte(0x001234) == 1 && never(byte(0x002345) == 2))"));
-        }
-
-        [Test]
-        public void TestRepeatedNeverNested()
-        {
-            var parser = Parse("achievement(\"T\", \"D\", 5, repeated(2, byte(0x1234) == 1 && never(repeated(3, byte(0x2345) == 2 && never(byte(0x3456) == 3)))))");
-            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
-
-            var achievement = parser.Achievements.First();
-            Assert.That(achievement.CoreRequirements.ElementAt(0).Type, Is.EqualTo(RequirementType.ResetNextIf));
-            Assert.That(achievement.CoreRequirements.ElementAt(0).HitCount, Is.EqualTo(0));
-            Assert.That(achievement.CoreRequirements.ElementAt(1).Type, Is.EqualTo(RequirementType.ResetNextIf));
-            Assert.That(achievement.CoreRequirements.ElementAt(1).HitCount, Is.EqualTo(3));
-            Assert.That(achievement.CoreRequirements.ElementAt(2).Type, Is.EqualTo(RequirementType.None));
-            Assert.That(achievement.CoreRequirements.ElementAt(2).HitCount, Is.EqualTo(2));
-            Assert.That(GetRequirements(achievement), Is.EqualTo("repeated(2, byte(0x001234) == 1 && never(repeated(3, byte(0x002345) == 2 && never(byte(0x003456) == 3))))"));
+            Assert.That(GetRequirements(achievement),
+                Is.EqualTo("once(byte(0x002222) == 0) && repeated(2, byte(0x001234) == 1 && never(byte(0x002345) == 2))"));
         }
     }
 }

--- a/Tests/Parser/Functions/DisableWhenFunctionTests.cs
+++ b/Tests/Parser/Functions/DisableWhenFunctionTests.cs
@@ -1,0 +1,155 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Data;
+using RATools.Parser;
+using RATools.Parser.Functions;
+using RATools.Parser.Internal;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RATools.Test.Parser.Functions
+{
+    [TestFixture]
+    class DisableWhenFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = AchievementScriptInterpreter.GetGlobalScope().GetFunction("disable_when");
+            Assert.That(def, Is.Not.Null);
+            Assert.That(def.Name.Name, Is.EqualTo("disable_when"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(2));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("comparison"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("until"));
+        }
+
+        private List<Requirement> Evaluate(string input, string expectedError = null)
+        {
+            var requirements = new List<Requirement>();
+
+            var expression = ExpressionBase.Parse(new PositionalTokenizer(Tokenizer.CreateTokenizer(input)));
+            Assert.That(expression, Is.InstanceOf<FunctionCallExpression>());
+            var funcCall = (FunctionCallExpression)expression;
+            var scope = AchievementScriptInterpreter.GetGlobalScope();
+            var funcDef = scope.GetFunction(funcCall.FunctionName.Name) as TriggerBuilderContext.FunctionDefinition;
+
+            ExpressionBase error;
+            scope = funcCall.GetParameters(funcDef, scope, out error);
+            var context = new TriggerBuilderContext { Trigger = requirements };
+            scope.Context = context;
+
+            ExpressionBase evaluated;
+            Assert.That(funcDef.ReplaceVariables(scope, out evaluated), Is.True);
+            funcCall = (FunctionCallExpression)evaluated;
+
+            if (expectedError == null)
+            {
+                Assert.That(funcDef.BuildTrigger(context, scope, funcCall), Is.Null);
+            }
+            else
+            {
+                var parseError = funcDef.BuildTrigger(context, scope, funcCall);
+                Assert.That(parseError, Is.Not.Null);
+                Assert.That(parseError.Message, Is.EqualTo(expectedError));
+            }
+
+            return requirements;
+        }
+
+        [Test]
+        public void TestSimple()
+        {
+            var requirements = Evaluate("disable_when(byte(0x1234) == 56)");
+            Assert.That(requirements.Count, Is.EqualTo(1));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.PauseIf));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestUntilSimple()
+        {
+            var requirements = Evaluate("disable_when(byte(0x1234) == 56, until=byte(0x2345) == 67)");
+            Assert.That(requirements.Count, Is.EqualTo(2));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("67"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.ResetNextIf));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.PauseIf));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestHitCount()
+        {
+            var requirements = Evaluate("disable_when(repeated(6, byte(0x1234) == 56))");
+            Assert.That(requirements.Count, Is.EqualTo(1));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.PauseIf));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(6));
+        }
+
+        [Test]
+        public void TestAndNext()
+        {
+            var requirements = Evaluate("disable_when(byte(0x1234) == 56 && byte(0x1235) == 55, until=byte(0x2345) == 67 && byte(0x2346) == 66)");
+            Assert.That(requirements.Count, Is.EqualTo(4));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("67"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.AndNext));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x002346)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("66"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.ResetNextIf));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.AndNext));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[3].Left.ToString(), Is.EqualTo("byte(0x001235)"));
+            Assert.That(requirements[3].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[3].Right.ToString(), Is.EqualTo("55"));
+            Assert.That(requirements[3].Type, Is.EqualTo(RequirementType.PauseIf));
+            Assert.That(requirements[3].HitCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestOrNext()
+        {
+            var requirements = Evaluate("disable_when(byte(0x1234) == 56 || byte(0x1235) == 55, until=byte(0x2345) == 67 || byte(0x2346) == 66)");
+            Assert.That(requirements.Count, Is.EqualTo(4));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("67"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.OrNext));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x002346)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("66"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.ResetNextIf));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.OrNext));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[3].Left.ToString(), Is.EqualTo("byte(0x001235)"));
+            Assert.That(requirements[3].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[3].Right.ToString(), Is.EqualTo("55"));
+            Assert.That(requirements[3].Type, Is.EqualTo(RequirementType.PauseIf));
+            Assert.That(requirements[3].HitCount, Is.EqualTo(1));
+        }
+    }
+}

--- a/Tests/Parser/Functions/DisableWhenFunctionTests.cs
+++ b/Tests/Parser/Functions/DisableWhenFunctionTests.cs
@@ -87,7 +87,7 @@ namespace RATools.Test.Parser.Functions
         }
 
         [Test]
-        public void TestHitCount()
+        public void TestHitTarget()
         {
             var requirements = Evaluate("disable_when(repeated(6, byte(0x1234) == 56))");
             Assert.That(requirements.Count, Is.EqualTo(1));

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -390,5 +390,44 @@ namespace RATools.Test.Parser.Functions
             Evaluate("repeated(4, unless(byte(0x1234) == 5) || once(byte(0x1234) == 34))", errorMessage);
             Evaluate("repeated(4, measured(repeated(6, byte(0x1234) == 5)) || byte(0x1234) == 34)", errorMessage);
         }
+
+        [Test]
+        public void TestNever()
+        {
+            var requirements = Evaluate("repeated(2, byte(0x1234) == 1 && never(byte(0x2345) == 2))");
+            Assert.That(requirements.Count, Is.EqualTo(2));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("2"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.ResetNextIf));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestNeverNested()
+        {
+            var requirements = Evaluate("repeated(2, byte(0x1234) == 1 && never(repeated(3, byte(0x2345) == 2 && never(byte(0x3456) == 3))))");
+            Assert.That(requirements.Count, Is.EqualTo(3));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x003456)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("3"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.ResetNextIf));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("2"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.ResetNextIf));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(3));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(2));
+        }
     }
 }

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Data\RequirementTests.cs" />
     <Compile Include="Data\FieldTests.cs" />
     <Compile Include="Parser\Functions\LeaderboardFunctionTests.cs" />
+    <Compile Include="Parser\Functions\DisableWhenFunctionTests.cs" />
     <Compile Include="Parser\TriggerBuilderContextTests.cs" />
     <Compile Include="Parser\AchievementBuilderTests.cs" />
     <Compile Include="Parser\AchievementScriptInterpreterTests.cs" />


### PR DESCRIPTION
implements #106 

```
disable_when(byte(0x1234) == 1, until=byte(0x2345) == 2)
```
will generate
```
ResetNextIf byte(0x2345) == 2
PauseIf     byte(0x1234) == 1 (1)
```

The `until` clause is optional, and a HitCount greater than 1 can be specified using `repeated` syntax:
```
disable_when(repeated(5, byte(0x1234) == 1))
```
will generate
```
PauseIf byte(0x1234) == 1 (5)
```

If no `until` is specified, the pause will remain locked until the emulator is reset or another `never` in the trigger clears the lock. It is the responsibility of the author to put the external `never` in a different group than the pause lock.