### PR TITLE
distribute ResetNextIf when building disable_when chain from tally

### DIFF
--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -2126,7 +2126,17 @@ namespace RATools.Parser
 
             // remove the common clause from each complex clause
             foreach (var requirementEx in resetNextIfClauses)
+            {
                 requirementEx.Requirements.RemoveRange(0, resetNextIf.Requirements.Count);
+                do
+                {
+                    int index = requirementEx.Requirements.FindIndex(r => r.Type == RequirementType.ResetNextIf);
+                    if (index == -1)
+                        break;
+
+                    requirementEx.Requirements.RemoveRange(index - resetNextIf.Requirements.Count + 1, resetNextIf.Requirements.Count);
+                } while (true);
+            }
 
             // change the ResetNextIf to a ResetIf
             resetNextIf.Requirements.Last().Type = RequirementType.ResetIf;

--- a/Parser/TriggerBuilderContext.cs
+++ b/Parser/TriggerBuilderContext.cs
@@ -1,6 +1,5 @@
 ﻿using RATools.Data;
 using RATools.Parser.Internal;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -410,6 +410,8 @@ namespace RATools.Test.Parser
                   "repeated(2, byte(0x001234) == 1 && never(byte(0x002345) == 2)) && repeated(3, byte(0x001234) == 3 && never(byte(0x002345) == 3))")] // dissimilar ResetNextIfs cannot be turned into a ResetIf
         [TestCase("disable_when(byte(0x1234) == 1, until=byte(0x2345) == 2)",
                   "unless(once(byte(0x001234) == 1)) && (never(byte(0x002345) == 2))")] // ResetNextIf can be turned into a ResetIf, but has to be moved into an alt group
+        [TestCase("disable_when(tally(2, byte(0x1234) == 1, byte(0x1234) == 2), until=byte(0x2345) == 2)",
+                  "unless(tally(2, byte(0x001234) == 1, byte(0x001234) == 2)) && (never(byte(0x002345) == 2))")] // tally will generate similar ResetNextIfs which can be turned into a ResetIf, but has to be moved into an alt group
         // ==== NormalizeNonHitCountResetAndPauseIfs ====
         [TestCase("never(byte(0x001234) != 5)", "byte(0x001234) == 5")]
         [TestCase("never(byte(0x001234) == 5)", "byte(0x001234) != 5")]

--- a/Tests/Parser/Functions/DisableWhenFunctionTests.cs
+++ b/Tests/Parser/Functions/DisableWhenFunctionTests.cs
@@ -2,11 +2,9 @@
 using NUnit.Framework;
 using RATools.Data;
 using RATools.Parser;
-using RATools.Parser.Functions;
 using RATools.Parser.Internal;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace RATools.Test.Parser.Functions
 {
@@ -150,6 +148,46 @@ namespace RATools.Test.Parser.Functions
             Assert.That(requirements[3].Right.ToString(), Is.EqualTo("55"));
             Assert.That(requirements[3].Type, Is.EqualTo(RequirementType.PauseIf));
             Assert.That(requirements[3].HitCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestTally()
+        {
+            // ResetNextIf has to proceed each clause of the tally
+            var requirements = Evaluate("disable_when(" +
+                "tally(3, once(byte(0x1234) == 56), byte(0x1235) == 55, repeated(2, byte(0x1236) == 54))," +
+                "until=byte(0x2345) == 1)");
+            Assert.That(requirements.Count, Is.EqualTo(6));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.ResetNextIf));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.AddHits));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(1));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.ResetNextIf));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[3].Left.ToString(), Is.EqualTo("byte(0x001236)"));
+            Assert.That(requirements[3].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[3].Right.ToString(), Is.EqualTo("54"));
+            Assert.That(requirements[3].Type, Is.EqualTo(RequirementType.AddHits));
+            Assert.That(requirements[3].HitCount, Is.EqualTo(2));
+            Assert.That(requirements[4].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[4].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[4].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[4].Type, Is.EqualTo(RequirementType.ResetNextIf));
+            Assert.That(requirements[4].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[5].Left.ToString(), Is.EqualTo("byte(0x001235)"));
+            Assert.That(requirements[5].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[5].Right.ToString(), Is.EqualTo("55"));
+            Assert.That(requirements[5].Type, Is.EqualTo(RequirementType.PauseIf));
+            Assert.That(requirements[5].HitCount, Is.EqualTo(3));
         }
     }
 }


### PR DESCRIPTION
`disable_when` was just injecting the `until` clause as a single `ResetNextIf` before then `when` clause. When the `when` clause is a `tally` sequence, a series of `AddHits` or `SubHits` conditions is generated. `ResetNextIf` does not traverse over an `AddHits` or `SubHits` condition, so the `until` was only affecting the first expression in the `tally` sequence. This expands on the `disable_when` functionality to inject the `until` clause after each `AddHits` or `SubHits` generated by the `tally` function. so they'll all be reset. The optimizer will still prefer to convert them back into a single `ResetIf` when possible