### PR TITLE
allow assigning functions to variables

### DIFF
--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -276,7 +276,10 @@ namespace RATools.Parser
         internal bool Run(ExpressionGroupCollection expressionGroups, IScriptInterpreterCallback callback)
         {
             if (expressionGroups.Scope == null)
-                expressionGroups.Scope = new InterpreterScope(GetGlobalScope());
+            {
+                var scriptScope = new InterpreterScope(GetGlobalScope()) { Context = this };
+                expressionGroups.Scope = new InterpreterScope(scriptScope);
+            }
 
             var scriptContext = new AchievementScriptContext();
 
@@ -580,7 +583,7 @@ namespace RATools.Parser
         private bool CallFunction(FunctionCallExpression expression, InterpreterScope scope)
         {
             ExpressionBase result;
-            bool success = (scope.GetInterpreterContext<AssignmentExpression>() != null) ? expression.ReplaceVariables(scope, out result) : expression.Invoke(scope, out result);
+            bool success = expression.Invoke(scope, out result);
             if (!success)
             {
                 if (scope.GetInterpreterContext<FunctionCallExpression>() != null)

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -411,17 +411,7 @@ namespace RATools.Parser
             switch (expression.Type)
             {
                 case ExpressionType.Assignment:
-                    var assignment = (AssignmentExpression)expression;
-                    var assignmentScope = new InterpreterScope(scope) { Context = assignment };
-
-                    ExpressionBase result;
-                    if (!assignment.Value.ReplaceVariables(assignmentScope, out result))
-                    {
-                        Error = result as ParseErrorExpression;
-                        return false;
-                    }
-
-                    Error = scope.AssignVariable(assignment.Variable, result);
+                    Error = ((AssignmentExpression)expression).Evaluate(scope);
                     return (Error == null);
 
                 case ExpressionType.FunctionCall:

--- a/Parser/Functions/AlwaysFalseFunction.cs
+++ b/Parser/Functions/AlwaysFalseFunction.cs
@@ -10,16 +10,6 @@ namespace RATools.Parser.Functions
         {
         }
 
-        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
-        {
-            if (!IsInTriggerClause(scope, out result))
-                return false;
-
-            result = new FunctionCallExpression(Name.Name, new ExpressionBase[0]);
-            CopyLocation(result);
-            return true;
-        }
-
         public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             context.Trigger.Add(CreateAlwaysFalseRequirement());

--- a/Parser/Functions/AlwaysTrueFunction.cs
+++ b/Parser/Functions/AlwaysTrueFunction.cs
@@ -10,16 +10,6 @@ namespace RATools.Parser.Functions
         {
         }
 
-        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
-        {
-            if (!IsInTriggerClause(scope, out result))
-                return false;
-
-            result = new FunctionCallExpression(Name.Name, new ExpressionBase[0]);
-            CopyLocation(result);
-            return true;
-        }
-
         public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             context.Trigger.Add(CreateAlwaysTrueRequirement());

--- a/Parser/Functions/ArrayPopFunction.cs
+++ b/Parser/Functions/ArrayPopFunction.cs
@@ -12,10 +12,11 @@ namespace RATools.Parser.Functions
 
         public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
-            var arrayExpression = GetParameter(scope, "array", out result);
+            var arrayExpression = GetReferenceParameter(scope, "array", out result);
             if (arrayExpression == null)
                 return false;
-            var array = arrayExpression as ArrayExpression;
+
+            var array = arrayExpression.Expression as ArrayExpression;
             if (array == null)
             {
                 result = new ParseErrorExpression("array did not evaluate to an array", arrayExpression);

--- a/Parser/Functions/ArrayPushFunction.cs
+++ b/Parser/Functions/ArrayPushFunction.cs
@@ -13,10 +13,11 @@ namespace RATools.Parser.Functions
 
         public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
-            var arrayExpression = GetParameter(scope, "array", out result);
+            var arrayExpression = GetReferenceParameter(scope, "array", out result);
             if (arrayExpression == null)
                 return false;
-            var array = arrayExpression as ArrayExpression;
+
+            var array = arrayExpression.Expression as ArrayExpression;
             if (array == null)
             {
                 result = new ParseErrorExpression("array did not evaluate to an array", arrayExpression);
@@ -26,9 +27,13 @@ namespace RATools.Parser.Functions
             var value = GetParameter(scope, "value", out result);
             if (value == null)
                 return false;
-            // don't call ReplaceVariables, we don't want to evaluate the item being added here
 
-            array.Entries.Add(value);
+            var variableExpression = new VariableExpression("array_push(" + arrayExpression.Variable.Name + ")");
+            var assignScope = new InterpreterScope(scope) { Context = new AssignmentExpression(variableExpression, value) };
+            if (!value.ReplaceVariables(assignScope, out result))
+                return false;
+
+            array.Entries.Add(result);
             result = null;
             return true;
         }

--- a/Parser/Functions/BitFunction.cs
+++ b/Parser/Functions/BitFunction.cs
@@ -14,24 +14,6 @@ namespace RATools.Parser.Functions
             Parameters.Add(new VariableDefinitionExpression("address"));
         }
 
-        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
-        {
-            if (!IsInTriggerClause(scope, out result))
-                return false;
-
-            var index = GetIntegerParameter(scope, "index", out result);
-            if (index == null)
-                return false;
-
-            var address = GetIntegerParameter(scope, "address", out result);
-            if (address == null)
-                return false;
-
-            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { index, address });
-            CopyLocation(result);
-            return true;
-        }
-
         public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var address = ((IntegerConstantExpression)functionCall.Parameters.ElementAt(1)).Value;

--- a/Parser/Functions/ComparisonModificationFunction.cs
+++ b/Parser/Functions/ComparisonModificationFunction.cs
@@ -11,20 +11,6 @@ namespace RATools.Parser.Functions
             Parameters.Add(new VariableDefinitionExpression("comparison"));
         }
 
-        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
-        {
-            if (!IsInTriggerClause(scope, out result))
-                return false;
-
-            var comparison = GetParameter(scope, "comparison", out result);
-            if (comparison == null)
-                return false;
-
-            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { comparison });
-            CopyLocation(result);
-            return true;
-        }
-
         public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var comparison = functionCall.Parameters.First();

--- a/Parser/Functions/FormatFunction.cs
+++ b/Parser/Functions/FormatFunction.cs
@@ -19,6 +19,11 @@ namespace RATools.Parser.Functions
         {
         }
 
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            return Evaluate(scope, out result);
+        }
+
         public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
             var stringExpression = GetStringParameter(scope, "format_string", out result);

--- a/Parser/Functions/LengthFunction.cs
+++ b/Parser/Functions/LengthFunction.cs
@@ -10,6 +10,11 @@ namespace RATools.Parser.Functions
             Parameters.Add(new VariableDefinitionExpression("object"));
         }
 
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            return Evaluate(scope, out result);
+        }
+
         public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
             var obj = GetParameter(scope, "object", out result);

--- a/Parser/Functions/MemoryAccessorFunction.cs
+++ b/Parser/Functions/MemoryAccessorFunction.cs
@@ -17,20 +17,6 @@ namespace RATools.Parser.Functions
 
         public FieldSize Size { get; private set; }
 
-        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
-        {
-            if (!IsInTriggerClause(scope, out result))
-                return false;
-
-            var address = GetParameter(scope, "address", out result);
-            if (address == null)
-                return false;
-
-            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { address });
-            CopyLocation(result);
-            return true;
-        }
-
         public static bool ContainsMemoryAccessor(ExpressionBase expression)
         {
             var funcCall = expression as FunctionCallExpression;

--- a/Parser/Functions/OnceFunction.cs
+++ b/Parser/Functions/OnceFunction.cs
@@ -10,20 +10,6 @@ namespace RATools.Parser.Functions
         {
         }
 
-        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
-        {
-            if (!IsInTriggerClause(scope, out result))
-                return false;
-
-            var comparison = GetParameter(scope, "comparison", out result);
-            if (comparison == null)
-                return false;
-
-            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { comparison });
-            CopyLocation(result);
-            return true;
-        }
-
         public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var comparison = functionCall.Parameters.First();

--- a/Parser/Functions/PrevPriorFunction.cs
+++ b/Parser/Functions/PrevPriorFunction.cs
@@ -18,9 +18,6 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            if (!IsInTriggerClause(scope, out result))
-                return false;
-
             var parameter = GetParameter(scope, "accessor", out result);
             if (parameter == null)
                 return false;

--- a/Parser/Functions/RangeFunction.cs
+++ b/Parser/Functions/RangeFunction.cs
@@ -16,6 +16,11 @@ namespace RATools.Parser.Functions
             DefaultParameters["step"] = new IntegerConstantExpression(1);
         }
 
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            return Evaluate(scope, out result);
+        }
+
         public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
             var start = GetIntegerParameter(scope, "start", out result);

--- a/Parser/Functions/RepeatedFunction.cs
+++ b/Parser/Functions/RepeatedFunction.cs
@@ -20,24 +20,6 @@ namespace RATools.Parser.Functions
         {
         }
 
-        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
-        {
-            if (!IsInTriggerClause(scope, out result))
-                return false;
-
-            var count = GetIntegerParameter(scope, "count", out result);
-            if (count == null)
-                return false;
-
-            var comparison = GetParameter(scope, "comparison", out result);
-            if (comparison == null)
-                return false;
-
-            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { count, comparison });
-            CopyLocation(result);
-            return true;
-        }
-
         protected override ParseErrorExpression ModifyRequirements(AchievementBuilder builder)
         {
             // not actually modifying requirements, but allows us to do some validation

--- a/Parser/Functions/RichPresenceDisplayFunction.cs
+++ b/Parser/Functions/RichPresenceDisplayFunction.cs
@@ -1,5 +1,4 @@
 ﻿using RATools.Parser.Internal;
-using System.Diagnostics;
 
 namespace RATools.Parser.Functions
 {
@@ -20,12 +19,18 @@ namespace RATools.Parser.Functions
         public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
             var context = scope.GetContext<AchievementScriptContext>();
-            Debug.Assert(context != null);
-
-            scope = new InterpreterScope(scope);
-            scope.Context = new RichPresenceDisplayContext
+            if (context == null)
             {
-                RichPresence = context.RichPresence,
+                result = new ParseErrorExpression(Name.Name + " has no meaning outside of an achievement script");
+                return false;
+            }
+
+            scope = new InterpreterScope(scope)
+            {
+                Context = new RichPresenceDisplayContext
+                {
+                    RichPresence = context.RichPresence,
+                }
             };
 
             if (!base.Evaluate(scope, out result))
@@ -58,28 +63,6 @@ namespace RATools.Parser.Functions
             public FunctionDefinition(string name)
                 : base(name)
             {
-            }
-
-            protected bool IsInRichPresenceDisplayClause(InterpreterScope scope, out ExpressionBase result)
-            {
-                var richPresence = scope.GetContext<RichPresenceDisplayContext>(); // explicitly in rich_presence_display clause
-                if (richPresence == null)
-                {
-                    var assignment = scope.GetInterpreterContext<AssignmentExpression>(); // in generic assignment clause - may be used byte rich_presence_display - will determine later
-                    if (assignment == null)
-                    {
-                        result = new ParseErrorExpression(Name.Name + " has no meaning outside of a rich_presence_display call");
-                        return false;
-                    }
-                }
-
-                result = null;
-                return true;
-            }
-
-            public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
-            {
-                return IsInRichPresenceDisplayClause(scope, out result);
             }
 
             public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)

--- a/Parser/Functions/RichPresenceLookupFunction.cs
+++ b/Parser/Functions/RichPresenceLookupFunction.cs
@@ -16,32 +16,6 @@ namespace RATools.Parser.Functions
             DefaultParameters["fallback"] = new StringConstantExpression("");
         }
 
-        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
-        {
-            if (!IsInRichPresenceDisplayClause(scope, out result))
-                return false;
-
-            var name = GetStringParameter(scope, "name", out result);
-            if (name == null)
-                return false;
-
-            var expression = GetParameter(scope, "expression", out result);
-            if (expression == null)
-                return false;
-
-            var dictionary = GetDictionaryParameter(scope, "dictionary", out result);
-            if (dictionary == null)
-                return false;
-
-            var fallback = GetStringParameter(scope, "fallback", out result);
-            if (fallback == null)
-                return false;
-
-            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { name, expression, dictionary, fallback });
-            CopyLocation(result);
-            return true;
-        }
-
         public override bool BuildMacro(RichPresenceDisplayFunction.RichPresenceDisplayContext context, InterpreterScope scope, out ExpressionBase result)
         {
             var name = GetStringParameter(scope, "name", out result);

--- a/Parser/Functions/RichPresenceValueFunction.cs
+++ b/Parser/Functions/RichPresenceValueFunction.cs
@@ -18,9 +18,6 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            if (!IsInRichPresenceDisplayClause(scope, out result))
-                return false;
-
             var name = GetStringParameter(scope, "name", out result);
             if (name == null)
                 return false;

--- a/Parser/Functions/TallyFunction.cs
+++ b/Parser/Functions/TallyFunction.cs
@@ -17,9 +17,6 @@ namespace RATools.Parser.Functions
 
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
-            if (!IsInTriggerClause(scope, out result))
-                return false;
-
             var count = GetIntegerParameter(scope, "count", out result);
             if (count == null)
                 return false;
@@ -36,8 +33,18 @@ namespace RATools.Parser.Functions
             parameters.Add(count);
 
             // special case - if there's a single array parameter, assume it's a list of conditions
-            if (varargs.Entries.Count == 1 && varargs.Entries[0] is ArrayExpression)
-                varargs = (ArrayExpression)varargs.Entries[0];
+            if (varargs.Entries.Count == 1)
+            {
+                var arrayExpression = varargs.Entries[0] as ArrayExpression;
+                if (arrayExpression == null)
+                {
+                    var referenceExpression = varargs.Entries[0] as VariableReferenceExpression;
+                    if (referenceExpression != null)
+                        arrayExpression = referenceExpression.Expression as ArrayExpression;
+                }
+                if (arrayExpression != null)
+                    varargs = arrayExpression;
+            }
 
             var tallyScope = new InterpreterScope(scope);
             tallyScope.Context = this;

--- a/Parser/Internal/AssignmentExpression.cs
+++ b/Parser/Internal/AssignmentExpression.cs
@@ -64,6 +64,24 @@ namespace RATools.Parser.Internal
         }
 
         /// <summary>
+        /// Updates the provided scope with the new variable value.
+        /// </summary>
+        /// <param name="scope">The scope object containing variable values and function parameters.</param>
+        /// <returns>
+        ///   <c>null</c> if successful, or a <see cref="ParseErrorExpression" /> if not.
+        /// </returns>
+        public ParseErrorExpression Evaluate(InterpreterScope scope)
+        {
+            var assignmentScope = new InterpreterScope(scope) { Context = this };
+
+            ExpressionBase result;
+            if (!Value.ReplaceVariables(assignmentScope, out result))
+                return (ParseErrorExpression)result;
+
+            return scope.AssignVariable(Variable, result);
+        }
+
+        /// <summary>
         /// Determines whether the specified <see cref="AssignmentExpression" /> is equal to this instance.
         /// </summary>
         /// <param name="obj">The <see cref="AssignmentExpression" /> to compare with this instance.</param>

--- a/Parser/Internal/DictionaryExpression.cs
+++ b/Parser/Internal/DictionaryExpression.cs
@@ -379,7 +379,23 @@ namespace RATools.Parser.Internal
         protected override bool Equals(ExpressionBase obj)
         {
             var that = obj as DictionaryExpression;
-            return that != null && _entries == that._entries;
+            if (that == null || _entries.Count != that._entries.Count)
+                return false;
+
+            if (ReferenceEquals(_entries, that._entries))
+                return true;
+
+            var unmatched = new List<DictionaryEntry>(that._entries);
+            foreach (var kvp in _entries)
+            {
+                int i = unmatched.FindIndex(e => e.Key == kvp.Key);
+                if (i == -1|| unmatched[i].Value != kvp.Value)
+                    return false;
+
+                unmatched.RemoveAt(i);
+            }
+
+            return true;
         }
 
         IEnumerable<ExpressionBase> INestedExpressions.NestedExpressions

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -26,10 +26,10 @@ namespace RATools.Parser.Internal
         /// <summary>
         /// Copies the location of this expression into another expression.
         /// </summary>
-        internal void CopyLocation(ExpressionBase source)
+        internal void CopyLocation(ExpressionBase target)
         {
             if (!Location.IsEmpty)
-                source.Location = Location;
+                target.Location = Location;
         }
 
         /// <summary>
@@ -437,7 +437,7 @@ namespace RATools.Parser.Internal
                     }
 
                     if (identifier == "function")
-                        return FunctionDefinitionExpression.Parse(tokenizer, line, column);
+                        return UserFunctionDefinitionExpression.Parse(tokenizer, line, column);
                     if (identifier == "for")
                         return ForExpression.Parse(tokenizer, line, column);
                     if (identifier == "if")
@@ -859,7 +859,7 @@ namespace RATools.Parser.Internal
         None = 0,
 
         /// <summary>
-        /// A variable reference.
+        /// A variable definition.
         /// </summary>
         Variable,
 
@@ -942,5 +942,10 @@ namespace RATools.Parser.Internal
         /// A parse error.
         /// </summary>
         ParseError,
+
+        /// <summary>
+        /// A reference to a variable.
+        /// </summary>
+        VariableReference,
     }
 }

--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -94,6 +94,12 @@ namespace RATools.Parser.Internal
                 return false;
             }
 
+            if (result == null)
+            {
+                result = new ParseErrorExpression(FunctionName.Name + " did not return a value", FunctionName);
+                return false;
+            }
+
             CopyLocation(result);
             return true;
         }

--- a/Parser/Internal/FunctionDefinitionExpression.cs
+++ b/Parser/Internal/FunctionDefinitionExpression.cs
@@ -429,4 +429,16 @@ namespace RATools.Parser.Internal
                 modifies.Remove(parameter.Name);
         }
     }
+
+    internal class FunctionReferenceExpression : VariableExpressionBase
+    {
+        public FunctionReferenceExpression(string name)
+            : base(name)
+        {
+        }
+        public override string ToString()
+        {
+            return "FunctionReference: " + Name;
+        }
+    }
 }

--- a/Parser/Internal/IndexedVariableExpression.cs
+++ b/Parser/Internal/IndexedVariableExpression.cs
@@ -153,6 +153,10 @@ namespace RATools.Parser.Internal
                 return;
             }
 
+            var variableReference = container as VariableReferenceExpression;
+            if (variableReference != null)
+                container = variableReference.Expression;
+
             var array = container as ArrayExpression;
             if (array != null)
             {

--- a/Parser/Internal/InterpreterScope.cs
+++ b/Parser/Internal/InterpreterScope.cs
@@ -89,6 +89,10 @@ namespace RATools.Parser.Internal
                 }
             }
 
+            var functionReference = GetVariable(functionName) as FunctionReferenceExpression;
+            if (functionReference != null)
+                return GetFunction(functionReference.Name);
+
             return null;
         }
 

--- a/Parser/Internal/InterpreterScope.cs
+++ b/Parser/Internal/InterpreterScope.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -145,6 +146,27 @@ namespace RATools.Parser.Internal
             var parentScope = GetParentScope(this);
             if (parentScope != null)
                 return parentScope.GetVariableDefinition(variableName);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets a reference to a variable.
+        /// </summary>
+        /// <param name="variableName">Name of the variable.</param>
+        /// <returns>Reference to the variable, <c>null</c> if not found.</returns>
+        public ExpressionBase GetVariableReference(string variableName)
+        {
+            VariableDefinitionPair variable;
+            if (_variables != null && _variables.TryGetValue(variableName, out variable))
+                return new VariableReferenceExpression(variable.Key, variable.Value);
+
+            if (_variable.Key != null && _variable.Key.Name == variableName)
+                return new VariableReferenceExpression(_variable.Key, _variable.Value);
+
+            var parentScope = GetParentScope(this);
+            if (parentScope != null)
+                return parentScope.GetVariableReference(variableName);
 
             return null;
         }

--- a/Parser/Internal/VariableExpression.cs
+++ b/Parser/Internal/VariableExpression.cs
@@ -139,4 +139,46 @@ namespace RATools.Parser.Internal
             modifies.Add(Name);
         }
     }
+
+    internal class VariableReferenceExpression : ExpressionBase
+    {
+        public VariableReferenceExpression(VariableDefinitionExpression variable, ExpressionBase expression)
+            : base(ExpressionType.VariableReference)
+        {
+            Variable = variable;
+            Expression = expression;
+        }
+
+        public VariableDefinitionExpression Variable { get; private set; }
+
+        public ExpressionBase Expression { get; private set; }
+
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            return Expression.ReplaceVariables(scope, out result);
+        }
+
+        protected override bool Equals(ExpressionBase obj)
+        {
+            var that = obj as VariableReferenceExpression;
+            return (that != null && Expression == that.Expression);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.Append(Expression.Type);
+            builder.Append(" Reference: ");
+            AppendString(builder);
+            return builder.ToString();
+        }
+
+        internal override void AppendString(StringBuilder builder)
+        {
+            builder.Append(Variable.Name);
+        }
+    }
 }

--- a/Parser/Internal/VariableExpression.cs
+++ b/Parser/Internal/VariableExpression.cs
@@ -72,10 +72,14 @@ namespace RATools.Parser.Internal
             {
                 var func = scope.GetFunction(Name);
                 if (func != null)
-                    result = new UnknownVariableParseErrorExpression("Function used like a variable: " + Name, this);
-                else
-                    result = new UnknownVariableParseErrorExpression("Unknown variable: " + Name, this);
+                {
+                    // special wrapper for returning a function as a variable
+                    result = new FunctionReferenceExpression(Name);
+                    result.CopyLocation(this);
+                    return true;
+                }
 
+                result = new UnknownVariableParseErrorExpression("Unknown variable: " + Name, this);
                 return false;
             }
 

--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -359,8 +359,11 @@ namespace RATools.Parser
                     return ExecuteAchievementMathematic((MathematicExpression)expression, scope);
 
                 case ExpressionType.Variable:
-                    if (!((VariableExpression)expression).ReplaceVariables(scope, out operand))
+                    if (!expression.ReplaceVariables(scope, out operand))
                         return new ParseErrorExpression(operand, expression);
+
+                    if (expression is FunctionReferenceExpression)
+                        return new ParseErrorExpression("Function used like a variable", expression);
 
                     return ExecuteAchievementExpression(operand, scope);
             }

--- a/Parser/TriggerBuilderContext.cs
+++ b/Parser/TriggerBuilderContext.cs
@@ -293,32 +293,16 @@ namespace RATools.Parser
             {
             }
 
-            protected bool IsInTriggerClause(InterpreterScope scope, out ExpressionBase result)
-            {
-                var triggerContext = scope.GetContext<TriggerBuilderContext>();
-                if (triggerContext == null) // explicitly in trigger clause
-                {
-                    var assignment = scope.GetInterpreterContext<AssignmentExpression>();
-                    if (assignment == null) // in generic assignment clause - may be used in a trigger - will determine later
-                    {
-                        result = new ParseErrorExpression(Name.Name + " has no meaning outside of a trigger clause");
-                        return false;
-                    }
-                }
-
-                result = null;
-                return true;
-            }
-
-            public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
-            {
-                return IsInTriggerClause(scope, out result);
-            }
-
             public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
             {
-                result = new ParseErrorExpression(Name.Name + " has no meaning outside of a trigger clause");
-                return false;
+                var context = scope.GetInterpreterContext<TriggerBuilderContext>();
+                if (context == null)
+                {
+                    result = new ParseErrorExpression(Name.Name + " has no meaning outside of a trigger clause");
+                    return false;
+                }
+
+                return ReplaceVariables(scope, out result);
             }
 
             public abstract ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall);

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using RATools.Data;
 using RATools.Parser;
+using RATools.Parser.Internal;
 using System.Linq;
 
 namespace RATools.Test.Parser
@@ -29,6 +30,19 @@ namespace RATools.Test.Parser
             }
 
             return parser;
+        }
+
+        private static InterpreterScope Evaluate(string script)
+        {
+            var groups = new ExpressionGroupCollection();
+            groups.Scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+
+            groups.Parse(new PositionalTokenizer(Tokenizer.CreateTokenizer(script)));
+
+            var interpreter = new AchievementScriptInterpreter();
+            Assert.That(interpreter.Run(groups, null), Is.True);
+
+            return groups.Scope;
         }
 
         private static string GetInnerErrorMessage(AchievementScriptInterpreter parser)
@@ -1024,6 +1038,44 @@ namespace RATools.Test.Parser
             achievement = parser.Achievements.First();
             Assert.That(GetRequirements(achievement),
                 Is.EqualTo("once(byte(0x002222) == 0) && repeated(2, byte(0x001234) == 1 && never(byte(0x002345) == 2))"));
+        }
+
+        [Test]
+        public void TestAssignFunctionToVariable()
+        {
+            var scope = Evaluate(
+                "function a(i) => i + 1\n" +
+                "b = a\n" +
+                "c = b\n" +
+                "d = c(3)\n");
+
+            var b = scope.GetVariable("b");
+            Assert.That(b, Is.InstanceOf<FunctionReferenceExpression>());
+            Assert.That(((FunctionReferenceExpression)b).Name, Is.EqualTo("a"));
+
+            var c = scope.GetVariable("c");
+            Assert.That(c, Is.InstanceOf<FunctionReferenceExpression>());
+            Assert.That(((FunctionReferenceExpression)c).Name, Is.EqualTo("a"));
+
+            var d = scope.GetVariable("d");
+            Assert.That(d, Is.InstanceOf<IntegerConstantExpression>());
+            var integerConstant = (IntegerConstantExpression)d;
+            Assert.That(integerConstant.Value, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void TestPassFunctionToFunction()
+        {
+            var scope = Evaluate(
+                "function a(i) => i + 1\n" +
+                "function b(f,i) => f(i)\n" +
+                "function c(i) => b(a,i)\n" +
+                "d = c(3)\n");
+
+            var d = scope.GetVariable("d");
+            Assert.That(d, Is.InstanceOf<IntegerConstantExpression>());
+            var integerConstant = (IntegerConstantExpression)d;
+            Assert.That(integerConstant.Value, Is.EqualTo(4));
         }
     }
 }

--- a/Tests/Parser/Functions/ArrayPushFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayPushFunctionTests.cs
@@ -91,16 +91,20 @@ namespace RATools.Test.Parser.Functions
             Evaluate("array_push(dict, 1)", scope, "array did not evaluate to an array");
         }
 
+        private void AddHappyFunction(InterpreterScope scope)
+        {
+            scope.AddFunction(UserFunctionDefinitionExpression.ParseForTest(
+                "function happy(num1) => num1"
+            ));
+        }
+
         [Test]
         public void TestPushFunctionCall()
         {
             var scope = new InterpreterScope();
             var array = new ArrayExpression();
             scope.DefineVariable(new VariableDefinitionExpression("arr"), array);
-            var happyFunc = new FunctionDefinitionExpression("happy");
-            happyFunc.Parameters.Add(new VariableDefinitionExpression("num1"));
-            happyFunc.Expressions.Add(new ReturnExpression(new VariableExpression("num1")));
-            scope.AddFunction(happyFunc);
+            AddHappyFunction(scope);
 
             Evaluate("array_push(arr, happy(1))", scope);
 
@@ -116,10 +120,7 @@ namespace RATools.Test.Parser.Functions
             var scope = new InterpreterScope();
             var array = new ArrayExpression();
             scope.DefineVariable(new VariableDefinitionExpression("arr"), array);
-            var happyFunc = new FunctionDefinitionExpression("happy");
-            happyFunc.Parameters.Add(new VariableDefinitionExpression("num1"));
-            happyFunc.Expressions.Add(new ReturnExpression(new VariableExpression("num1")));
-            scope.AddFunction(happyFunc);
+            AddHappyFunction(scope);
 
             Evaluate("array_push(arr, happy(1) == 2)", scope);
 
@@ -136,10 +137,7 @@ namespace RATools.Test.Parser.Functions
             var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
             var array = new ArrayExpression();
             scope.DefineVariable(new VariableDefinitionExpression("arr"), array);
-            var happyFunc = new FunctionDefinitionExpression("happy");
-            happyFunc.Parameters.Add(new VariableDefinitionExpression("num1"));
-            happyFunc.Expressions.Add(new ReturnExpression(new VariableExpression("num1")));
-            scope.AddFunction(happyFunc);
+            AddHappyFunction(scope);
 
             Evaluate("array_push(arr, byte(1) == 2)", scope);
 

--- a/Tests/Parser/Functions/LengthFunctionTests.cs
+++ b/Tests/Parser/Functions/LengthFunctionTests.cs
@@ -131,10 +131,9 @@ namespace RATools.Test.Parser.Functions
             var scope = new InterpreterScope();
             var array = new ArrayExpression();
             scope.DefineVariable(new VariableDefinitionExpression("arr"), array);
-            var happyFunc = new FunctionDefinitionExpression("happy");
-            happyFunc.Parameters.Add(new VariableDefinitionExpression("str1"));
-            happyFunc.Expressions.Add(new ReturnExpression(new MathematicExpression(new VariableExpression("str1"), MathematicOperation.Add, new StringConstantExpression("rama"))));
-            scope.AddFunction(happyFunc);
+            scope.AddFunction(UserFunctionDefinitionExpression.ParseForTest(
+                "function happy(val) => val + \"rama\""
+            ));
 
             Assert.That(Evaluate("length(happy(\"banana\"))", scope), Is.EqualTo(10));
         }

--- a/Tests/Parser/Internal/DictionaryExpressionTests.cs
+++ b/Tests/Parser/Internal/DictionaryExpressionTests.cs
@@ -116,10 +116,7 @@ namespace RATools.Test.Parser.Internal
         [Test]
         public void TestReplaceVariablesFunctionCall()
         {
-            var input = "function func(i) => 6";
-            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
-            tokenizer.Match("function");
-            var functionDefinition = (FunctionDefinitionExpression)FunctionDefinitionExpression.Parse(tokenizer);
+            var functionDefinition = UserFunctionDefinitionExpression.ParseForTest("function func(i) => 6");
 
             var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { new IntegerConstantExpression(2) });
             var value1 = new IntegerConstantExpression(98);
@@ -141,10 +138,7 @@ namespace RATools.Test.Parser.Internal
         [Test]
         public void TestReplaceVariablesLogicalFunctionCall()
         {
-            var input = "function func(i) => i == 1";
-            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
-            tokenizer.Match("function");
-            var functionDefinition = (FunctionDefinitionExpression)FunctionDefinitionExpression.Parse(tokenizer);
+            var functionDefinition = UserFunctionDefinitionExpression.ParseForTest("function func(i) => i == 1");
 
             var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { new IntegerConstantExpression(2) });
             var value1 = new IntegerConstantExpression(98);
@@ -163,10 +157,7 @@ namespace RATools.Test.Parser.Internal
         [Test]
         public void TestReplaceVariablesMethodCall()
         {
-            var input = "function func(i) { j = i }";
-            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
-            tokenizer.Match("function");
-            var functionDefinition = (FunctionDefinitionExpression)FunctionDefinitionExpression.Parse(tokenizer);
+            var functionDefinition = UserFunctionDefinitionExpression.ParseForTest("function func(i) { j = i }");
 
             var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { new IntegerConstantExpression(2) });
             var value1 = new IntegerConstantExpression(98);

--- a/Tests/Parser/Internal/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Internal/FunctionCallExpressionTests.cs
@@ -75,11 +75,9 @@ namespace RATools.Test.Parser.Internal
 
         private FunctionDefinitionExpression Parse(string input)
         {
-            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
-            tokenizer.Match("function");
-            var expr = FunctionDefinitionExpression.Parse(tokenizer);
-            Assert.That(expr, Is.InstanceOf<FunctionDefinitionExpression>());
-            return (FunctionDefinitionExpression)expr;
+            var def = UserFunctionDefinitionExpression.ParseForTest(input);
+            Assert.That(def, Is.Not.Null);
+            return (FunctionDefinitionExpression)def;
         }
 
         [Test]
@@ -402,7 +400,7 @@ namespace RATools.Test.Parser.Internal
         }
 
         [Test]
-        public void TestReplaceVariablesMethod()
+        public void TestReplaceVariablesNoReturnValue()
         {
             var functionDefinition = Parse("function func(i) { j = i }");
             var scope = new InterpreterScope();
@@ -495,7 +493,7 @@ namespace RATools.Test.Parser.Internal
         }
 
         [Test]
-        public void TestEvaluateMethod()
+        public void TestEvaluateNoReturnValue()
         {
             var functionDefinition = Parse("function func(i) { j = i }");
             var scope = new InterpreterScope();

--- a/Tests/Parser/Internal/FunctionDefinitionExpressionTests.cs
+++ b/Tests/Parser/Internal/FunctionDefinitionExpressionTests.cs
@@ -38,7 +38,7 @@ namespace RATools.Test.Parser.Internal
         {
             var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
             tokenizer.Match("function");
-            var expr = FunctionDefinitionExpression.Parse(tokenizer);
+            var expr = UserFunctionDefinitionExpression.Parse(tokenizer);
             Assert.That(expr, Is.InstanceOf<FunctionDefinitionExpression>());
             return (FunctionDefinitionExpression)expr;
         }
@@ -89,7 +89,7 @@ namespace RATools.Test.Parser.Internal
         {
             var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer("function func() { if (j) { j = i } }"));
             tokenizer.Match("function");
-            var expr = FunctionDefinitionExpression.Parse(tokenizer);
+            var expr = UserFunctionDefinitionExpression.Parse(tokenizer);
 
             Assert.That(expr, Is.InstanceOf<ParseErrorExpression>());
             Assert.That(((ParseErrorExpression)expr).Message, Is.EqualTo("Expected conditional statement following if"));
@@ -101,7 +101,7 @@ namespace RATools.Test.Parser.Internal
             var group = new ExpressionGroup();
             var tokenizer = new ExpressionTokenizer(Tokenizer.CreateTokenizer("function func() { if (j) { j = i } }"), group);
             tokenizer.Match("function");
-            var expr = FunctionDefinitionExpression.Parse(tokenizer);
+            var expr = UserFunctionDefinitionExpression.Parse(tokenizer);
 
             Assert.That(expr, Is.InstanceOf<FunctionDefinitionExpression>());
             Assert.That(group.ParseErrors.Count(), Is.EqualTo(1));

--- a/Tests/Parser/Internal/IndexedVariableExpressionTests.cs
+++ b/Tests/Parser/Internal/IndexedVariableExpressionTests.cs
@@ -150,10 +150,7 @@ namespace RATools.Test.Parser.Internal
         [Test]
         public void TestReplaceVariablesIndexFunctionCall()
         {
-            var input = "function func(i) => 6";
-            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
-            tokenizer.Match("function");
-            var functionDefinition = (FunctionDefinitionExpression)FunctionDefinitionExpression.Parse(tokenizer);
+            var functionDefinition = UserFunctionDefinitionExpression.ParseForTest("function func(i) => 6");
 
             var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { new IntegerConstantExpression(2) });
             var value = new IntegerConstantExpression(98);

--- a/Tests/Parser/Internal/VariableExpressionTests.cs
+++ b/Tests/Parser/Internal/VariableExpressionTests.cs
@@ -43,9 +43,9 @@ namespace RATools.Test.Parser.Internal
             scope.AddFunction(new FunctionDefinitionExpression("func"));
 
             ExpressionBase result;
-            Assert.That(variable.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Function used like a variable: func"));
+            Assert.That(variable.ReplaceVariables(scope, out result), Is.True);
+            Assert.That(result, Is.InstanceOf<FunctionReferenceExpression>());
+            Assert.That(((FunctionReferenceExpression)result).Name, Is.EqualTo("func"));
         }
 
         [Test]


### PR DESCRIPTION
Primarily for passing functions to other functions. Here's a contrived example:
```
function adjust(f,i) => f(i)
function increment(i) => i + 1
function next(i) => adjust(increment,i)
function decrement(i) => i - 1
function previous(i) => adjust(decrement,i)
a = next(3)
b = previous(3)
```
`next` passes the `increment` function to `adjust`, so `a` will be `4`.
`previous` passes the `decrement` function to `adjust`, so `b` will be `3`.

I intend to leverage this functionality to provide built-in functions for chaining a series of conditions together. The function parameter will generate a single condition in the chain.