### PR TITLE
support for anonymous functions

### DIFF
--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -176,6 +176,11 @@ namespace RATools.Parser.Internal
                         tokenizer.Advance();
                         clause = ParseComparison(tokenizer, clause, ComparisonOperation.Equal, joinerLine, joinerColumn);
                     }
+                    else if (tokenizer.NextChar == '>')
+                    {
+                        tokenizer.Advance();
+                        clause = UserFunctionDefinitionExpression.ParseAnonymous(tokenizer, clause);
+                    }
                     else
                     {
                         clause = ParseAssignment(tokenizer, clause, joinerLine, joinerColumn);
@@ -355,6 +360,9 @@ namespace RATools.Parser.Internal
                     return new ConditionalExpression(null, ConditionalOperation.Not, clause);
 
                 case '(':
+                    if (UserFunctionDefinitionExpression.IsAnonymousParameterList(tokenizer))
+                        return UserFunctionDefinitionExpression.ParseAnonymous(tokenizer);
+
                     tokenizer.Advance();
                     clause = ExpressionBase.Parse(tokenizer);
                     if (clause.Type == ExpressionType.ParseError)
@@ -370,6 +378,7 @@ namespace RATools.Parser.Internal
 
                     clause.IsLogicalUnit = true;
                     tokenizer.Advance();
+
                     return clause;
 
                 case '"':

--- a/Parser/Internal/InterpreterScope.cs
+++ b/Parser/Internal/InterpreterScope.cs
@@ -71,6 +71,10 @@ namespace RATools.Parser.Internal
             if (_functions != null && _functions.TryGetValue(functionName, out function))
                 return function;
 
+            var functionReference = GetVariable(functionName) as FunctionReferenceExpression;
+            if (functionReference != null)
+                return GetFunction(functionReference.Name);
+
             var parentScope = GetParentScope(this);
             if (parentScope != null)
             {
@@ -89,10 +93,6 @@ namespace RATools.Parser.Internal
                     return function;
                 }
             }
-
-            var functionReference = GetVariable(functionName) as FunctionReferenceExpression;
-            if (functionReference != null)
-                return GetFunction(functionReference.Name);
 
             return null;
         }

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -37,7 +37,7 @@ namespace RATools.Test.Parser
             var groups = new ExpressionGroupCollection();
             groups.Scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
 
-            groups.Parse(new PositionalTokenizer(Tokenizer.CreateTokenizer(script)));
+            groups.Parse(Tokenizer.CreateTokenizer(script));
 
             var interpreter = new AchievementScriptInterpreter();
 
@@ -48,7 +48,9 @@ namespace RATools.Test.Parser
                 return null;
             }
 
-            Assert.That(interpreter.Run(groups, null), Is.True);
+            if (!interpreter.Run(groups, null))
+                Assert.Fail(interpreter.ErrorMessage);
+
             return groups.Scope;
         }
 
@@ -1135,6 +1137,24 @@ namespace RATools.Test.Parser
             achievement = parser.Achievements.ElementAt(4);
             Assert.That(achievement.Id, Is.EqualTo(20));
             Assert.That(achievement.BadgeName, Is.EqualTo("12345"));
+        }
+
+        [Test]
+        [TestCase("b = function a(i) => i + 1\nc = b(3)")] // full function definition
+        [TestCase("b = (i) => i + 1\nc = b(3)")] // anonymous function definition
+        [TestCase("b = (i) { return i + 1 }\nc = b(3)")] // anonymous long-form function definition
+        [TestCase("b = (i, j) => i + j\nc = b(3, 1)")] // anonymous multiple parameter function definition
+        [TestCase("b = i => i + 1\nc = b(3)")] // anonymous function definition without parenthesis
+        [TestCase("a = i => i + 1\nb = (f,i) => f(i)\nc = b(a, 3)")] // anonymous function passed as parameter
+        [TestCase("b = (f,i) => f(i)\nc = b(i => i + 1, 3)")] // anonymous function defined as parameter
+        public void TestAnonymousFunction(string definition)
+        {
+            var scope = Evaluate(definition);
+
+            var c = scope.GetVariable("c");
+            Assert.That(c, Is.InstanceOf<IntegerConstantExpression>());
+            var integerConstant = (IntegerConstantExpression)c;
+            Assert.That(integerConstant.Value, Is.EqualTo(4));
         }
     }
 }


### PR DESCRIPTION
An anonymous function is defined as follows:
```
(parameterlist) => expression
```
If `parameterlist` is a single parameter, the parentheses can be omitted.

examples:
```
a = (i) => i + 1
b = i => i + 1
c = (i,j) => i + j
```
The long form can also be used for defining a function if more logic is required.
```
d = (i, j) {
    if (i > j)
        return i - j

    return i + j
}
```
Parentheses cannot be omitted when using the long form, even if the `parameterlist` is a single parameter.

All of the above examples illustrate assigning a function to a variable. They can also be passed as function parameters, which is the primary use for anonymous functions:
```
e = somefunc(i => i + 1)
f = somefunc2((i, j) => i + j)
g = somefunc((i) {
    if (i == 0)
        return 0
   
    return i + 1
})
```