### PR TITLE
Iterable helper functions

### DIFF
--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -491,52 +491,14 @@ namespace RATools.Parser
                 return false;
             }
 
-            var dict = range as DictionaryExpression;
-            if (dict != null)
+            var iterableExpression = range as IIterableExpression;
+            if (iterableExpression != null)
             {
                 var iterator = forExpression.IteratorName;
                 var iteratorScope = new InterpreterScope(scope);
                 var iteratorVariable = new VariableExpression(iterator.Name);
 
-                foreach (var entry in dict.Keys)
-                {
-                    iteratorScope.Context = new AssignmentExpression(iteratorVariable, entry);
-
-                    ExpressionBase key;
-                    if (!entry.ReplaceVariables(iteratorScope, out key))
-                    {
-                        Error = key as ParseErrorExpression;
-                        return false;
-                    }
-
-                    var loopScope = new InterpreterScope(scope);
-                    loopScope.DefineVariable(iterator, key);
-
-                    if (!Evaluate(forExpression.Expressions, loopScope))
-                        return false;
-
-                    if (loopScope.IsComplete)
-                    {
-                        if (loopScope.ReturnValue != null)
-                        {
-                            scope.ReturnValue = loopScope.ReturnValue;
-                            scope.IsComplete = true;
-                        }
-                        break;
-                    }
-                }
-
-                return true;
-            }
-
-            var array = range as ArrayExpression;
-            if (array != null)
-            {
-                var iterator = forExpression.IteratorName;
-                var iteratorScope = new InterpreterScope(scope);
-                var iteratorVariable = new VariableExpression(iterator.Name);
-
-                foreach (var entry in array.Entries)
+                foreach (var entry in iterableExpression.IterableExpressions())
                 {
                     iteratorScope.Context = new AssignmentExpression(iteratorVariable, entry);
 

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -117,6 +117,7 @@ namespace RATools.Parser
 
                 _globalScope.AddFunction(new AllOfFunction());
                 _globalScope.AddFunction(new AnyOfFunction());
+                _globalScope.AddFunction(new NoneOfFunction());
 
                 _globalScope.AddFunction(new RangeFunction());
                 _globalScope.AddFunction(new FormatFunction());

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -115,6 +115,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new AlwaysTrueFunction());
                 _globalScope.AddFunction(new AlwaysFalseFunction());
 
+                _globalScope.AddFunction(new AllOfFunction());
                 _globalScope.AddFunction(new AnyOfFunction());
 
                 _globalScope.AddFunction(new RangeFunction());

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -118,6 +118,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new AllOfFunction());
                 _globalScope.AddFunction(new AnyOfFunction());
                 _globalScope.AddFunction(new NoneOfFunction());
+                _globalScope.AddFunction(new SumOfFunction());
 
                 _globalScope.AddFunction(new RangeFunction());
                 _globalScope.AddFunction(new FormatFunction());

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -115,6 +115,8 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new AlwaysTrueFunction());
                 _globalScope.AddFunction(new AlwaysFalseFunction());
 
+                _globalScope.AddFunction(new AnyOfFunction());
+
                 _globalScope.AddFunction(new RangeFunction());
                 _globalScope.AddFunction(new FormatFunction());
                 _globalScope.AddFunction(new LengthFunction());

--- a/Parser/Functions/AllOfFunction.cs
+++ b/Parser/Functions/AllOfFunction.cs
@@ -1,0 +1,22 @@
+﻿using RATools.Parser.Internal;
+
+namespace RATools.Parser.Functions
+{
+    internal class AllOfFunction : IterableJoiningFunction
+    {
+        public AllOfFunction()
+            : base("all_of")
+        {
+        }
+
+        protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
+        {
+            return new ConditionalExpression(left, ConditionalOperation.And, right);
+        }
+
+        protected override ExpressionBase GenerateEmptyResult()
+        {
+            return new FunctionCallExpression("always_true", new ExpressionBase[0]);
+        }
+    }
+}

--- a/Parser/Functions/AnyOfFunction.cs
+++ b/Parser/Functions/AnyOfFunction.cs
@@ -11,6 +11,11 @@ namespace RATools.Parser.Functions
 
         protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
         {
+            right.IsLogicalUnit = true;
+
+            if (left == null)
+                return right;
+
             return new ConditionalExpression(left, ConditionalOperation.Or, right);
         }
 

--- a/Parser/Functions/AnyOfFunction.cs
+++ b/Parser/Functions/AnyOfFunction.cs
@@ -1,0 +1,22 @@
+﻿using RATools.Parser.Internal;
+
+namespace RATools.Parser.Functions
+{
+    internal class AnyOfFunction : IterableJoiningFunction
+    {
+        public AnyOfFunction()
+            : base("any_of")
+        {
+        }
+
+        protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
+        {
+            return new ConditionalExpression(left, ConditionalOperation.Or, right);
+        }
+
+        protected override ExpressionBase GenerateEmptyResult()
+        {
+            return new FunctionCallExpression("always_false", new ExpressionBase[0]);
+        }
+    }
+}

--- a/Parser/Functions/IterableJoiningFunction.cs
+++ b/Parser/Functions/IterableJoiningFunction.cs
@@ -1,0 +1,106 @@
+﻿using RATools.Parser.Internal;
+using System.Linq;
+
+namespace RATools.Parser.Functions
+{
+    internal abstract class IterableJoiningFunction : FunctionDefinitionExpression
+    {
+        protected IterableJoiningFunction(string name)
+            : base(name)
+        {
+            Parameters.Clear();
+            Parameters.Add(new VariableDefinitionExpression("inputs"));
+            Parameters.Add(new VariableDefinitionExpression("predicate"));
+        }
+
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            var inputs = GetParameter(scope, "inputs", out result);
+            if (inputs == null)
+                return false;
+
+            if (!inputs.ReplaceVariables(scope, out result))
+                return false;
+
+            inputs = result;
+            if (!(inputs is IIterableExpression))
+            {
+                result = new ParseErrorExpression("Cannot iterate over " + inputs.ToString(), inputs);
+                return false;
+            }
+
+            var predicate = GetParameter(scope, "predicate", out result);
+            if (predicate == null)
+                return false;
+
+            var functionReference = predicate as FunctionReferenceExpression;
+            if (functionReference == null)
+            {
+                result = new ParseErrorExpression("predicate must be a function reference");
+                return false;
+            }
+
+            result = new FunctionCallExpression(Name.Name, new ExpressionBase[] { inputs, predicate });
+            CopyLocation(result);
+            return true;
+        }
+
+        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        {
+            var inputs = GetParameter(scope, "inputs", out result) as IIterableExpression;
+            if (inputs == null)
+                return false;
+
+            var predicateReference = GetParameter(scope, "predicate", out result) as FunctionReferenceExpression;
+            if (predicateReference == null)
+                return false;
+
+            var predicate = scope.GetFunction(predicateReference.Name);
+            if (predicate == null)
+            {
+                result = new ParseErrorExpression("Could not locate function: " + predicateReference.Name, predicateReference);
+                return false;
+            }
+
+            if ((predicate.Parameters.Count - predicate.DefaultParameters.Count) != 1)
+            {
+                result = new ParseErrorExpression("predicate function must accept a single parameter");
+                return false;
+            }
+
+            var iteratorScope = new InterpreterScope(scope);
+            var predicateParameter = new VariableExpression(predicate.Parameters.First().Name);
+            foreach (var kvp in predicate.DefaultParameters)
+                iteratorScope.AssignVariable(new VariableExpression(kvp.Key), kvp.Value);
+
+            ExpressionBase expression = null;
+            foreach (var input in inputs.IterableExpressions())
+            {
+                if (!input.ReplaceVariables(iteratorScope, out result))
+                    return false;
+
+                iteratorScope.AssignVariable(predicateParameter, result);
+
+                if (!predicate.Evaluate(iteratorScope, out result))
+                    return false;
+                result.IsLogicalUnit = true;
+
+                if (expression == null)
+                    expression = result;
+                else
+                    expression = Combine(expression, result);
+            }
+
+            if (expression != null)
+                result = expression;
+            else
+                result = GenerateEmptyResult();
+
+            return true;
+        }
+
+        protected abstract ExpressionBase Combine(ExpressionBase left, ExpressionBase right);
+
+        protected abstract ExpressionBase GenerateEmptyResult();
+    }
+}

--- a/Parser/Functions/IterableJoiningFunction.cs
+++ b/Parser/Functions/IterableJoiningFunction.cs
@@ -83,12 +83,13 @@ namespace RATools.Parser.Functions
 
                 if (!predicate.Evaluate(iteratorScope, out result))
                     return false;
-                result.IsLogicalUnit = true;
 
-                if (expression == null)
-                    expression = result;
-                else
-                    expression = Combine(expression, result);
+                expression = Combine(expression, result);
+                if (expression.Type == ExpressionType.ParseError)
+                {
+                    result = expression;
+                    return false;
+                }
             }
 
             if (expression != null)

--- a/Parser/Functions/NoneOfFunction.cs
+++ b/Parser/Functions/NoneOfFunction.cs
@@ -2,15 +2,19 @@
 
 namespace RATools.Parser.Functions
 {
-    internal class AllOfFunction : IterableJoiningFunction
+    internal class NoneOfFunction : IterableJoiningFunction
     {
-        public AllOfFunction()
-            : base("all_of")
+        public NoneOfFunction()
+            : base("none_of")
         {
         }
 
         protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
         {
+            right = ConditionalExpression.InvertExpression(right);
+            if (right.Type == ExpressionType.ParseError)
+                return right;
+
             right.IsLogicalUnit = true;
 
             if (left == null)

--- a/Parser/Functions/SumOfFunction.cs
+++ b/Parser/Functions/SumOfFunction.cs
@@ -1,0 +1,26 @@
+﻿using RATools.Parser.Internal;
+
+namespace RATools.Parser.Functions
+{
+    internal class SumOfFunction : IterableJoiningFunction
+    {
+        public SumOfFunction()
+            : base("sum_of")
+        {
+        }
+
+        protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
+        {
+            if (left == null)
+                return right;
+
+            var combined = new MathematicExpression(left, MathematicOperation.Add, right);
+            return combined.MergeOperands();
+        }
+
+        protected override ExpressionBase GenerateEmptyResult()
+        {
+            return new IntegerConstantExpression(0);
+        }
+    }
+}

--- a/Parser/Internal/ArrayExpression.cs
+++ b/Parser/Internal/ArrayExpression.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace RATools.Parser.Internal
 {
-    internal class ArrayExpression : ExpressionBase, INestedExpressions
+    internal class ArrayExpression : ExpressionBase, INestedExpressions, IIterableExpression
     {
         public ArrayExpression()
             : base(ExpressionType.Array)
@@ -108,6 +108,11 @@ namespace RATools.Parser.Internal
 
         void INestedExpressions.GetModifications(HashSet<string> modifies)
         {
+        }
+
+        IEnumerable<ExpressionBase> IIterableExpression.IterableExpressions()
+        {
+            return Entries;
         }
     }
 }

--- a/Parser/Internal/ConditionalExpression.cs
+++ b/Parser/Internal/ConditionalExpression.cs
@@ -95,6 +95,8 @@ namespace RATools.Parser.Internal
                 if (result.Type == ExpressionType.ParseError)
                     return false;
 
+                CopyLocation(result);
+
                 // InvertExpression may distribute Nots to subnodes, recurse
                 return result.ReplaceVariables(scope, out result);
             }
@@ -104,7 +106,7 @@ namespace RATools.Parser.Internal
             return true;
         }
 
-        private static ExpressionBase InvertExpression(ExpressionBase expression)
+        internal static ExpressionBase InvertExpression(ExpressionBase expression)
         {
             // logical inversion
             var condition = expression as ConditionalExpression;

--- a/Parser/Internal/DictionaryExpression.cs
+++ b/Parser/Internal/DictionaryExpression.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace RATools.Parser.Internal
 {
-    internal class DictionaryExpression : ExpressionBase, INestedExpressions
+    internal class DictionaryExpression : ExpressionBase, INestedExpressions, IIterableExpression
     {
         public DictionaryExpression()
             : base(ExpressionType.Dictionary)
@@ -426,6 +426,11 @@ namespace RATools.Parser.Internal
 
         void INestedExpressions.GetModifications(HashSet<string> modifies)
         {
+        }
+
+        IEnumerable<ExpressionBase> IIterableExpression.IterableExpressions()
+        {
+            return Keys;
         }
 
         [DebuggerDisplay("{Key}: {Value}")]

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -179,7 +179,7 @@ namespace RATools.Parser.Internal
                     else if (tokenizer.NextChar == '>')
                     {
                         tokenizer.Advance();
-                        clause = UserFunctionDefinitionExpression.ParseAnonymous(tokenizer, clause);
+                        clause = AnonymousUserFunctionDefinitionExpression.ParseAnonymous(tokenizer, clause);
                     }
                     else
                     {
@@ -360,8 +360,8 @@ namespace RATools.Parser.Internal
                     return new ConditionalExpression(null, ConditionalOperation.Not, clause);
 
                 case '(':
-                    if (UserFunctionDefinitionExpression.IsAnonymousParameterList(tokenizer))
-                        return UserFunctionDefinitionExpression.ParseAnonymous(tokenizer);
+                    if (AnonymousUserFunctionDefinitionExpression.IsAnonymousParameterList(tokenizer))
+                        return AnonymousUserFunctionDefinitionExpression.ParseAnonymous(tokenizer);
 
                     tokenizer.Advance();
                     clause = ExpressionBase.Parse(tokenizer);

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -236,8 +236,6 @@ namespace RATools.Parser.Internal
                     {
                         tokenizer.Advance();
                         clause = ParseConditional(tokenizer, clause, ConditionalOperation.And, joinerLine, joinerColumn);
-                        if (clause.Type == ExpressionType.ParseError)
-                            return clause;
                     }
                     break;
 
@@ -251,8 +249,6 @@ namespace RATools.Parser.Internal
                     {
                         tokenizer.Advance();
                         clause = ParseConditional(tokenizer, clause, ConditionalOperation.Or, joinerLine, joinerColumn);
-                        if (clause.Type == ExpressionType.ParseError)
-                            return clause;
                     }
                     break;
 
@@ -262,6 +258,9 @@ namespace RATools.Parser.Internal
 
                     return clause;
             }
+
+            if (clause.Type == ExpressionType.ParseError)
+                return clause;
 
             clause = clause.Rebalance();
 

--- a/Parser/Internal/ForExpression.cs
+++ b/Parser/Internal/ForExpression.cs
@@ -142,4 +142,9 @@ namespace RATools.Parser.Internal
             }
         }
     }
+
+    internal interface IIterableExpression
+    {
+        IEnumerable<ExpressionBase> IterableExpressions();
+    }
 }

--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -214,7 +214,9 @@ namespace RATools.Parser.Internal
                     break;
 
                 case ExpressionType.FunctionDefinition:
-                    // anonymous function, do nothing
+                    var anonymousFunction = value as AnonymousUserFunctionDefinitionExpression;
+                    if (anonymousFunction != null)
+                        anonymousFunction.CaptureVariables(parameterScope);
                     break;
 
                 default:
@@ -275,7 +277,7 @@ namespace RATools.Parser.Internal
         /// <returns>The new scope, <c>null</c> if an error occurred - see <paramref name="error"/> for error details.</returns>
         public InterpreterScope GetParameters(FunctionDefinitionExpression function, InterpreterScope scope, out ExpressionBase error)
         {
-            var parameterScope = new InterpreterScope(scope);
+            var parameterScope = function.CreateCaptureScope(scope);
 
             // optimization for no parameter function
             if (function.Parameters.Count == 0 && Parameters.Count == 0)

--- a/Parser/Internal/FunctionDefinitionExpression.cs
+++ b/Parser/Internal/FunctionDefinitionExpression.cs
@@ -1,6 +1,7 @@
 ﻿using Jamiras.Components;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace RATools.Parser.Internal
@@ -329,43 +330,17 @@ namespace RATools.Parser.Internal
         public InterpreterScope CreateCaptureScope(InterpreterScope scope)
         {
             var captureScope = new InterpreterScope(scope);
+            captureScope.Context = this;
 
             // only have to capture variables for anonymous functions
-            var userFunctionDefinition = this as UserFunctionDefinitionExpression;
-            if (userFunctionDefinition == null || !userFunctionDefinition.IsAnonymousFunction)
-                return captureScope;
-
-            // Initialize the new scope object with a FunctionCall context so we can determine which
-            // variables have to be captured. The FunctionCall context will only see the globals.
-            captureScope.Context = new FunctionCallExpression(Name.Name, new ExpressionBase[0]);
-
-            // if the anonymous function is being passed to another function, it should be able
-            // to see the variables visible to the function it's being passed to. temporarily hide
-            // the FunctionCall context for the function to be called.
-            var passingToFunctionContext = scope.Context as FunctionCallExpression;
-            if (passingToFunctionContext != null)
-                scope.Context = null;
-
-            var possibleDependencies = new HashSet<string>();
-            ((INestedExpressions)this).GetDependencies(possibleDependencies);
-            foreach (var dependency in possibleDependencies)
+            var userFunctionDefinition = this as AnonymousUserFunctionDefinitionExpression;
+            if (userFunctionDefinition != null)
             {
-                if (captureScope.GetVariable(dependency) == null)
-                {
-                    // the variable is not visible to the function scope. check to see if it's visible
-                    // in the calling scope. if it is, create a copy for the function call.
-                    var variable = scope.GetVariableReference(dependency);
-                    if (variable != null)
-                        captureScope.DefineVariable(variable.Variable, variable.Expression);
-                }
+                foreach (var captured in userFunctionDefinition.CapturedVariables)
+                    captureScope.DefineVariable(captured.Variable, captured.Expression);
             }
 
-            // restore the FunctionCall context for the function to be called.
-            if (passingToFunctionContext != null)
-                scope.Context = passingToFunctionContext;
-
-            // change the context to the function definition and return the new context
-            captureScope.Context = this;
+            // set the context to the function definition and return the new context
             return captureScope;
         }
 
@@ -432,7 +407,7 @@ namespace RATools.Parser.Internal
 
     internal class UserFunctionDefinitionExpression : FunctionDefinitionExpression
     {
-        private UserFunctionDefinitionExpression(VariableDefinitionExpression name)
+        protected UserFunctionDefinitionExpression(VariableDefinitionExpression name)
             : base(name)
         {
         }
@@ -470,7 +445,7 @@ namespace RATools.Parser.Internal
             return function.Parse(tokenizer);
         }
 
-        private new ExpressionBase Parse(PositionalTokenizer tokenizer)
+        protected new ExpressionBase Parse(PositionalTokenizer tokenizer)
         {
             ExpressionBase.SkipWhitespace(tokenizer);
             if (tokenizer.NextChar != '(')
@@ -572,7 +547,7 @@ namespace RATools.Parser.Internal
             return this;
         }
 
-        private ExpressionBase ParseShorthandBody(PositionalTokenizer tokenizer)
+        protected ExpressionBase ParseShorthandBody(PositionalTokenizer tokenizer)
         {
             ExpressionBase.SkipWhitespace(tokenizer);
 
@@ -587,6 +562,42 @@ namespace RATools.Parser.Internal
             Expressions.Add(returnExpression);
             Location = new TextRange(Location.Start, expression.Location.End);
             return this;
+        }
+
+
+        /// <summary>
+        /// Replaces the variables in the expression with values from <paramref name="scope"/>.
+        /// </summary>
+        /// <param name="scope">The scope object containing variable values.</param>
+        /// <param name="result">[out] The new expression containing the replaced variables.</param>
+        /// <returns><c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result"/> will likely be a <see cref="ParseErrorExpression"/>.</returns>
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            // user-defined functions should be evaluated (expanded) immediately.
+            if (!Evaluate(scope, out result))
+                return false;
+
+            if (result == null)
+            {
+                var functionCall = scope.GetContext<FunctionCallExpression>();
+                if (functionCall != null)
+                    result = new ParseErrorExpression(Name.Name + " did not return a value", functionCall.FunctionName);
+                else
+                    result = new ParseErrorExpression(Name.Name + " did not return a value");
+
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    internal class AnonymousUserFunctionDefinitionExpression : UserFunctionDefinitionExpression
+    {
+        protected AnonymousUserFunctionDefinitionExpression(VariableDefinitionExpression name)
+            : base(name)
+        {
+            CapturedVariables = Enumerable.Empty<VariableReferenceExpression>();
         }
 
         /// <summary>
@@ -631,21 +642,18 @@ namespace RATools.Parser.Internal
             return new VariableDefinitionExpression(String.Format("AnonymousFunction@{0},{1}", line, column));
         }
 
-        public bool IsAnonymousFunction
+        public static bool IsAnonymousFunctionName(string functionName)
         {
-            get
-            {
-                return Name.Name.StartsWith("AnonymousFunction@");
-            }
+            return functionName.StartsWith("AnonymousFunction@");
         }
 
         /// <summary>
         /// Parses an anonymous function definition in the format "(a) => body" or "(a) { body }"
         /// </summary>
-        internal static ExpressionBase ParseAnonymous(PositionalTokenizer tokenizer)
+        public static ExpressionBase ParseAnonymous(PositionalTokenizer tokenizer)
         {
             var name = CreateAnonymousFunctionName(tokenizer.Line, tokenizer.Column);
-            var function = new UserFunctionDefinitionExpression(name);
+            var function = new AnonymousUserFunctionDefinitionExpression(name);
             function.Location = new TextRange(tokenizer.Line, tokenizer.Column, 0, 0);
             return function.Parse(tokenizer);
         }
@@ -654,43 +662,46 @@ namespace RATools.Parser.Internal
         /// Parses an anonymous function definition in the format "a => body" where <paramref name="parameter"/> 
         /// is "a" and <paramref name="tokenizer"/> is pointing at "body".
         /// </summary>
-        internal static ExpressionBase ParseAnonymous(PositionalTokenizer tokenizer, ExpressionBase parameter)
+        public static ExpressionBase ParseAnonymous(PositionalTokenizer tokenizer, ExpressionBase parameter)
         {
             var variable = parameter as VariableExpression;
             if (variable == null)
                 return new ParseErrorExpression("Cannot create anonymous function from " + parameter.Type);
 
             var name = CreateAnonymousFunctionName(parameter.Location.Start.Line, parameter.Location.Start.Column);
-            var function = new UserFunctionDefinitionExpression(name);
+            var function = new AnonymousUserFunctionDefinitionExpression(name);
             function.Location = parameter.Location;
             function.Parameters.Add(new VariableDefinitionExpression(variable.Name, variable.Location.Start.Line, variable.Location.Start.Column));
             return function.ParseShorthandBody(tokenizer);
         }
 
-        /// <summary>
-        /// Replaces the variables in the expression with values from <paramref name="scope"/>.
-        /// </summary>
-        /// <param name="scope">The scope object containing variable values.</param>
-        /// <param name="result">[out] The new expression containing the replaced variables.</param>
-        /// <returns><c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result"/> will likely be a <see cref="ParseErrorExpression"/>.</returns>
-        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        public IEnumerable<VariableReferenceExpression> CapturedVariables { get; private set; }
+
+        public void CaptureVariables(InterpreterScope scope)
         {
-            // user-defined functions should be evaluated (expanded) immediately.
-            if (!Evaluate(scope, out result))
-                return false;
+            // Initialize a new scope object with a FunctionCall context so we can determine which
+            // variables have to be captured. The FunctionCall context will only see the globals.
+            var captureScope = new InterpreterScope(scope);
+            captureScope.Context = new FunctionCallExpression("NonAnonymousFunction", new ExpressionBase[0]);
 
-            if (result == null)
+            var capturedVariables = new List<VariableReferenceExpression>();
+
+            var possibleDependencies = new HashSet<string>();
+            ((INestedExpressions)this).GetDependencies(possibleDependencies);
+            foreach (var dependency in possibleDependencies)
             {
-                var functionCall = scope.GetContext<FunctionCallExpression>();
-                if (functionCall != null)
-                    result = new ParseErrorExpression(Name.Name + " did not return a value", functionCall.FunctionName);
-                else
-                    result = new ParseErrorExpression(Name.Name + " did not return a value");
-
-                return false;
+                if (captureScope.GetVariable(dependency) == null)
+                {
+                    // the variable is not visible to the function scope. check to see if it's visible
+                    // in the calling scope. if it is, create a copy for the function call.
+                    var variable = scope.GetVariableReference(dependency);
+                    if (variable != null)
+                        capturedVariables.Add(variable);
+                }
             }
 
-            return true;
+            if (capturedVariables.Count > 0)
+                CapturedVariables = capturedVariables.ToArray();
         }
     }
 

--- a/Parser/Internal/InterpreterScope.cs
+++ b/Parser/Internal/InterpreterScope.cs
@@ -61,6 +61,14 @@ namespace RATools.Parser.Internal
         }
 
         /// <summary>
+        /// Determines if the specified function is provided by this InterpreterScope object.
+        /// </summary>
+        public bool ProvidesFunction(string functionName)
+        {
+            return (_functions != null && _functions.ContainsKey(functionName));
+        }
+
+        /// <summary>
         /// Gets the function definition for a function.
         /// </summary>
         /// <param name="functionName">Name of the function.</param>

--- a/Parser/Internal/MathematicExpression.cs
+++ b/Parser/Internal/MathematicExpression.cs
@@ -155,6 +155,16 @@ namespace RATools.Parser.Internal
             return MergeOperands(left, right, out result);
         }
 
+        /// <summary>
+        /// Attempts to merge the operands without evaluating them.
+        /// </summary>
+        internal ExpressionBase MergeOperands()
+        {
+            ExpressionBase result;
+            MergeOperands(Left, Right, out result);
+            return result;
+        }
+
         private bool MergeOperands(ExpressionBase left, ExpressionBase right, out ExpressionBase result)
         { 
             var integerLeft = left as IntegerConstantExpression;

--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -897,7 +897,7 @@ namespace RATools.Parser
                 return context.CallFunction(functionCall, scope);
             }
 
-            return ExecuteAchievementClause(evaluated, scope);
+            return ExecuteAchievementExpression(evaluated, scope);
         }
     }
 }

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Data\Requirement.cs" />
     <Compile Include="Data\RequirementEx.cs" />
     <Compile Include="Parser\AchievementScriptContext.cs" />
+    <Compile Include="Parser\Functions\AnyOfFunction.cs" />
     <Compile Include="Parser\Functions\LengthFunction.cs" />
     <Compile Include="Parser\Functions\ArrayPopFunction.cs" />
     <Compile Include="Parser\Functions\ArrayPushFunction.cs" />
@@ -75,6 +76,7 @@
     <Compile Include="Parser\Functions\FlagConditionFunction.cs" />
     <Compile Include="Parser\Functions\AlwaysTrueFunction.cs" />
     <Compile Include="Parser\Functions\RangeFunction.cs" />
+    <Compile Include="Parser\Functions\IterableJoiningFunction.cs" />
     <Compile Include="Parser\Functions\TallyFunction.cs" />
     <Compile Include="Parser\Functions\RichPresenceConditionalDisplayFunction.cs" />
     <Compile Include="Parser\Functions\FormatFunction.cs" />

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Data\Requirement.cs" />
     <Compile Include="Data\RequirementEx.cs" />
     <Compile Include="Parser\AchievementScriptContext.cs" />
+    <Compile Include="Parser\Functions\NoneOfFunction.cs" />
     <Compile Include="Parser\Functions\AllOfFunction.cs" />
     <Compile Include="Parser\Functions\AnyOfFunction.cs" />
     <Compile Include="Parser\Functions\LengthFunction.cs" />

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Data\Requirement.cs" />
     <Compile Include="Data\RequirementEx.cs" />
     <Compile Include="Parser\AchievementScriptContext.cs" />
+    <Compile Include="Parser\Functions\SumOfFunction.cs" />
     <Compile Include="Parser\Functions\NoneOfFunction.cs" />
     <Compile Include="Parser\Functions\AllOfFunction.cs" />
     <Compile Include="Parser\Functions\AnyOfFunction.cs" />

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Data\Requirement.cs" />
     <Compile Include="Data\RequirementEx.cs" />
     <Compile Include="Parser\AchievementScriptContext.cs" />
+    <Compile Include="Parser\Functions\AllOfFunction.cs" />
     <Compile Include="Parser\Functions\AnyOfFunction.cs" />
     <Compile Include="Parser\Functions\LengthFunction.cs" />
     <Compile Include="Parser\Functions\ArrayPopFunction.cs" />

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -1076,6 +1076,7 @@ namespace RATools.Test.Parser
         [TestCase("b = (i, j) => i + j\nc = b(3, 1)")] // anonymous multiple parameter function definition
         [TestCase("b = i => i + 1\nc = b(3)")] // anonymous function definition without parenthesis
         [TestCase("a = i => i + 1\nb = (f,i) => f(i)\nc = b(a, 3)")] // anonymous function passed as parameter
+        [TestCase("a = f => f(1)\nb = n => a(i => i + n)\nc = b(3)")] // anonymous function captures variable
         [TestCase("b = (f,i) => f(i)\nc = b(i => i + 1, 3)")] // anonymous function defined as parameter
         public void TestAnonymousFunction(string definition)
         {

--- a/Tests/Parser/Functions/AllOfFunctionTests.cs
+++ b/Tests/Parser/Functions/AllOfFunctionTests.cs
@@ -32,7 +32,7 @@ namespace RATools.Test.Parser.Functions
                 return builder.RequirementsDebugString;
             }
 
-            return parser.ErrorMessage;
+            return parser.Error.InnermostError.Message;
         }
 
         [Test]

--- a/Tests/Parser/Functions/AllOfFunctionTests.cs
+++ b/Tests/Parser/Functions/AllOfFunctionTests.cs
@@ -1,19 +1,23 @@
 ﻿using Jamiras.Components;
 using NUnit.Framework;
+using RATools.Data;
 using RATools.Parser;
 using RATools.Parser.Functions;
+using RATools.Parser.Internal;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace RATools.Test.Parser.Functions
 {
     [TestFixture]
-    class AnyOfFunctionTests
+    class AllOfFunctionTests
     {
         [Test]
         public void TestDefinition()
         {
-            var def = new AnyOfFunction();
-            Assert.That(def.Name.Name, Is.EqualTo("any_of"));
+            var def = new AllOfFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("all_of"));
             Assert.That(def.Parameters.Count, Is.EqualTo(2));
             Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("inputs"));
             Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("predicate"));
@@ -38,44 +42,44 @@ namespace RATools.Test.Parser.Functions
         [Test]
         public void TestSimple()
         {
-            Assert.That(Evaluate("any_of([1, 2, 3], a => byte(0x1234) == a)"),
-                Is.EqualTo("byte(0x001234) == 1 || byte(0x001234) == 2 || byte(0x001234) == 3"));
+            Assert.That(Evaluate("all_of([1, 2, 3], a => byte(0x1234) != a)"),
+                Is.EqualTo("byte(0x001234) != 1 && byte(0x001234) != 2 && byte(0x001234) != 3"));
         }
 
         [Test]
         public void TestSingleElement()
         {
-            Assert.That(Evaluate("any_of([1], a => byte(0x1234) == a)"),
-                Is.EqualTo("byte(0x001234) == 1"));
+            Assert.That(Evaluate("all_of([1], a => byte(0x1234) != a)"),
+                Is.EqualTo("byte(0x001234) != 1"));
         }
 
         [Test]
         public void TestNoElements()
         {
-            Assert.That(Evaluate("any_of([], a => byte(0x1234) == a)"),
-                Is.EqualTo("always_false()"));
+            Assert.That(Evaluate("all_of([], a => byte(0x1234) != a)"),
+                Is.EqualTo("always_true()"));
         }
 
         [Test]
         public void TestLogic()
         {
-            // always_false() elements returned by predicate will be optimized out by the AchievementScriptInterpreter
-            Assert.That(Evaluate("any_of([1, 2, 3], (a) { if (a % 2 == 0) { return byte(0x1234) == a } else { return always_false() }})"),
-                Is.EqualTo("byte(0x001234) == 2"));
+            // always_true() elements returned by predicate will be optimized out by the AchievementScriptInterpreter
+            Assert.That(Evaluate("all_of([1, 2, 3], (a) { if (a % 2 == 0) { return byte(0x1234) != a } else { return always_true() }})"),
+                Is.EqualTo("byte(0x001234) != 2"));
         }
 
         [Test]
         public void TestRange()
         {
-            Assert.That(Evaluate("any_of(range(1,5,2), a => byte(0x1234) == a)"),
-                Is.EqualTo("byte(0x001234) == 1 || byte(0x001234) == 3 || byte(0x001234) == 5"));
+            Assert.That(Evaluate("all_of(range(1,5,2), a => byte(0x1234) != a)"),
+                Is.EqualTo("byte(0x001234) != 1 && byte(0x001234) != 3 && byte(0x001234) != 5"));
         }
 
         [Test]
         public void TestDictionary()
         {
-            Assert.That(Evaluate("any_of({1:\"One\",2:\"Two\",3:\"Three\"}, a => byte(0x1234) == a)"),
-                Is.EqualTo("byte(0x001234) == 1 || byte(0x001234) == 2 || byte(0x001234) == 3"));
+            Assert.That(Evaluate("all_of({1:\"One\",2:\"Two\",3:\"Three\"}, a => byte(0x1234) != a)"),
+                Is.EqualTo("byte(0x001234) != 1 && byte(0x001234) != 2 && byte(0x001234) != 3"));
         }
     }
 }

--- a/Tests/Parser/Functions/AnyOfFunctionTests.cs
+++ b/Tests/Parser/Functions/AnyOfFunctionTests.cs
@@ -1,0 +1,85 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Data;
+using RATools.Parser;
+using RATools.Parser.Functions;
+using RATools.Parser.Internal;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RATools.Test.Parser.Functions
+{
+    [TestFixture]
+    class AnyOfFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new AnyOfFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("any_of"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(2));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("inputs"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("predicate"));
+        }
+
+        private static string Evaluate(string input)
+        {
+            var script = "achievement(\"title\", \"desc\", 5,\n" + input + "\n)";
+            var tokenizer = Tokenizer.CreateTokenizer(script);
+            var parser = new AchievementScriptInterpreter();
+
+            if (parser.Run(tokenizer))
+            {
+                var achievement = parser.Achievements.First();
+                var builder = new AchievementBuilder(achievement);
+                return builder.RequirementsDebugString;
+            }
+
+            return parser.ErrorMessage;
+        }
+
+        [Test]
+        public void TestSimple()
+        {
+            Assert.That(Evaluate("any_of([1, 2, 3], a => byte(0x1234) == a)"),
+                Is.EqualTo("byte(0x001234) == 1 || byte(0x001234) == 2 || byte(0x001234) == 3"));
+        }
+
+        [Test]
+        public void TestSingleElement()
+        {
+            Assert.That(Evaluate("any_of([1], a => byte(0x1234) == a)"),
+                Is.EqualTo("byte(0x001234) == 1"));
+        }
+
+        [Test]
+        public void TestNoElements()
+        {
+            Assert.That(Evaluate("any_of([], a => byte(0x1234) == a)"),
+                Is.EqualTo("always_false()"));
+        }
+
+        [Test]
+        public void TestLogic()
+        {
+            // always_false() elements returned by predicate will be optimized out by the AchievementScriptInterpreter
+            Assert.That(Evaluate("any_of([1, 2, 3], (a) { if (a % 2 == 0) { return byte(0x1234) == a } else { return always_false() }})"),
+                Is.EqualTo("byte(0x001234) == 2"));
+        }
+
+        [Test]
+        public void TestRange()
+        {
+            Assert.That(Evaluate("any_of(range(1,5,2), a => byte(0x1234) == a)"),
+                Is.EqualTo("byte(0x001234) == 1 || byte(0x001234) == 3 || byte(0x001234) == 5"));
+        }
+
+        [Test]
+        public void TestDictionary()
+        {
+            Assert.That(Evaluate("any_of({1:\"One\",2:\"Two\",3:\"Three\"}, a => byte(0x1234) == a)"),
+                Is.EqualTo("byte(0x001234) == 1 || byte(0x001234) == 2 || byte(0x001234) == 3"));
+        }
+    }
+}

--- a/Tests/Parser/Functions/AnyOfFunctionTests.cs
+++ b/Tests/Parser/Functions/AnyOfFunctionTests.cs
@@ -32,7 +32,7 @@ namespace RATools.Test.Parser.Functions
                 return builder.RequirementsDebugString;
             }
 
-            return parser.ErrorMessage;
+            return parser.Error.InnermostError.Message;
         }
 
         [Test]
@@ -47,6 +47,13 @@ namespace RATools.Test.Parser.Functions
         {
             Assert.That(Evaluate("any_of([1], a => byte(0x1234) == a)"),
                 Is.EqualTo("byte(0x001234) == 1"));
+        }
+
+        [Test]
+        public void TestNonIterable()
+        {
+            Assert.That(Evaluate("any_of(1, a => byte(0x1234) == a)"),
+                Is.EqualTo("Cannot iterate over IntegerConstant: 1"));
         }
 
         [Test]
@@ -110,6 +117,20 @@ namespace RATools.Test.Parser.Functions
             var builder = new AchievementBuilder(achievement);
             Assert.That(builder.RequirementsDebugString, Is.EqualTo(
                 "byte(0x000001) == 17 || byte(0x000002) == 17 || byte(0x000003) == 17"));
+        }
+
+        [Test]
+        public void TestPredicateWithNoParameters()
+        {
+            Assert.That(Evaluate("any_of([1], () => byte(0x1234) == 1)"),
+                Is.EqualTo("predicate function must accept a single parameter"));
+        }
+
+        [Test]
+        public void TestPredicateWithExtraParameters()
+        {
+            Assert.That(Evaluate("any_of([1], (a, b) => byte(0x1234) == a)"),
+                Is.EqualTo("predicate function must accept a single parameter"));
         }
     }
 }

--- a/Tests/Parser/Functions/NoneOfFunctionTests.cs
+++ b/Tests/Parser/Functions/NoneOfFunctionTests.cs
@@ -32,7 +32,7 @@ namespace RATools.Test.Parser.Functions
                 return builder.RequirementsDebugString;
             }
 
-            return parser.ErrorMessage;
+            return parser.Error.InnermostError.Message;
         }
 
         [Test]

--- a/Tests/Parser/Functions/NoneOfFunctionTests.cs
+++ b/Tests/Parser/Functions/NoneOfFunctionTests.cs
@@ -7,13 +7,13 @@ using System.Linq;
 namespace RATools.Test.Parser.Functions
 {
     [TestFixture]
-    class AllOfFunctionTests
+    class NoneOfFunctionTests
     {
         [Test]
         public void TestDefinition()
         {
-            var def = new AllOfFunction();
-            Assert.That(def.Name.Name, Is.EqualTo("all_of"));
+            var def = new NoneOfFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("none_of"));
             Assert.That(def.Parameters.Count, Is.EqualTo(2));
             Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("inputs"));
             Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("predicate"));
@@ -38,43 +38,43 @@ namespace RATools.Test.Parser.Functions
         [Test]
         public void TestSimple()
         {
-            Assert.That(Evaluate("all_of([1, 2, 3], a => byte(0x1234) != a)"),
+            Assert.That(Evaluate("none_of([1, 2, 3], a => byte(0x1234) == a)"),
                 Is.EqualTo("byte(0x001234) != 1 && byte(0x001234) != 2 && byte(0x001234) != 3"));
         }
 
         [Test]
         public void TestSingleElement()
         {
-            Assert.That(Evaluate("all_of([1], a => byte(0x1234) != a)"),
+            Assert.That(Evaluate("none_of([1], a => byte(0x1234) == a)"),
                 Is.EqualTo("byte(0x001234) != 1"));
         }
 
         [Test]
         public void TestNoElements()
         {
-            Assert.That(Evaluate("all_of([], a => byte(0x1234) != a)"),
+            Assert.That(Evaluate("none_of([], a => byte(0x1234) == a)"),
                 Is.EqualTo("always_true()"));
         }
 
         [Test]
         public void TestLogic()
         {
-            // always_true() elements returned by predicate will be optimized out by the AchievementScriptInterpreter
-            Assert.That(Evaluate("all_of([1, 2, 3], (a) { if (a % 2 == 0) { return byte(0x1234) != a } else { return always_true() }})"),
+            // always_false() elements returned by predicate will be optimized out by the AchievementScriptInterpreter
+            Assert.That(Evaluate("none_of([1, 2, 3], (a) { if (a % 2 == 0) { return byte(0x1234) == a } else { return always_false() }})"),
                 Is.EqualTo("byte(0x001234) != 2"));
         }
 
         [Test]
         public void TestRange()
         {
-            Assert.That(Evaluate("all_of(range(1,5,2), a => byte(0x1234) != a)"),
+            Assert.That(Evaluate("none_of(range(1,5,2), a => byte(0x1234) == a)"),
                 Is.EqualTo("byte(0x001234) != 1 && byte(0x001234) != 3 && byte(0x001234) != 5"));
         }
 
         [Test]
         public void TestDictionary()
         {
-            Assert.That(Evaluate("all_of({1:\"One\",2:\"Two\",3:\"Three\"}, a => byte(0x1234) != a)"),
+            Assert.That(Evaluate("none_of({1:\"One\",2:\"Two\",3:\"Three\"}, a => byte(0x1234) == a)"),
                 Is.EqualTo("byte(0x001234) != 1 && byte(0x001234) != 2 && byte(0x001234) != 3"));
         }
     }

--- a/Tests/Parser/Functions/SumOfFunctionTests.cs
+++ b/Tests/Parser/Functions/SumOfFunctionTests.cs
@@ -32,7 +32,7 @@ namespace RATools.Test.Parser.Functions
                 return builder.RequirementsDebugString;
             }
 
-            return parser.ErrorMessage;
+            return parser.Error.InnermostError.Message;
         }
 
         [Test]

--- a/Tests/Parser/Functions/SumOfFunctionTests.cs
+++ b/Tests/Parser/Functions/SumOfFunctionTests.cs
@@ -1,0 +1,81 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Parser;
+using RATools.Parser.Functions;
+using System.Linq;
+
+namespace RATools.Test.Parser.Functions
+{
+    [TestFixture]
+    class SumOfFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new SumOfFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("sum_of"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(2));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("inputs"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("predicate"));
+        }
+
+        private static string Evaluate(string input)
+        {
+            var script = "achievement(\"title\", \"desc\", 5,\n" + input + "\n)";
+            var tokenizer = Tokenizer.CreateTokenizer(script);
+            var parser = new AchievementScriptInterpreter();
+
+            if (parser.Run(tokenizer))
+            {
+                var achievement = parser.Achievements.First();
+                var builder = new AchievementBuilder(achievement);
+                return builder.RequirementsDebugString;
+            }
+
+            return parser.ErrorMessage;
+        }
+
+        [Test]
+        public void TestSimple()
+        {
+            Assert.That(Evaluate("sum_of([1, 2, 3], a => byte(a)) == 9"),
+                Is.EqualTo("(byte(0x000001) + byte(0x000002) + byte(0x000003)) == 9"));
+        }
+
+        [Test]
+        public void TestSingleElement()
+        {
+            Assert.That(Evaluate("sum_of([1], a => byte(a)) == 9"),
+                Is.EqualTo("byte(0x000001) == 9"));
+        }
+
+        [Test]
+        public void TestNoElements()
+        {
+            Assert.That(Evaluate("sum_of([], a => byte(a)) == byte(9)"),
+                Is.EqualTo("byte(0x000009) == 0"));
+        }
+
+        [Test]
+        public void TestLogic()
+        {
+            // always_false() elements returned by predicate will be optimized out by the AchievementScriptInterpreter
+            Assert.That(Evaluate("sum_of([1, 2, 3], (a) { if (a % 2 == 0) { return byte(a) } else { return 0 }}) == 9"),
+                Is.EqualTo("byte(0x000002) == 9"));
+        }
+
+        [Test]
+        public void TestRange()
+        {
+            Assert.That(Evaluate("sum_of(range(1,5,2), a => byte(a)) == 9"),
+                Is.EqualTo("(byte(0x000001) + byte(0x000003) + byte(0x000005)) == 9"));
+        }
+
+        [Test]
+        public void TestDictionary()
+        {
+            Assert.That(Evaluate("sum_of({1:\"One\",2:\"Two\",3:\"Three\"}, a => byte(a)) == 9"),
+                Is.EqualTo("(byte(0x000001) + byte(0x000002) + byte(0x000003)) == 9"));
+        }
+    }
+}

--- a/Tests/Parser/Internal/ComparisonExpressionTests.cs
+++ b/Tests/Parser/Internal/ComparisonExpressionTests.cs
@@ -72,6 +72,8 @@ namespace RATools.Test.Parser.Internal
         [TestCase("byte(1) - 3 == prev(byte(1))", "byte(1) - 3 == prev(byte(1))")] // value increases by 3
         [TestCase("byte(1) == prev(byte(1)) + 3", "byte(1) - 3 == prev(byte(1))")] // value increases by 3
         [TestCase("byte(1) - prev(byte(1)) == 3", "byte(1) - prev(byte(1)) == 3")] // value increases by 3
+        [TestCase("0 + byte(1) + 0 == 9", "byte(1) == 9")] // 0s should be removed without reordering
+        [TestCase("0 + byte(1) - 9 == 0", "byte(1) == 9")] // 9 should be moved to right hand side, then 0s removed
         public void TestReplaceVariables(string input, string expected)
         {
             var tokenizer = Tokenizer.CreateTokenizer(input);

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -112,6 +112,7 @@
   <ItemGroup>
     <Compile Include="Data\RequirementTests.cs" />
     <Compile Include="Data\FieldTests.cs" />
+    <Compile Include="Parser\Functions\NoneOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\AllOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\LeaderboardFunctionTests.cs" />
     <Compile Include="Parser\Functions\DisableWhenFunctionTests.cs" />

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Data\FieldTests.cs" />
     <Compile Include="Parser\Functions\LeaderboardFunctionTests.cs" />
     <Compile Include="Parser\Functions\DisableWhenFunctionTests.cs" />
+    <Compile Include="Parser\Functions\AnyOfFunctionTests.cs" />
     <Compile Include="Parser\RichPresenceBuilderTests.cs" />
     <Compile Include="Parser\TriggerBuilderContextTests.cs" />
     <Compile Include="Parser\AchievementBuilderTests.cs" />

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -112,6 +112,7 @@
   <ItemGroup>
     <Compile Include="Data\RequirementTests.cs" />
     <Compile Include="Data\FieldTests.cs" />
+    <Compile Include="Parser\Functions\AllOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\LeaderboardFunctionTests.cs" />
     <Compile Include="Parser\Functions\DisableWhenFunctionTests.cs" />
     <Compile Include="Parser\Functions\AnyOfFunctionTests.cs" />

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -112,6 +112,7 @@
   <ItemGroup>
     <Compile Include="Data\RequirementTests.cs" />
     <Compile Include="Data\FieldTests.cs" />
+    <Compile Include="Parser\Functions\SumOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\NoneOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\AllOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\LeaderboardFunctionTests.cs" />


### PR DESCRIPTION
Adds `any_of`, `all_of`, `none_of` and `sum_of` functions.

Each takes a list of inputs (either an array or a dictionary) and a predicate function. Each item in the array, or each key of the dictionary will be passed to the predicate function. The return values from the predicate function will be joined based on which helper function was called.

Because `range` generates an array, it can be used for the inputs.

-----

`any_of` generates a set of conditions that will be true if any individual condition is true
* `any_of([1,2,3], a => byte(0x1234) == a)` -> `byte(0x1234) == 1 || byte(0x1234) == 2 || byte(0x1234) == 3`

`all_of` generates a set of conditions that will be true only if all the conditions are true
* `all_of([1,2,3], a => byte(0x1234) != a)` -> `byte(0x1234) != 1 && byte(0x1234) != 2 && byte(0x1234) != 3`

`none_of` generates a set of conditions that will be true only if all conditions are false
* `none_of([1,2,3], a => byte(0x1234) == a)` -> `byte(0x1234) != 1 && byte(0x1234) != 2 && byte(0x1234) != 3`

`sum_of` generates a mathematic expression that adds the conditions together
* `sum_of([1,2,3], a => byte(a)) == 9` -> `byte(0x000001) + byte(0x000002) + byte(0x000003) == 9`

-----

These helper functions are meant to replace repetitive code that build chains using a for loop.
```
function ItemInInventory(id)
{
    result = always_false()
    for addr in range(0x1200, 0x1220, step=2)
        result = result || word(addr) == id
        
    return result
}
```
becomes
```
function ItemInInventory(id) => any_of(range(0x1200, 0x1220, step=2), addr => word(addr) == id)
```