### PR TITLE
remember badge through delete/update cycle

### DIFF
--- a/ViewModels/GameViewModel.cs
+++ b/ViewModels/GameViewModel.cs
@@ -252,8 +252,25 @@ namespace RATools.ViewModels
                 }
             }
 
-            _localAchievements.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, validateAll ? null : achievement);
+            if (_localAchievementCommitSuspendCount == 0)
+                _localAchievements.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, validateAll ? null : achievement);
         }
+
+        private int _localAchievementCommitSuspendCount = 0;
+        internal void SuspendCommitLocalAchievements()
+        {
+            ++_localAchievementCommitSuspendCount;
+        }
+
+        internal void ResumeCommitLocalAchievements()
+        {
+            if (_localAchievementCommitSuspendCount > 0 && --_localAchievementCommitSuspendCount == 0)
+            {
+                var warning = new StringBuilder();
+                _localAchievements.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, null);
+            }
+        }
+
 
         public static readonly ModelProperty TitleProperty = ModelProperty.Register(typeof(MainWindowViewModel), "Title", typeof(string), String.Empty);
         public string Title

--- a/ViewModels/GameViewModel.cs
+++ b/ViewModels/GameViewModel.cs
@@ -170,8 +170,8 @@ namespace RATools.ViewModels
 
             foreach (var achievement in editors.OfType<GeneratedAchievementViewModel>())
             {
-                if (achievement.Local != null && achievement.Local.Id == 0)
-                    achievement.Local.Id = nextLocalId++;
+                if (achievement.Local != null && achievement.Local.Achievement.Id == 0)
+                    achievement.Local.Achievement.Id = nextLocalId++;
 
                 achievement.UpdateCommonProperties(this);
             }

--- a/ViewModels/GeneratedAchievementViewModel.cs
+++ b/ViewModels/GeneratedAchievementViewModel.cs
@@ -52,6 +52,8 @@ namespace RATools.ViewModels
             get { return (ImageSource)GetValue(BadgeProperty); }
         }
 
+        private string BadgeName { get; set; }
+
         private static ImageSource GetBadge(ModelBase model)
         {
             var vm = (GeneratedAchievementViewModel)model;
@@ -61,6 +63,13 @@ namespace RATools.ViewModels
                 return vm.Unofficial.Badge;
             if (!String.IsNullOrEmpty(vm.Local.BadgeName))
                 return vm.Local.Badge;
+
+            if (!String.IsNullOrEmpty(vm.BadgeName))
+            {
+                vm.Local.BadgeName = vm.BadgeName;
+                return vm.Local.Badge;
+            }
+
             return null;
         }
 
@@ -119,6 +128,13 @@ namespace RATools.ViewModels
                 Id = Unofficial.Id;
             else if (Local.Achievement != null)
                 Id = Local.Id;
+
+            if (!String.IsNullOrEmpty(Local.BadgeName) && Local.BadgeName != "0")
+                BadgeName = Local.BadgeName;
+            else if (!String.IsNullOrEmpty(Core.BadgeName) && Core.BadgeName != "0")
+                BadgeName = Core.BadgeName;
+            else if (!String.IsNullOrEmpty(Unofficial.BadgeName) && Unofficial.BadgeName != "0")
+                BadgeName = Unofficial.BadgeName;
 
             UpdateModified();
         }
@@ -372,28 +388,10 @@ namespace RATools.ViewModels
             var achievement = Generated.Achievement;
 
             if (achievement.Id == 0)
-            {
-                // script doesn't provide an ID. see if one is available
-                if (Core.Id > 0)
-                    Id = achievement.Id = Core.Id;
-                else if (Unofficial.Id > 0)
-                    Id = achievement.Id = Unofficial.Id;
-                else if (Local.Id > 0)
-                    Id = achievement.Id = Local.Id;
-                else if (Id > 0)
-                    achievement.Id = Id;
-            }
+                achievement.Id = Id;
 
             if (String.IsNullOrEmpty(achievement.BadgeName) || achievement.BadgeName == "0")
-            {
-                // script doesn't provide a badge. see if one is available.
-                if (!String.IsNullOrEmpty(Local.BadgeName) && Local.BadgeName != "0")
-                    achievement.BadgeName = Local.BadgeName;
-                else if (!String.IsNullOrEmpty(Core.BadgeName) && Core.BadgeName != "0")
-                    achievement.BadgeName = Core.BadgeName;
-                else if (!String.IsNullOrEmpty(Unofficial.BadgeName) && Unofficial.BadgeName != "0")
-                    achievement.BadgeName = Unofficial.BadgeName;
-            }
+                achievement.BadgeName = BadgeName;
 
             _owner.UpdateLocal(achievement, Local.Achievement, warning, validateAll);
 

--- a/ViewModels/GeneratedAchievementViewModel.cs
+++ b/ViewModels/GeneratedAchievementViewModel.cs
@@ -98,7 +98,6 @@ namespace RATools.ViewModels
 
             if (Generated.Achievement != null)
             {
-                Id = Generated.Id;
                 SetBinding(TitleProperty, new ModelBinding(Generated.Title, TextFieldViewModel.TextProperty, ModelBindingMode.OneWay));
                 SetBinding(DescriptionProperty, new ModelBinding(Generated.Description, TextFieldViewModel.TextProperty, ModelBindingMode.OneWay));
                 SetBinding(PointsProperty, new ModelBinding(Generated.Points, IntegerFieldViewModel.ValueProperty, ModelBindingMode.OneWay));
@@ -122,14 +121,18 @@ namespace RATools.ViewModels
                 Points = Local.Points.Value.GetValueOrDefault();
             }
 
-            if (Core.Achievement != null)
-                Id = Core.Id;
-            else if (Unofficial.Achievement != null)
-                Id = Unofficial.Id;
-            else if (Local.Achievement != null)
+            if (Generated.Id != 0)
+                Id = Generated.Id;
+            else if (Local.Id != 0)
                 Id = Local.Id;
+            else if (Core.Id != 0)
+                Id = Core.Id;
+            else
+                Id = Unofficial.Id;
 
-            if (!String.IsNullOrEmpty(Local.BadgeName) && Local.BadgeName != "0")
+            if (!String.IsNullOrEmpty(Generated.BadgeName) && Generated.BadgeName != "0")
+                BadgeName = Generated.BadgeName;
+            else if (!String.IsNullOrEmpty(Local.BadgeName) && Local.BadgeName != "0")
                 BadgeName = Local.BadgeName;
             else if (!String.IsNullOrEmpty(Core.BadgeName) && Core.BadgeName != "0")
                 BadgeName = Core.BadgeName;

--- a/ViewModels/GeneratedAchievementViewModel.cs
+++ b/ViewModels/GeneratedAchievementViewModel.cs
@@ -138,6 +138,8 @@ namespace RATools.ViewModels
                 BadgeName = Core.BadgeName;
             else if (!String.IsNullOrEmpty(Unofficial.BadgeName) && Unofficial.BadgeName != "0")
                 BadgeName = Unofficial.BadgeName;
+            else
+                BadgeName = "00000";
 
             UpdateModified();
         }

--- a/ViewModels/UpdateLocalViewModel.cs
+++ b/ViewModels/UpdateLocalViewModel.cs
@@ -40,6 +40,8 @@ namespace RATools.ViewModels
         {
             var warning = new StringBuilder();
 
+            _game.SuspendCommitLocalAchievements();
+
             foreach (var achievement in _achievements)
             {
                 if (achievement.IsUpdated)
@@ -52,6 +54,8 @@ namespace RATools.ViewModels
                     achievement.Achievement.DeleteLocalCommand.Execute();
                 }
             }
+
+            _game.ResumeCommitLocalAchievements();
 
             if (warning.Length > 0)
                 TaskDialogViewModel.ShowWarningMessage("Your achievements may not function as expected.", warning.ToString());


### PR DESCRIPTION
fixes an issue where badges added to local achievements via the editor disappear when doing a delete/update cycle from the update local dialog