### PR TITLE
update source line when generating group moves but doesn't change

### DIFF
--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -284,15 +284,9 @@ namespace RATools.Parser
 
         internal bool Run(ExpressionGroupCollection expressionGroups, IScriptInterpreterCallback callback)
         {
-            if (expressionGroups.Scope == null)
-            {
-                var scriptScope = new InterpreterScope(GetGlobalScope()) { Context = this };
-                expressionGroups.Scope = new InterpreterScope(scriptScope);
-            }
-
             var scriptContext = new AchievementScriptContext();
-
-            expressionGroups.Scope.Context = scriptContext;
+            var scriptScope = new InterpreterScope(expressionGroups.Scope ?? GetGlobalScope()) { Context = this };
+            expressionGroups.Scope = new InterpreterScope(scriptScope) { Context = scriptContext };
             expressionGroups.ResetErrors();
 
             bool result = true;

--- a/Parser/Internal/ExpressionGroup.cs
+++ b/Parser/Internal/ExpressionGroup.cs
@@ -331,30 +331,6 @@ namespace RATools.Parser.Internal
             }
         }
 
-        public void AdjustLines(int amount)
-        {
-            FirstLine += amount;
-            LastLine += amount;
-
-            foreach (var expression in Expressions)
-                AdjustLines(expression, amount);
-
-            foreach (var expression in ParseErrors)
-                AdjustLines(expression, amount);
-        }
-
-        private static void AdjustLines(ExpressionBase expression, int amount)
-        {
-            expression.AdjustLines(amount);
-
-            var nested = expression as INestedExpressions;
-            if (nested != null)
-            {
-                foreach (var nestedExpression in nested.NestedExpressions)
-                    AdjustLines(nestedExpression, amount);
-            }
-        }
-
         public override string ToString()
         {
             if (IsEmpty)

--- a/Parser/Internal/ExpressionGroupCollection.cs
+++ b/Parser/Internal/ExpressionGroupCollection.cs
@@ -124,8 +124,24 @@ namespace RATools.Parser.Internal
                         break;
                     }
 
+                    int achievementOffset = (existingGroup.GeneratedAchievements != null) ?
+                        existingGroup.GeneratedAchievements.First().SourceLine - existingGroup.FirstLine : 0;
+                    int leaderboardOffset = (existingGroup.GeneratedLeaderboards != null) ?
+                        existingGroup.GeneratedLeaderboards.First().SourceLine - existingGroup.FirstLine : 0;
+
                     existingGroup.ReplaceExpressions(newGroup, false);
                     Scope.UpdateVariables(existingGroup.Modifies, newGroup);
+
+                    if (existingGroup.GeneratedAchievements != null)
+                    {
+                        foreach (var achievement in existingGroup.GeneratedAchievements)
+                            achievement.SourceLine = existingGroup.FirstLine + achievementOffset;
+                    }
+                    if (existingGroup.GeneratedLeaderboards != null)
+                    {
+                        foreach (var leaderboard in existingGroup.GeneratedLeaderboards)
+                            leaderboard.SourceLine = existingGroup.FirstLine + leaderboardOffset;
+                    }
 
                     if (newGroupStop == 0)
                     {

--- a/Tests/Parser/Internal/ExpressionGroupTests.cs
+++ b/Tests/Parser/Internal/ExpressionGroupTests.cs
@@ -142,33 +142,6 @@ namespace RATools.Test.Parser.Internal
         }
 
         [Test]
-        public void TestAdjustLines()
-        {
-            var group = Parse("a = 3").Groups.First(); // Parse will call UpdateMetadata
-            Assert.That(group.FirstLine, Is.EqualTo(1));
-            Assert.That(group.LastLine, Is.EqualTo(1));
-            var assignment = group.Expressions.First() as AssignmentExpression;
-            Assert.That(assignment, Is.Not.Null);
-            Assert.That(assignment.Location.Start.Line, Is.EqualTo(1));
-            Assert.That(assignment.Variable.Location.Start.Line, Is.EqualTo(1));
-            Assert.That(assignment.Value.Location.Start.Line, Is.EqualTo(1));
-
-            group.AdjustLines(6);
-            Assert.That(group.FirstLine, Is.EqualTo(7));
-            Assert.That(group.LastLine, Is.EqualTo(7));
-            Assert.That(assignment.Location.Start.Line, Is.EqualTo(7));
-            Assert.That(assignment.Variable.Location.Start.Line, Is.EqualTo(7));
-            Assert.That(assignment.Value.Location.Start.Line, Is.EqualTo(7));
-
-            group.AdjustLines(-2);
-            Assert.That(group.FirstLine, Is.EqualTo(5));
-            Assert.That(group.LastLine, Is.EqualTo(5));
-            Assert.That(assignment.Location.Start.Line, Is.EqualTo(5));
-            Assert.That(assignment.Variable.Location.Start.Line, Is.EqualTo(5));
-            Assert.That(assignment.Value.Location.Start.Line, Is.EqualTo(5));
-        }
-
-        [Test]
         public void TestIsDependentOn()
         {
             var group = Parse("a = b").Groups.First(); // Parse will call UpdateMetadata


### PR DESCRIPTION
Fixes "go to source" not going to the correct line when lines are added or removed above the generating code.