### PR TITLE
use single child view model for Core and Unofficial published achievements

### DIFF
--- a/Data/Achievement.cs
+++ b/Data/Achievement.cs
@@ -38,6 +38,19 @@ namespace RATools.Data
         public int Points { get; internal set; }
 
         /// <summary>
+        /// Gets the achievement category (3=Core, 5=Unofficial).
+        /// </summary>
+        public int Category { get; internal set; }
+
+        /// <summary>
+        /// Gets whether or not the achievement is Unofficial.
+        /// </summary>
+        public bool IsUnofficial
+        {
+            get { return Category == 5; }
+        }
+
+        /// <summary>
         /// Gets the name of the badge for the achievement.
         /// </summary>
         public string BadgeName { get; internal set; }

--- a/ViewModels/AchievementViewModel.cs
+++ b/ViewModels/AchievementViewModel.cs
@@ -66,6 +66,11 @@ namespace RATools.ViewModels
         public TextFieldViewModel Description { get; private set; }
         public IntegerFieldViewModel Points { get; private set; }
 
+        public bool IsUnofficial
+        {
+            get { return (Achievement != null) && Achievement.IsUnofficial; }
+        }
+
         public static readonly ModelProperty BadgeNameProperty = ModelProperty.Register(typeof(AchievementViewModel), "BadgeName", typeof(string), String.Empty);
         public string BadgeName
         {

--- a/ViewModels/GameViewModel.cs
+++ b/ViewModels/GameViewModel.cs
@@ -382,16 +382,16 @@ namespace RATools.ViewModels
                     builtAchievement.Published = UnixEpoch.AddSeconds(publishedAchievement.GetField("Created").IntegerValue.GetValueOrDefault());
                     builtAchievement.LastModified = UnixEpoch.AddSeconds(publishedAchievement.GetField("Modified").IntegerValue.GetValueOrDefault());
 
-                    var flags = publishedAchievement.GetField("Flags").IntegerValue;
-                    if (flags == 5)
+                    builtAchievement.Category = publishedAchievement.GetField("Flags").IntegerValue.GetValueOrDefault();
+                    if (builtAchievement.Category == 5)
                     {
-                        achievement.Unofficial.LoadAchievement(builtAchievement);
+                        achievement.Published.LoadAchievement(builtAchievement);
                         unofficialCount++;
                         unofficialPoints += points;
                     }
-                    else if (flags == 3)
+                    else if (builtAchievement.Category == 3)
                     {
-                        achievement.Core.LoadAchievement(builtAchievement);
+                        achievement.Published.LoadAchievement(builtAchievement);
                         coreCount++;
                         corePoints += points;
                     }
@@ -430,7 +430,7 @@ namespace RATools.ViewModels
                     achievements.Add(achievement);
                 }
 
-                achievement.Core.LoadAchievement(publishedAchievement);
+                achievement.Published.LoadAchievement(publishedAchievement);
                 count++;
                 points += publishedAchievement.Points;
             }
@@ -448,7 +448,7 @@ namespace RATools.ViewModels
                         achievements.Add(achievement);
                     }
 
-                    achievement.Unofficial.LoadAchievement(publishedAchievement);
+                    achievement.Published.LoadAchievement(publishedAchievement);
                     count++;
                     points += publishedAchievement.Points;
                 }

--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -100,7 +100,7 @@ namespace RATools.ViewModels
 
         private void LoadGame(int gameId, string raCacheDirectory)
         {
-            _game = new GameViewModel(GameId.Value.GetValueOrDefault(), "", raCacheDirectory);
+            _game = new GameViewModel(gameId, "", raCacheDirectory);
             _game.PopulateEditorList(null);
             DialogTitle = "New Script - " + _game.Title;
 
@@ -112,16 +112,12 @@ namespace RATools.ViewModels
             var unofficialAchievements = new List<DumpAchievementItem>();
             foreach (var achievement in _game.Editors.OfType<GeneratedAchievementViewModel>())
             {
-                AchievementViewModel source = achievement.Core;
+                AchievementViewModel source = achievement.Published;
                 if (source.Achievement == null)
-                {
-                    source = achievement.Unofficial;
-                    if (source.Achievement == null)
-                        continue;
-                }
+                    continue;
 
                 var dumpAchievement = new DumpAchievementItem(achievement.Id, source.Title.Text);
-                if (achievement.Core.Achievement == null)
+                if (achievement.Published.Achievement == null)
                 {
                     dumpAchievement.IsUnofficial = true;
                     unofficialAchievements.Add(dumpAchievement);
@@ -916,7 +912,7 @@ namespace RATools.ViewModels
 
                     stream.WriteLine("achievement(");
 
-                    var achievementViewModel = (achievement.Core.Achievement != null) ? achievement.Core : achievement.Unofficial;
+                    var achievementViewModel = achievement.Published;
                     var achievementData = achievementViewModel.Achievement;
 
                     stream.Write("    title = \"");

--- a/Views/AchievementViewer.xaml
+++ b/Views/AchievementViewer.xaml
@@ -249,7 +249,7 @@
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}">
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Unofficial.Modified}" Value="None">
+                                    <DataTrigger Binding="{Binding Published.IsUnofficial}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
                                     </DataTrigger>
                                 </Style.Triggers>


### PR DESCRIPTION
Core and Unofficial are mutually exclusive, so can be represented by a single ViewModel, which simplifies a little of the logic for calculating differences between published, local, and generated achievements.