### PR TITLE
fix game stats not showing up without an ApiKey

### DIFF
--- a/Views/GameStatsDialog.xaml
+++ b/Views/GameStatsDialog.xaml
@@ -82,7 +82,7 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="150" />
                             <ColumnDefinition Width="40" />
-                            <ColumnDefinition Width="200" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <TextBlock>
                             <Hyperlink Style="{StaticResource subtleHyperlink}"

--- a/Views/UserHistoryDialog.xaml
+++ b/Views/UserHistoryDialog.xaml
@@ -20,7 +20,19 @@
                             <ColumnDefinition Width="200" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Text="{Binding UnlockTime}" HorizontalAlignment="Right" Margin="0,0,6,0"/>
+                        <TextBlock HorizontalAlignment="Right" Margin="0,0,6,0">
+                            <TextBlock.Style>
+                                <Style TargetType="{x:Type TextBlock}">
+                                    <Setter Property="Text" Value="{Binding UnlockTime}"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding UnlockTime}" Value="{x:Null}">
+                                            <Setter Property="Text" Value="[Unknown]" />
+                                            <Setter Property="Opacity" Value="0.4" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
                         <TextBlock Grid.Column="1" Text="{Binding Title}" />
                         <TextBlock Grid.Column="2" Text="{Binding Description}" />
                     </Grid>


### PR DESCRIPTION
At some point, the achievement detail page change its user links from "/User/XXXX" to "/user/XXXX", so the parsing code could no longer find them.

Without an ApiKey, the additional data that is normally queried for the users who have been identified as having mastered the game is not queried, so all the data comes from the achievement detail pages. With the parsing code failing, the code could not identify any unlocks.

This fixes the URL matching to look for lowercase, and pops up a warning when all achievement unlocks for a user who has mastered a game cannot be determined from the achievement detail pages and no ApiKey is available.