### PR TITLE
don't generate RP lookup entries that match fallback value

### DIFF
--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -133,6 +133,8 @@ namespace RATools.Test.Parser.Functions
         public void TestOrNextNoHitTarget()
         {
             // ensures an OrNext chain can be forcibly generated even without a hit target
+            // this behavior is required by CrossMultiplyOrConditions to prevent the number
+            // of generated alts from becoming too cumbersome.
             var requirements = Evaluate("repeated(0, byte(0x1234) == 56 || byte(0x2345) == 67)");
             Assert.That(requirements.Count, Is.EqualTo(2));
             Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));

--- a/Tests/Parser/RichPresenceBuilderTests.cs
+++ b/Tests/Parser/RichPresenceBuilderTests.cs
@@ -269,5 +269,47 @@ namespace RATools.Test.Parser
                 "@T(0xH1234)\n"
             ));
         }
+
+        [Test]
+        public void TestLookupFieldFallbackCollapse()
+        {
+            var dict = new Dictionary<int, string>
+            {
+                { 1, "Odd" },
+                { 2, "Even" },
+                { 3, "Odd" },
+                { 4, "Even" },
+                { 5, "Odd" },
+                { 6, "Even" },
+            };
+
+            var builder = new RichPresenceBuilder();
+            Assert.That(builder.AddLookupField(null, "OddOrEven", CreateDictionaryExpression(dict),
+                new StringConstantExpression("Even")), Is.Null);
+            builder.DisplayString = "@OddOrEven(0xH1234)";
+
+            Assert.That(builder.DisableLookupCollapsing, Is.False);
+            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+                "Lookup:OddOrEven\n" +
+                "1,3,5=Odd\n" +
+                "*=Even\n" +
+                "\n" +
+                "Display:\n" +
+                "@OddOrEven(0xH1234)\n"
+            ));
+
+            builder.DisableLookupCollapsing = true;
+            Assert.That(builder.DisableLookupCollapsing, Is.True);
+            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+                "Lookup:OddOrEven\n" +
+                "1=Odd\n" +
+                "3=Odd\n" +
+                "5=Odd\n" +
+                "*=Even\n" +
+                "\n" +
+                "Display:\n" +
+                "@OddOrEven(0xH1234)\n"
+            ));
+        }
     }
 }


### PR DESCRIPTION
Prevents emission of lookup entries that match the default value.

For example, if the following lookup were generated:
```
Lookup:OddOrEven
1=Odd
2=Even
3=Odd
4=Even
5=Odd
6=Even
7=Odd
*=Even
```
Since "Even" is the default string to display when no matching entry can be found, all items explicitly providing the value "Even" can be eliminated:
```
Lookup:OddOrEven
1=Odd
3=Odd
5=Odd
7=Odd
*=Even
```