### PR TITLE
Added support for negative relative offsets

### DIFF
--- a/Parser/Functions/MemoryAccessorFunction.cs
+++ b/Parser/Functions/MemoryAccessorFunction.cs
@@ -107,14 +107,6 @@ namespace RATools.Parser.Functions
                     {
                         if (mathematic.Operation == MathematicOperation.Subtract)
                             offsetConstant = new IntegerConstantExpression(-offsetConstant.Value);
-
-                        if (offsetConstant.Value < 0)
-                        {
-                            // Negative relative offsets can actually be handled by the runtime through overflow
-                            // addition, but the editor generates an error if the offset is larger than the
-                            // available memory space for the current system.
-                            return new ParseErrorExpression("Negative relative offset not supported", address);
-                        }
                     }
 
                     mathematic = address as MathematicExpression;

--- a/Tests/Parser/Functions/MemoryAccessorFunctionTests.cs
+++ b/Tests/Parser/Functions/MemoryAccessorFunctionTests.cs
@@ -159,6 +159,7 @@ namespace RATools.Test.Parser.Functions
         [TestCase("bit(18, 10 + word(0x1234))", "bit2(word(0x001234) + 0x00000C)")] // indirect pointer
         [TestCase("bit(18, prev(word(0x1234)))", "bit2(prev(word(0x001234)) + 0x000002)")] // direct pointer using prev data
         [TestCase("bit(18, 0x1234 + word(0x2345) * 2)", "bit2(word(0x002345) * 0x00000002 + 0x001236)")] // scaled array index
+        [TestCase("byte(word(0x1234) - 10)", "byte(word(0x001234) + 0xFFFFFFF6)")]
         public void TestAddAddress(string input, string expected)
         {
             var requirements = Evaluate(input);
@@ -177,7 +178,6 @@ namespace RATools.Test.Parser.Functions
         [TestCase("byte(repeated(4, word(0x1234) == 3))", "Cannot convert to an address: repeated(4, word(4660) == 3)")]
         [TestCase("byte(word(0x1234) == 3)", "Cannot convert to an address: word(4660) == 3")]
         [TestCase("byte(word(0x1234) == 3 && 2 > 1)", "Cannot convert to an address: word(4660) == 3 && 2 > 1")]
-        [TestCase("byte(word(0x1234) - 10)", "Negative relative offset not supported")]
         public void TestInvalidAddress(string input, string error)
         {
             Evaluate(input, error);

--- a/Tests/Parser/TriggerBuilderContextTests.cs
+++ b/Tests/Parser/TriggerBuilderContextTests.cs
@@ -50,6 +50,7 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x1234 + byte(0x2345)) - byte(0x1235 + byte(0x2345))", "I:0xH002345_B:0xH001235_I:0xH002345_M:0xH001234")]
         [TestCase("byte(0x1234 + byte(0x2345)) * 2", "I:0xH002345_M:0xH001234*2")]
         [TestCase("measured(byte(0x1234) != prev(byte(0x1234))", "M:0xH001234!=d0xH001234")]
+        [TestCase("byte(byte(0x1234) - 10)", "I:0xH001234_M:0xHfffffff6")]
         public void TestGetValueString(string input, string expected)
         {
             ExpressionBase error;


### PR DESCRIPTION
Fixes #242 

As the editor now supports negative offsets via integer overflow math without throwing an error when a dev attempts to do so, the code preventing the same in RATools is no longer required. This change aims for further feature parity with the editor.