### PR TITLE
simplify prev distribution over mathematic chain

### DIFF
--- a/Parser/Functions/PrevPriorFunction.cs
+++ b/Parser/Functions/PrevPriorFunction.cs
@@ -26,36 +26,62 @@ namespace RATools.Parser.Functions
                 return false;
             parameter = result;
 
+            // convert "prev(a + b)" => "prev(a) + prev(b)"
             var mathematic = parameter as MathematicExpression;
             if (mathematic != null)
+                return ReplaceVariablesMathematic(mathematic, scope, out result);
+
+            // make sure accessor is a memory accessor
+            return WrapMemoryAccessor(parameter, scope, out result);
+        }
+
+        private bool ReplaceVariablesMathematic(MathematicExpression mathematic, InterpreterScope scope, out ExpressionBase result)
+        {
+            // assert: left/right already expanded by calling function
+            var left = mathematic.Left;
+
+            var mathematicLeft = left as MathematicExpression;
+            if (mathematicLeft != null)
             {
-                var left = mathematic.Left;
-                if (!(left is IntegerConstantExpression))
-                {
-                    left = new FunctionCallExpression(Name.Name, new ExpressionBase[] { mathematic.Left });
-                    if (!left.ReplaceVariables(scope, out result))
-                        return false;
-                    left = result;
-                }
+                if (!ReplaceVariablesMathematic(mathematicLeft, scope, out result))
+                    return false;
 
-                var right = mathematic.Right;
-                if (!(right is IntegerConstantExpression))
-                {
-                    right = new FunctionCallExpression(Name.Name, new ExpressionBase[] { mathematic.Right });
-                    if (!right.ReplaceVariables(scope, out result))
-                        return false;
-                    right = result;
-                }
-
-                result = new MathematicExpression(left, mathematic.Operation, right);
-                CopyLocation(result);
-                return true;
+                left = result;
+            }
+            else if (left.Type != ExpressionType.IntegerConstant)
+            {
+                if (!WrapMemoryAccessor(left, scope, out result))
+                    return false;
+                left = result;
             }
 
-            var functionCall = parameter as FunctionCallExpression;
+            var right = mathematic.Right;
+            var mathematicRight = right as MathematicExpression;
+            if (mathematicRight != null)
+            {
+                if (!ReplaceVariablesMathematic(mathematicRight, scope, out result))
+                    return false;
+
+                right = result;
+            }
+            else if (right.Type != ExpressionType.IntegerConstant)
+            {
+                if (!WrapMemoryAccessor(right, scope, out result))
+                    return false;
+                right = result;
+            }
+
+            result = new MathematicExpression(left, mathematic.Operation, right);
+            CopyLocation(result);
+            return true;
+        }
+
+        private bool WrapMemoryAccessor(ExpressionBase expression, InterpreterScope scope, out ExpressionBase result)
+        {
+            var functionCall = expression as FunctionCallExpression;
             if (functionCall == null)
             {
-                result = new ParseErrorExpression("accessor did not evaluate to a memory accessor", parameter);
+                result = new ParseErrorExpression("accessor did not evaluate to a memory accessor", expression);
                 return false;
             }
 
@@ -63,7 +89,7 @@ namespace RATools.Parser.Functions
             var memoryAccessor = functionDefinition as MemoryAccessorFunction;
             if (memoryAccessor == null)
             {
-                result = new ParseErrorExpression("accessor did not evaluate to a memory accessor", parameter);
+                result = new ParseErrorExpression("accessor did not evaluate to a memory accessor", expression);
                 return false;
             }
 

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -392,41 +392,6 @@ namespace RATools.Test.Parser
         }
 
         [Test]
-        public void TestPrev()
-        {
-            var parser = Parse("achievement(\"T\", \"D\", 5, prev(byte(0x1234)) == 1)");
-            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
-            var achievement = parser.Achievements.First();
-            Assert.That(GetRequirements(achievement), Is.EqualTo("prev(byte(0x001234)) == 1"));
-        }
-
-        [Test]
-        public void TestPrevMalformed()
-        {
-            var parser = Parse("achievement(\"T\", \"D\", 5, prev(byte(0x1234) == 1))", false);
-            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:31 accessor did not evaluate to a memory accessor"));
-        }
-
-        [Test]
-        public void TestPrevMathematic()
-        {
-            var parser = Parse("achievement(\"T\", \"D\", 5, prev(byte(0x1234) + 6) == 10)");
-            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
-            var achievement = parser.Achievements.First();
-            Assert.That(GetRequirements(achievement), Is.EqualTo("prev(byte(0x001234)) == 4"));
-
-            parser = Parse("achievement(\"T\", \"D\", 5, prev(byte(0x1234) * 10 + 20) == 80)");
-            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
-            achievement = parser.Achievements.First();
-            Assert.That(GetRequirements(achievement), Is.EqualTo("prev(byte(0x001234)) == 6"));
-
-            parser = Parse("achievement(\"T\", \"D\", 5, prev(byte(0x1234) + byte(0x2345)) == 7)");
-            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
-            achievement = parser.Achievements.First();
-            Assert.That(GetRequirements(achievement), Is.EqualTo("(prev(byte(0x001234)) + prev(byte(0x002345))) == 7"));
-        }
-
-        [Test]
         public void TestOnce()
         {
             var parser = Parse("achievement(\"T\", \"D\", 5, once(byte(0x1234) == 1))");

--- a/Tests/Parser/Functions/PrevPriorFunctionTests.cs
+++ b/Tests/Parser/Functions/PrevPriorFunctionTests.cs
@@ -1,0 +1,105 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Data;
+using RATools.Parser;
+using RATools.Parser.Functions;
+using System.Linq;
+using System.Text;
+
+namespace RATools.Test.Parser.Functions
+{
+    [TestFixture]
+    class PrevPriorFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new PrevPriorFunction("prev", FieldType.PreviousValue);
+            Assert.That(def.Name.Name, Is.EqualTo("prev"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(1));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("accessor"));
+        }
+
+        private AchievementScriptInterpreter Parse(string input, bool expectedSuccess = true)
+        {
+            var tokenizer = Tokenizer.CreateTokenizer(input);
+            var parser = new AchievementScriptInterpreter();
+
+            if (expectedSuccess)
+            {
+                if (!parser.Run(tokenizer))
+                {
+                    Assert.That(parser.ErrorMessage, Is.Null);
+                    Assert.Fail("AchievementScriptInterpreter.Run failed with no error message");
+                }
+            }
+            else
+            {
+                Assert.That(parser.Run(tokenizer), Is.False);
+                Assert.That(parser.ErrorMessage, Is.Not.Null);
+            }
+
+            return parser;
+        }
+
+        private string Process(string input)
+        {
+            var parser = Parse("achievement(\"T\", \"D\", 5, " + input + ")");
+            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
+            var achievement = parser.Achievements.First();
+            var builder = new AchievementBuilder(achievement);
+            return builder.SerializeRequirements();
+        }
+
+        private static string GetInnerErrorMessage(AchievementScriptInterpreter parser)
+        {
+            if (parser.Error == null)
+                return null;
+
+            var err = parser.Error;
+            while (err.InnerError != null)
+                err = err.InnerError;
+
+            return string.Format("{0}:{1} {2}", err.Location.Start.Line, err.Location.Start.Column, err.Message);
+        }
+
+        [Test]
+        [TestCase("prev(byte(0x1234)) == 56", "d0xH001234=56")]
+        [TestCase("prev(byte(0x1234) + 6) == 10", "d0xH001234=4")] // modifier is distributed
+        [TestCase("prev(byte(0x1234) * 10 + 20) == 80", "d0xH001234=6")] // modifier is distributed
+        [TestCase("prev(byte(0x1234) + byte(0x2345)) == 7", "A:d0xH001234=0_d0xH002345=7")] // prev is distributed
+        [TestCase("prev(byte(0x1234) - byte(0x2345)) == 7", "B:d0xH002345=0_d0xH001234=7")] // prev is distributed
+        public void TestPrev(string input, string expected)
+        {
+            var definition = Process(input);
+            Assert.That(definition, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void TestPrevMalformed()
+        {
+            var parser = Parse("achievement(\"T\", \"D\", 5, prev(byte(0x1234) == 1))", false);
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:31 accessor did not evaluate to a memory accessor"));
+        }
+
+        [Test]
+        public void TestPrevLargeMathematicChain()
+        {
+            var largeInput = new StringBuilder();
+            var largeOutput = new StringBuilder();
+
+            largeInput.Append("prev(");
+            for (int i = 0; i < 100; i++)
+            {
+                largeInput.AppendFormat("byte(0x{0:X4}) +", i + 0x1000);
+                largeOutput.AppendFormat("A:d0xH{0:x6}=0_", i + 0x1000);
+            }
+
+            largeInput.Append("byte(0x1234)) == 87");
+            largeOutput.Append("d0xH001234=87");
+
+            var definition = Process(largeInput.ToString());
+            Assert.That(definition, Is.EqualTo(largeOutput.ToString()));
+        }
+    }
+}

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -131,6 +131,7 @@
   <ItemGroup>
     <Compile Include="Data\RequirementTests.cs" />
     <Compile Include="Data\FieldTests.cs" />
+    <Compile Include="Parser\Functions\PrevPriorFunctionTests.cs" />
     <Compile Include="Parser\Functions\SumOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\NoneOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\AllOfFunctionTests.cs" />


### PR DESCRIPTION
fixes a "maximum recursion depth exceeded" error when wrapping a large addsource chain in prev().