### PR TITLE
prevent maximum recursion error when modifying the same function over and over

### DIFF
--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -285,8 +285,8 @@ namespace RATools.Parser
         internal bool Run(ExpressionGroupCollection expressionGroups, IScriptInterpreterCallback callback)
         {
             var scriptContext = new AchievementScriptContext();
-            var scriptScope = new InterpreterScope(expressionGroups.Scope ?? GetGlobalScope()) { Context = this };
-            expressionGroups.Scope = new InterpreterScope(scriptScope) { Context = scriptContext };
+            var scope = new InterpreterScope(expressionGroups.Scope ?? GetGlobalScope()) { Context = scriptContext };
+
             expressionGroups.ResetErrors();
 
             bool result = true;
@@ -301,7 +301,7 @@ namespace RATools.Parser
                     if (scriptContext.RichPresence == null)
                         scriptContext.RichPresence = new RichPresenceBuilder();
 
-                    if (!Evaluate(expressionGroup.Expressions, expressionGroups.Scope, callback))
+                    if (!Evaluate(expressionGroup.Expressions, scope, callback))
                     {
                         var error = Error;
                         if (error != null)
@@ -337,6 +337,19 @@ namespace RATools.Parser
                     }
 
                     expressionGroup.MarkEvaluated();
+                }
+            }
+
+            if (scope.FunctionCount > 0 || scope.VariableCount > 0)
+            {
+                if (expressionGroups.Scope != null)
+                {
+                    expressionGroups.Scope.Merge(scope);
+                }
+                else
+                {
+                    scope.Context = null;
+                    expressionGroups.Scope = scope;
                 }
             }
 

--- a/Parser/Internal/InterpreterScope.cs
+++ b/Parser/Internal/InterpreterScope.cs
@@ -322,6 +322,11 @@ namespace RATools.Parser.Internal
             return false;
         }
 
+        /// <summary>
+        /// Updates the specified variables/functions from definitions in a secondary <see cref="ExpressionGroup"/>.
+        /// </summary>
+        /// <param name="names">The variables/functions to update</param>
+        /// <param name="newGroup">The <see cref="ExpressionGroup"/> containing the new definitions of the variables/functions.</param>
         internal void UpdateVariables(IEnumerable<string> names, ExpressionGroup newGroup)
         {
             if (_variable.Key != null)
@@ -347,6 +352,29 @@ namespace RATools.Parser.Internal
                     if (_functions.TryGetValue(name, out function))
                         UpdateFunction(name, newGroup.Expressions);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Merges all varaibles/functions from the provided <see cref="InterpreterScope"/> into this <see cref="InterpreterScope"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="InterpreterScope"/> to merge variables/functions from.</param>
+        internal void Merge(InterpreterScope source)
+        {
+            if (source._variable.Key != null)
+            {
+                DefineVariable(source._variable.Key, source._variable.Value);
+            }
+            else if (source._variables != null)
+            {
+                foreach (var kvp in source._variables)
+                    DefineVariable(kvp.Value.Key, kvp.Value.Value);
+            }
+
+            if (source._functions != null)
+            {
+                foreach (var kvp in source._functions)
+                    AddFunction(kvp.Value);
             }
         }
 

--- a/Tests/Parser/Internal/InterpreterScopeTests.cs
+++ b/Tests/Parser/Internal/InterpreterScopeTests.cs
@@ -171,5 +171,46 @@ namespace RATools.Test.Parser.Internal
 
             Assert.That(array.Entries[0], Is.SameAs(value));
         }
+
+        [Test]
+        public void TestMerge()
+        {
+            var scope1 = new InterpreterScope();
+            scope1.DefineVariable(new VariableDefinitionExpression("a"), new IntegerConstantExpression(1));
+
+            var scope2 = new InterpreterScope();
+            scope2.DefineVariable(new VariableDefinitionExpression("a"), new IntegerConstantExpression(4));
+            scope2.DefineVariable(new VariableDefinitionExpression("d"), new IntegerConstantExpression(5));
+            scope2.AddFunction(new FunctionDefinitionExpression("f1"));
+
+            var scope3 = new InterpreterScope();
+            scope3.DefineVariable(new VariableDefinitionExpression("b"), new IntegerConstantExpression(2));
+            scope3.DefineVariable(new VariableDefinitionExpression("c"), new IntegerConstantExpression(3));
+
+            var scope4 = new InterpreterScope();
+            scope4.AddFunction(new FunctionDefinitionExpression("f1"));
+            scope4.AddFunction(new FunctionDefinitionExpression("f2"));
+
+            var union = new InterpreterScope();
+            Assert.That(union.VariableCount, Is.EqualTo(0));
+            Assert.That(union.FunctionCount, Is.EqualTo(0));
+
+            union.Merge(scope1);
+            Assert.That(union.VariableCount, Is.EqualTo(1));
+            Assert.That(union.FunctionCount, Is.EqualTo(0));
+
+            union.Merge(scope2);
+            Assert.That(union.VariableCount, Is.EqualTo(2));
+            Assert.That(union.FunctionCount, Is.EqualTo(1));
+            Assert.That(union.GetVariable("a"), Is.EqualTo(new IntegerConstantExpression(4)));
+
+            union.Merge(scope3);
+            Assert.That(union.VariableCount, Is.EqualTo(4));
+            Assert.That(union.FunctionCount, Is.EqualTo(1));
+
+            union.Merge(scope4);
+            Assert.That(union.VariableCount, Is.EqualTo(4));
+            Assert.That(union.FunctionCount, Is.EqualTo(2));
+        }
     }
 }


### PR DESCRIPTION
Each time a chunk of the script was re-evaluated, it would generate another nested scope, eventually getting deep enough to cause a maximum recursion error.

This modifies the logic to merge the nested scope instead of appending it.