### PR TITLE
report double comparison as error

### DIFF
--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -773,10 +773,12 @@ namespace RATools.Parser
 
         private ParseErrorExpression ExecuteAchievementComparison(ComparisonExpression comparison, InterpreterScope scope)
         {
-            var context = scope.GetContext<TriggerBuilderContext>();
             var left = comparison.Left;
             var right = comparison.Right;
+            if (left.Type == ExpressionType.Comparison || right.Type == ExpressionType.Comparison)
+                return new ParseErrorExpression("comparison did not evaluate to a valid comparison", comparison);
 
+            var context = scope.GetContext<TriggerBuilderContext>();
             var op = GetRequirementOperator(comparison.Operation);
 
             if (left.Type == ExpressionType.IntegerConstant)

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -710,5 +710,11 @@ namespace RATools.Test.Parser
             CreateAchievement("byte(0x1234) || byte(0x2345) == 1", "Incomplete trigger condition");
             CreateAchievement("byte(0x1234) == 1 || byte(0x2345)", "Incomplete trigger condition");
         }
+
+        [Test]
+        public void TestNestedComparison()
+        {
+            CreateAchievement("(byte(0x1234) == 2) == 1", "comparison did not evaluate to a valid comparison");
+        }
     }
 }

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -1052,5 +1052,15 @@ namespace RATools.Test.Parser
             var integerConstant = (IntegerConstantExpression)c;
             Assert.That(integerConstant.Value, Is.EqualTo(4));
         }
+
+        [Test]
+        public void TestNestedComparisonFunction()
+        {
+            Evaluate("function f() => byte(0x1234) == 2\n" +
+                     "achievement(\"T\", \"D\", 5, f() == 1)\n",
+
+                     "2:1 achievement call failed\r\n" +
+                     "- 2:26 comparison did not evaluate to a valid comparison");
+        }
     }
 }


### PR DESCRIPTION
Generates an error when doing a comparison to a function result where the function result is also a comparison:
```
function f() => byte(0x1234) == 2
achievement("Title", "Description", 5, f() == 1)
```

Previously, this would process the `f()` call correctly, then append the `==1` as an `AddSource 0 == 1`.