### PR TITLE
boolean support

### DIFF
--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -550,14 +550,20 @@ namespace RATools.Parser
         private bool EvaluateIf(IfExpression ifExpression, InterpreterScope scope)
         {
             ParseErrorExpression error;
-            bool result = ifExpression.Condition.IsTrue(scope, out error);
+            bool? result = ifExpression.Condition.IsTrue(scope, out error);
             if (error != null)
             {
                 Error = error;
                 return false;
             }
 
-            return Evaluate(result ? ifExpression.Expressions : ifExpression.ElseExpressions, scope);
+            if (result == null)
+            {
+                Error = new ParseErrorExpression("Condition did not evaluate to a boolean.", ifExpression.Condition);
+                return false;
+            }
+
+            return Evaluate(result.GetValueOrDefault() ? ifExpression.Expressions : ifExpression.ElseExpressions, scope);
         }
 
         private bool CallFunction(FunctionCallExpression expression, InterpreterScope scope)

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -271,15 +271,7 @@ namespace RATools.Parser
                 }
             }
 
-            if (!Run(expressionGroups, null))
-            {
-                if (Error == null)
-                    Error = expressionGroups.Errors.FirstOrDefault();
-
-                return false;
-            }
-
-            return true;
+            return Run(expressionGroups, null);
         }
 
         internal bool Run(ExpressionGroupCollection expressionGroups, IScriptInterpreterCallback callback)
@@ -389,6 +381,7 @@ namespace RATools.Parser
                 RichPresenceLine = _richPresence.Line;
             }
 
+            Error = expressionGroups.Errors.FirstOrDefault();
             return result;
         }
 

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -381,7 +381,9 @@ namespace RATools.Parser
                 RichPresenceLine = _richPresence.Line;
             }
 
-            Error = expressionGroups.Errors.FirstOrDefault();
+            if (Error == null)
+                Error = expressionGroups.Errors.FirstOrDefault();
+
             return result;
         }
 

--- a/Parser/Internal/BooleanConstantExpression.cs
+++ b/Parser/Internal/BooleanConstantExpression.cs
@@ -43,7 +43,7 @@ namespace RATools.Parser.Internal
             return (that != null && Value == that.Value);
         }
 
-        public override bool IsTrue(InterpreterScope scope, out ParseErrorExpression error)
+        public override bool? IsTrue(InterpreterScope scope, out ParseErrorExpression error)
         {
             error = null;
             return Value;

--- a/Parser/Internal/BooleanConstantExpression.cs
+++ b/Parser/Internal/BooleanConstantExpression.cs
@@ -1,11 +1,18 @@
-﻿using System.Text;
+﻿using Jamiras.Components;
+using System.Text;
 
 namespace RATools.Parser.Internal
 {
-    internal class IntegerConstantExpression : ExpressionBase
+    internal class BooleanConstantExpression : ExpressionBase
     {
-        public IntegerConstantExpression(int value)
-            : base(ExpressionType.IntegerConstant)
+        public BooleanConstantExpression(bool value, int line, int column)
+            : this(value)
+        {
+            Location = new TextRange(line, column, line, column + (value ? 4 : 5));
+        }
+
+        public BooleanConstantExpression(bool value)
+            : base(ExpressionType.BooleanConstant)
         {
             Value = value;
         }
@@ -13,14 +20,14 @@ namespace RATools.Parser.Internal
         /// <summary>
         /// Gets the value.
         /// </summary>
-        public int Value { get; private set; }
+        public bool Value { get; private set; }
 
         /// <summary>
         /// Appends the textual representation of this expression to <paramref name="builder" />.
         /// </summary>
         internal override void AppendString(StringBuilder builder)
         {
-            builder.Append(Value);
+            builder.Append(Value ? "true" : "false");
         }
 
         /// <summary>
@@ -32,8 +39,14 @@ namespace RATools.Parser.Internal
         /// </returns>
         protected override bool Equals(ExpressionBase obj)
         {
-            var that = obj as IntegerConstantExpression;
+            var that = obj as BooleanConstantExpression;
             return (that != null && Value == that.Value);
+        }
+
+        public override bool IsTrue(InterpreterScope scope, out ParseErrorExpression error)
+        {
+            error = null;
+            return Value;
         }
     }
 }

--- a/Parser/Internal/BooleanConstantExpression.cs
+++ b/Parser/Internal/BooleanConstantExpression.cs
@@ -23,6 +23,14 @@ namespace RATools.Parser.Internal
         public bool Value { get; private set; }
 
         /// <summary>
+        /// Gets whether this is non-changing.
+        /// </summary>
+        public override bool IsConstant
+        {
+            get { return true; }
+        }
+
+        /// <summary>
         /// Appends the textual representation of this expression to <paramref name="builder" />.
         /// </summary>
         internal override void AppendString(StringBuilder builder)

--- a/Parser/Internal/ConditionalExpression.cs
+++ b/Parser/Internal/ConditionalExpression.cs
@@ -205,26 +205,30 @@ namespace RATools.Parser.Internal
         /// </returns>
         public override bool IsTrue(InterpreterScope scope, out ParseErrorExpression error)
         {
-            bool result = Left.IsTrue(scope, out error);
-            if (error != null)
-                return false;
+            bool result = false;
+            error = null;
 
             switch (Operation)
             {
                 case ConditionalOperation.And:
-                    if (result)
+                    result = Left.IsTrue(scope, out error);
+                    if (result && error == null)
                         result = Right.IsTrue(scope, out error);
                     break;
 
                 case ConditionalOperation.Or:
-                    if (!result)
+                    result = Left.IsTrue(scope, out error);
+                    if (!result && error == null)
                         result = Right.IsTrue(scope, out error);
                     break;
 
                 case ConditionalOperation.Not:
-                    result = !result;
+                    result = !Right.IsTrue(scope, out error);
                     break;
             }
+
+            if (error != null)
+                return false;
 
             return result;
         }

--- a/Parser/Internal/ConditionalExpression.cs
+++ b/Parser/Internal/ConditionalExpression.cs
@@ -246,22 +246,22 @@ namespace RATools.Parser.Internal
         /// <returns>
         /// The result of evaluating the expression
         /// </returns>
-        public override bool IsTrue(InterpreterScope scope, out ParseErrorExpression error)
+        public override bool? IsTrue(InterpreterScope scope, out ParseErrorExpression error)
         {
-            bool result = false;
+            bool? result = false;
             error = null;
 
             switch (Operation)
             {
                 case ConditionalOperation.And:
                     result = Left.IsTrue(scope, out error);
-                    if (result && error == null)
+                    if (result == true && error == null)
                         result = Right.IsTrue(scope, out error);
                     break;
 
                 case ConditionalOperation.Or:
                     result = Left.IsTrue(scope, out error);
-                    if (!result && error == null)
+                    if (result == false && error == null)
                         result = Right.IsTrue(scope, out error);
                     break;
 
@@ -271,7 +271,7 @@ namespace RATools.Parser.Internal
             }
 
             if (error != null)
-                return false;
+                result = null;
 
             return result;
         }

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -887,7 +887,7 @@ namespace RATools.Parser.Internal
         /// <returns>The result of evaluating the expression</returns>
         public virtual bool IsTrue(InterpreterScope scope, out ParseErrorExpression error)
         {
-            error = null;
+            error = new ParseErrorExpression("Expression did not evaluate to a boolean result.", this);
             return false;
         }
     }

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -891,10 +891,10 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="error">[out] The error that prevented evaluation (or null if successful).</param>
         /// <returns>The result of evaluating the expression</returns>
-        public virtual bool IsTrue(InterpreterScope scope, out ParseErrorExpression error)
+        public virtual bool? IsTrue(InterpreterScope scope, out ParseErrorExpression error)
         {
-            error = new ParseErrorExpression("Expression did not evaluate to a boolean result.", this);
-            return false;
+            error = null;
+            return null;
         }
     }
 

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -67,6 +67,14 @@ namespace RATools.Parser.Internal
         public bool IsLogicalUnit { get; set; }
 
         /// <summary>
+        /// Gets whether this is non-changing.
+        /// </summary>
+        public virtual bool IsConstant
+        {
+            get { return false; }
+        }
+
+        /// <summary>
         /// Rebalances this expression based on the precendence of operators.
         /// </summary>
         /// <returns>Rebalanced expression</returns>
@@ -582,12 +590,11 @@ namespace RATools.Parser.Internal
                 case ExpressionType.ParseError:
                     return right;
 
-                case ExpressionType.Comparison:
-                case ExpressionType.Conditional:
-                case ExpressionType.Dictionary:
+                case ExpressionType.Comparison: // will be rebalanced
+                case ExpressionType.Conditional: // will be rebalanced
+                case ExpressionType.Mathematic:
                 case ExpressionType.FunctionCall:
                 case ExpressionType.IntegerConstant:
-                case ExpressionType.Mathematic:
                 case ExpressionType.StringConstant:
                 case ExpressionType.Variable:
                     break;
@@ -618,6 +625,7 @@ namespace RATools.Parser.Internal
                 case ExpressionType.IntegerConstant:
                 case ExpressionType.Mathematic:
                 case ExpressionType.StringConstant:
+                case ExpressionType.BooleanConstant:
                 case ExpressionType.Variable:
                     break;
 
@@ -684,6 +692,7 @@ namespace RATools.Parser.Internal
                 case ExpressionType.IntegerConstant:
                 case ExpressionType.Mathematic:
                 case ExpressionType.StringConstant:
+                case ExpressionType.BooleanConstant:
                 case ExpressionType.Variable:
                     break;
 

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -486,6 +486,11 @@ namespace RATools.Parser.Internal
                     if (identifier == "if")
                         return IfExpression.Parse(tokenizer, line, column);
 
+                    if (identifier == "true")
+                        return new BooleanConstantExpression(true, line, column);
+                    if (identifier == "false")
+                        return new BooleanConstantExpression(false, line, column);
+
                     if (tokenizer.NextChar == '(')
                     {
                         tokenizer.Advance();
@@ -642,6 +647,7 @@ namespace RATools.Parser.Internal
                 case ExpressionType.Conditional:
                 case ExpressionType.FunctionCall:
                 case ExpressionType.Variable:
+                case ExpressionType.BooleanConstant:
                     break;
 
                 default:
@@ -916,6 +922,11 @@ namespace RATools.Parser.Internal
         /// A string constant.
         /// </summary>
         StringConstant,
+
+        /// <summary>
+        /// A boolean constant.
+        /// </summary>
+        BooleanConstant,
 
         /// <summary>
         /// A function call.

--- a/Parser/Internal/FunctionCallExpression.cs
+++ b/Parser/Internal/FunctionCallExpression.cs
@@ -443,13 +443,13 @@ namespace RATools.Parser.Internal
         {
         }
 
-        public override bool IsTrue(InterpreterScope scope, out ParseErrorExpression error)
+        public override bool? IsTrue(InterpreterScope scope, out ParseErrorExpression error)
         {
             ExpressionBase result;
             if (!Evaluate(scope, true, out result))
             {
                 error = result as ParseErrorExpression;
-                return false;
+                return null;
             }
 
             var functionCall = result as FunctionCallExpression;
@@ -464,8 +464,7 @@ namespace RATools.Parser.Internal
                 if (funcDef is Functions.AlwaysFalseFunction)
                     return false;
 
-                error = new ParseErrorExpression("Expression did not evaluate to a boolean result.", this);
-                return false;
+                return null;
             }
 
             return result.IsTrue(scope, out error);

--- a/Parser/Internal/FunctionDefinitionExpression.cs
+++ b/Parser/Internal/FunctionDefinitionExpression.cs
@@ -555,8 +555,17 @@ namespace RATools.Parser.Internal
             if (expression.Type == ExpressionType.ParseError)
                 return expression;
 
-            if (expression.Type == ExpressionType.Return)
-                return new ParseErrorExpression("Return statement is implied by =>", ((ReturnExpression)expression).Keyword);
+            switch (expression.Type)
+            {
+                case ExpressionType.Return:
+                    return ParseError(tokenizer, "Return statement is implied by =>", ((ReturnExpression)expression).Keyword);
+
+                case ExpressionType.For:
+                    return ParseError(tokenizer, "Shorthand function definition does not support loops.", expression);
+
+                case ExpressionType.If:
+                    return ParseError(tokenizer, "Shorthand function definition does not support branches.", expression);
+            }
 
             var returnExpression = new ReturnExpression(expression);
             Expressions.Add(returnExpression);

--- a/Parser/Internal/IfExpression.cs
+++ b/Parser/Internal/IfExpression.cs
@@ -75,7 +75,10 @@ namespace RATools.Parser.Internal
         {
             builder.Append("if (");
             Condition.AppendString(builder);
-            builder.Append(')');
+            builder.Append(") { ... }");
+
+            if (ElseExpressions.Count > 0)
+                builder.Append(" else { ... }");
         }
 
         /// <summary>

--- a/Parser/Internal/IfExpression.cs
+++ b/Parser/Internal/IfExpression.cs
@@ -45,9 +45,6 @@ namespace RATools.Parser.Internal
             if (condition.Type == ExpressionType.ParseError)
                 return condition;
 
-            if (condition.Type != ExpressionType.Conditional && condition.Type != ExpressionType.Comparison)
-                return ParseError(tokenizer, "Expected conditional statement following if", condition);
-
             var ifExpression = new IfExpression(condition);
             ifExpression._keyword = new KeywordExpression("if", line, column);
 

--- a/Parser/Internal/IfExpression.cs
+++ b/Parser/Internal/IfExpression.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Jamiras.Components;
 

--- a/Parser/Internal/IntegerConstantExpression.cs
+++ b/Parser/Internal/IntegerConstantExpression.cs
@@ -16,6 +16,14 @@ namespace RATools.Parser.Internal
         public int Value { get; private set; }
 
         /// <summary>
+        /// Gets whether this is non-changing.
+        /// </summary>
+        public override bool IsConstant
+        {
+            get { return true; }
+        }
+
+        /// <summary>
         /// Appends the textual representation of this expression to <paramref name="builder" />.
         /// </summary>
         internal override void AppendString(StringBuilder builder)

--- a/Parser/Internal/StringConstantExpression.cs
+++ b/Parser/Internal/StringConstantExpression.cs
@@ -16,6 +16,14 @@ namespace RATools.Parser.Internal
         public string Value { get; private set; }
 
         /// <summary>
+        /// Gets whether this is non-changing.
+        /// </summary>
+        public override bool IsConstant
+        {
+            get { return true; }
+        }
+
+        /// <summary>
         /// Appends the textual representation of this expression to <paramref name="builder" />.
         /// </summary>
         internal override void AppendString(StringBuilder builder)

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Parser\Internal\ExpressionGroupCollection.cs" />
     <Compile Include="Parser\Internal\ExpressionGroup.cs" />
     <Compile Include="Parser\Internal\ExpressionTokenizer.cs" />
+    <Compile Include="Parser\Internal\BooleanConstantExpression.cs" />
     <Compile Include="Parser\Internal\KeywordExpression.cs" />
     <Compile Include="Parser\Internal\LeftRightExpressionBase.cs" />
     <Compile Include="Parser\RichPresenceBuilder.cs" />

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -171,6 +171,22 @@ namespace RATools.Test.Parser
         }
 
         [Test]
+        public void TestDictionaryLogic()
+        {
+            var parser = Parse("dict = { 1: \"T\", 2: \"D\" }\n" +
+                               "function f(key) => dict[key] == \"D\"\n" +
+                               "if (f(2))\n" +
+                               "    achievement(dict[1], dict[2], 5, byte(0x1234) == 1)");
+            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
+
+            var achievement = parser.Achievements.First();
+            Assert.That(achievement.Title, Is.EqualTo("T"));
+            Assert.That(achievement.Description, Is.EqualTo("D"));
+            Assert.That(achievement.Points, Is.EqualTo(5));
+            Assert.That(GetRequirements(achievement), Is.EqualTo("byte(0x001234) == 1"));
+        }
+
+        [Test]
         public void TestArrayLookup()
         {
             var parser = Parse("array = [ \"A\", \"B\", \"C\" ]\n" +

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -1062,5 +1062,36 @@ namespace RATools.Test.Parser
                      "2:1 achievement call failed\r\n" +
                      "- 2:26 comparison did not evaluate to a valid comparison");
         }
+
+        [Test]
+        public void TestIfFunctionResult()
+        {
+            var scope = Evaluate("function t() => always_true()\n" +
+                                 "function f() => always_false()\n" +
+                                 "a = 0\n" +
+                                 "b = 0\n" +
+                                 "c = 0\n" +
+                                 "d = 0\n" +
+                                 "if (t()) { a = 1 }" +
+                                 "if (!t()) { b = 1 }" +
+                                 "if (f()) { c = 1 }" +
+                                 "if (!f()) { d = 1 }");
+
+            var a = scope.GetVariable("a");
+            Assert.That(a, Is.InstanceOf<IntegerConstantExpression>());
+            Assert.That(((IntegerConstantExpression)a).Value, Is.EqualTo(1));
+
+            var b = scope.GetVariable("b");
+            Assert.That(b, Is.InstanceOf<IntegerConstantExpression>());
+            Assert.That(((IntegerConstantExpression)b).Value, Is.EqualTo(0));
+
+            var c = scope.GetVariable("c");
+            Assert.That(c, Is.InstanceOf<IntegerConstantExpression>());
+            Assert.That(((IntegerConstantExpression)c).Value, Is.EqualTo(0));
+
+            var d = scope.GetVariable("d");
+            Assert.That(d, Is.InstanceOf<IntegerConstantExpression>());
+            Assert.That(((IntegerConstantExpression)d).Value, Is.EqualTo(1));
+        }
     }
 }

--- a/Tests/Parser/Functions/AllOfFunctionTests.cs
+++ b/Tests/Parser/Functions/AllOfFunctionTests.cs
@@ -32,7 +32,8 @@ namespace RATools.Test.Parser.Functions
                 return builder.RequirementsDebugString;
             }
 
-            return parser.Error.InnermostError.Message;
+            var error = parser.Error.InnermostError ?? parser.Error;
+            return error.Message;
         }
 
         [Test]

--- a/Tests/Parser/Functions/ArrayPushFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayPushFunctionTests.cs
@@ -124,11 +124,8 @@ namespace RATools.Test.Parser.Functions
 
             Evaluate("array_push(arr, happy(1) == 2)", scope);
 
-            var comparison = (ComparisonExpression)array.Entries[0];
-            Assert.That(comparison.Left, Is.InstanceOf<IntegerConstantExpression>());
-            Assert.That(((IntegerConstantExpression)comparison.Left).Value, Is.EqualTo(1));
-            Assert.That(comparison.Right, Is.InstanceOf<IntegerConstantExpression>());
-            Assert.That(((IntegerConstantExpression)comparison.Right).Value, Is.EqualTo(2));
+            var comparison = (BooleanConstantExpression)array.Entries[0];
+            Assert.That(comparison.Value, Is.False);
         }
 
         [Test]

--- a/Tests/Parser/Functions/LengthFunctionTests.cs
+++ b/Tests/Parser/Functions/LengthFunctionTests.cs
@@ -1,5 +1,6 @@
 ﻿using Jamiras.Components;
 using NUnit.Framework;
+using RATools.Parser;
 using RATools.Parser.Functions;
 using RATools.Parser.Internal;
 using System.Linq;
@@ -117,12 +118,19 @@ namespace RATools.Test.Parser.Functions
         }
 
         [Test]
-        public void TestComparison()
+        public void TestBoolean()
         {
             var scope = new InterpreterScope();
             scope.DefineVariable(new VariableDefinitionExpression("i"), new IntegerConstantExpression(12345));
 
-            Evaluate("length(i != 12)", scope, "Cannot calculate length of Comparison");
+            Evaluate("length(true)", scope, "Cannot calculate length of BooleanConstant");
+        }
+
+        [Test]
+        public void TestComparison()
+        {
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+            Evaluate("length(byte(0x1234) != 12)", scope, "Cannot calculate length of Comparison");
         }
 
         [Test]

--- a/Tests/Parser/Internal/BooleanConstantExpressionTests.cs
+++ b/Tests/Parser/Internal/BooleanConstantExpressionTests.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+using RATools.Parser.Internal;
+using System.Text;
+
+namespace RATools.Test.Parser.Internal
+{
+    [TestFixture]
+    class BooleanConstantExpressionTests
+    {
+        [Test]
+        public void TestAppendStringTrue()
+        {
+            var expr = new BooleanConstantExpression(true);
+
+            var builder = new StringBuilder();
+            expr.AppendString(builder);
+            Assert.That(builder.ToString(), Is.EqualTo("true"));
+        }
+
+        [Test]
+        public void TestAppendStringFalse()
+        {
+            var expr = new BooleanConstantExpression(false);
+
+            var builder = new StringBuilder();
+            expr.AppendString(builder);
+            Assert.That(builder.ToString(), Is.EqualTo("false"));
+        }
+
+        [Test]
+        public void TestIsTrueTrue()
+        {
+            var expr = new BooleanConstantExpression(true);
+            ParseErrorExpression error;
+            Assert.That(expr.IsTrue(new InterpreterScope(), out error), Is.True);
+            Assert.That(error, Is.Null);
+        }
+
+        [Test]
+        public void TestIsTrueFalse()
+        {
+            var expr = new BooleanConstantExpression(false);
+            ParseErrorExpression error;
+            Assert.That(expr.IsTrue(new InterpreterScope(), out error), Is.False);
+            Assert.That(error, Is.Null);
+        }
+    }
+}

--- a/Tests/Parser/Internal/ComparisonExpressionTests.cs
+++ b/Tests/Parser/Internal/ComparisonExpressionTests.cs
@@ -28,7 +28,8 @@ namespace RATools.Test.Parser.Internal
         }
 
         [Test]
-        [TestCase("variable1 > variable2", "98 > 99")] // simple variable substitution
+        [TestCase("byte(1) > variable2", "byte(1) > 99")] // simple variable substitution
+        [TestCase("variable1 > variable2", "false")] // evaluates to a constant
         [TestCase("1 == byte(2)", "byte(2) == 1")] // move constant to right side
         [TestCase("1 != byte(2)", "byte(2) != 1")] // move constant to right side
         [TestCase("1 < byte(2)", "byte(2) > 1")] // move constant to right side

--- a/Tests/Parser/Internal/ConditionalExpressionTests.cs
+++ b/Tests/Parser/Internal/ConditionalExpressionTests.cs
@@ -27,28 +27,25 @@ namespace RATools.Test.Parser.Internal
         }
 
         [Test]
-        public void TestReplaceVariables()
-        {
-            var variable1 = new VariableExpression("variable1");
-            var variable2 = new VariableExpression("variable2");
-            var value1 = new IntegerConstantExpression(98);
-            var value2 = new IntegerConstantExpression(99);
-            var expr = new ConditionalExpression(variable1, ConditionalOperation.And, variable2);
-
-            var scope = new InterpreterScope();
-            scope.AssignVariable(variable1, value1);
-            scope.AssignVariable(variable2, value2);
-
-            ExpressionBase result;
-            Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
-            Assert.That(result, Is.InstanceOf<ConditionalExpression>());
-            Assert.That(((ConditionalExpression)result).Left, Is.EqualTo(value1));
-            Assert.That(((ConditionalExpression)result).Operation, Is.EqualTo(expr.Operation));
-            Assert.That(((ConditionalExpression)result).Right, Is.EqualTo(value2));
-        }
-
-        [Test]
         [TestCase("A == B", "A == B")]
+        [TestCase("A == 1 && B == 1", "A == 1 && B == 1")]
+        [TestCase("A == 1 || B == 1", "A == 1 || B == 1")]
+        [TestCase("A == 1 || true", "true")]
+        [TestCase("A == 1 || false", "A == 1")]
+        [TestCase("A == 1 && true", "A == 1")]
+        [TestCase("A == 1 && false", "false")]
+        [TestCase("true || A == 1", "true")]
+        [TestCase("false || A == 1", "A == 1")]
+        [TestCase("true && A == 1", "A == 1")]
+        [TestCase("false && A == 1", "false")]
+        [TestCase("true || true", "true")]
+        [TestCase("true || false", "true")]
+        [TestCase("false || false", "false")]
+        [TestCase("true && true", "true")]
+        [TestCase("true && false", "false")]
+        [TestCase("false && false", "false")]
+        [TestCase("!true", "false")]
+        [TestCase("!false", "true")]
         [TestCase("!(A == B)", "A != B")]
         [TestCase("!(A != B)", "A == B")]
         [TestCase("!(A < B)", "A >= B")]
@@ -64,7 +61,7 @@ namespace RATools.Test.Parser.Internal
         [TestCase("!always_true()", "always_false()")]
         [TestCase("!always_false()", "always_true()")]
         [TestCase("!(always_false() || A == 1)", "always_true() && A != 1")]
-        public void TestReplaceVariablesNormalizeNots(string input, string expected)
+        public void TestReplaceVariables(string input, string expected)
         {
             input = input.Replace("A", "byte(10)");
             input = input.Replace("B", "byte(11)");
@@ -158,7 +155,6 @@ namespace RATools.Test.Parser.Internal
         [TestCase("!false && !false", true)]
         public void TestIsTrue(string input, bool expected)
         {
-            input = input.Replace("true", "always_true()").Replace("false", "always_false()");
             var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
             var expression = ExpressionBase.Parse(tokenizer);
             Assert.That(expression, Is.InstanceOf<ConditionalExpression>());

--- a/Tests/Parser/Internal/ConditionalExpressionTests.cs
+++ b/Tests/Parser/Internal/ConditionalExpressionTests.cs
@@ -140,5 +140,34 @@ namespace RATools.Test.Parser.Internal
             rebalanced.AppendString(builder);
             Assert.That(builder.ToString(), Is.EqualTo(expected));
         }
+
+        [Test]
+        [TestCase("true || true", true)]
+        [TestCase("true || false", true)]
+        [TestCase("false || true", true)]
+        [TestCase("false || false", false)]
+        [TestCase("true && true", true)]
+        [TestCase("true && false", false)]
+        [TestCase("false && true", false)]
+        [TestCase("false && false", false)]
+        [TestCase("!true", false)]
+        [TestCase("!false", true)]
+        [TestCase("!true && !true", false)]
+        [TestCase("!true && !false", false)]
+        [TestCase("!false && !true", false)]
+        [TestCase("!false && !false", true)]
+        public void TestIsTrue(string input, bool expected)
+        {
+            input = input.Replace("true", "always_true()").Replace("false", "always_false()");
+            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
+            var expression = ExpressionBase.Parse(tokenizer);
+            Assert.That(expression, Is.InstanceOf<ConditionalExpression>());
+
+            ParseErrorExpression error;
+            var scope = AchievementScriptInterpreter.GetGlobalScope();
+            var result = expression.IsTrue(scope, out error);
+            Assert.That(error, Is.Null);
+            Assert.That(result, Is.EqualTo(expected));
+        }
     }
 }

--- a/Tests/Parser/Internal/DictionaryExpressionTests.cs
+++ b/Tests/Parser/Internal/DictionaryExpressionTests.cs
@@ -138,14 +138,14 @@ namespace RATools.Test.Parser.Internal
         [Test]
         public void TestReplaceVariablesLogicalFunctionCall()
         {
-            var functionDefinition = UserFunctionDefinitionExpression.ParseForTest("function func(i) => i == 1");
+            var functionDefinition = UserFunctionDefinitionExpression.ParseForTest("function func(i) => byte(i) == 1");
 
             var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { new IntegerConstantExpression(2) });
             var value1 = new IntegerConstantExpression(98);
             var expr = new DictionaryExpression();
             expr.Add(functionCall, value1);
 
-            var scope = new InterpreterScope();
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
             scope.AddFunction(functionDefinition);
 
             ExpressionBase result;

--- a/Tests/Parser/Internal/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Internal/FunctionCallExpressionTests.cs
@@ -635,9 +635,8 @@ namespace RATools.Test.Parser.Internal
             var scope = AchievementScriptInterpreter.GetGlobalScope();
 
             ParseErrorExpression error;
-            Assert.That(expr.IsTrue(scope, out error), Is.False);
-            Assert.That(error, Is.Not.Null);
-            Assert.That(error.Message, Is.EqualTo("Expression did not evaluate to a boolean result."));
+            Assert.That(expr.IsTrue(scope, out error), Is.Null);
+            Assert.That(error, Is.Null);
         }
 
         [Test]
@@ -649,9 +648,8 @@ namespace RATools.Test.Parser.Internal
             scope.AddFunction(userFunc);
 
             ParseErrorExpression error;
-            Assert.That(expr.IsTrue(scope, out error), Is.False);
-            Assert.That(error, Is.Not.Null);
-            Assert.That(error.Message, Is.EqualTo("Expression did not evaluate to a boolean result."));
+            Assert.That(expr.IsTrue(scope, out error), Is.Null);
+            Assert.That(error, Is.Null);
         }
 
         [Test]

--- a/Tests/Parser/Internal/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Internal/FunctionCallExpressionTests.cs
@@ -1,9 +1,9 @@
 ﻿using NUnit.Framework;
+using RATools.Parser;
 using RATools.Parser.Internal;
-using System.Text;
-using System.Linq;
-using Jamiras.Components;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace RATools.Test.Parser.Internal
 {
@@ -604,6 +604,67 @@ namespace RATools.Test.Parser.Internal
             ((INestedExpressions)expr).GetModifications(modifications);
 
             Assert.That(modifications.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestIsTrueAlwaysTrueFunction()
+        {
+            var expr = new FunctionCallExpression("always_true", new ExpressionBase[0]);
+            var scope = AchievementScriptInterpreter.GetGlobalScope();
+
+            ParseErrorExpression error;
+            Assert.That(expr.IsTrue(scope, out error), Is.True);
+            Assert.That(error, Is.Null);
+        }
+
+        [Test]
+        public void TestIsTrueAlwaysFalseFunction()
+        {
+            var expr = new FunctionCallExpression("always_false", new ExpressionBase[0]);
+            var scope = AchievementScriptInterpreter.GetGlobalScope();
+
+            ParseErrorExpression error;
+            Assert.That(expr.IsTrue(scope, out error), Is.False);
+            Assert.That(error, Is.Null);
+        }
+
+        [Test]
+        public void TestIsTrueMemoryAccessorFunction()
+        {
+            var expr = new FunctionCallExpression("byte", new ExpressionBase[] { new IntegerConstantExpression(0x1234) });
+            var scope = AchievementScriptInterpreter.GetGlobalScope();
+
+            ParseErrorExpression error;
+            Assert.That(expr.IsTrue(scope, out error), Is.False);
+            Assert.That(error, Is.Not.Null);
+            Assert.That(error.Message, Is.EqualTo("Expression did not evaluate to a boolean result."));
+        }
+
+        [Test]
+        public void TestIsTrueUserFunctionReturningInteger()
+        {
+            var userFunc = Parse("function u() => 3");
+            var expr = new FunctionCallExpression("u", new ExpressionBase[0]);
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+            scope.AddFunction(userFunc);
+
+            ParseErrorExpression error;
+            Assert.That(expr.IsTrue(scope, out error), Is.False);
+            Assert.That(error, Is.Not.Null);
+            Assert.That(error.Message, Is.EqualTo("Expression did not evaluate to a boolean result."));
+        }
+
+        [Test]
+        public void TestIsTrueUserFunctionReturningBoolean()
+        {
+            var userFunc = Parse("function u() => always_true()");
+            var expr = new FunctionCallExpression("u", new ExpressionBase[0]);
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+            scope.AddFunction(userFunc);
+
+            ParseErrorExpression error;
+            Assert.That(expr.IsTrue(scope, out error), Is.True);
+            Assert.That(error, Is.Null);
         }
     }
 }

--- a/Tests/Parser/Internal/FunctionDefinitionExpressionTests.cs
+++ b/Tests/Parser/Internal/FunctionDefinitionExpressionTests.cs
@@ -174,25 +174,25 @@ namespace RATools.Test.Parser.Internal
         [Test]
         public void TestParseErrorInsideDefinition()
         {
-            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer("function func() { if (j) { j = i } }"));
+            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer("function func() { j = }"));
             tokenizer.Match("function");
             var expr = UserFunctionDefinitionExpression.Parse(tokenizer);
 
             Assert.That(expr, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)expr).Message, Is.EqualTo("Expected conditional statement following if"));
+            Assert.That(((ParseErrorExpression)expr).Message, Is.EqualTo("Unexpected end of script"));
         }
 
         [Test]
         public void TestParseErrorInsideDefinitionExpressionTokenizer()
         {
             var group = new ExpressionGroup();
-            var tokenizer = new ExpressionTokenizer(Tokenizer.CreateTokenizer("function func() { if (j) { j = i } }"), group);
+            var tokenizer = new ExpressionTokenizer(Tokenizer.CreateTokenizer("function func() { j = }"), group);
             tokenizer.Match("function");
             var expr = UserFunctionDefinitionExpression.Parse(tokenizer);
 
             Assert.That(expr, Is.InstanceOf<FunctionDefinitionExpression>());
-            Assert.That(group.ParseErrors.Count(), Is.EqualTo(1));
-            Assert.That(group.ParseErrors.First().Message, Is.EqualTo("Expected conditional statement following if"));
+            Assert.That(group.ParseErrors.Count(), Is.EqualTo(2));
+            Assert.That(group.ParseErrors.First().Message, Is.EqualTo("Unexpected character: }"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/IfExpressionTests.cs
+++ b/Tests/Parser/Internal/IfExpressionTests.cs
@@ -17,7 +17,7 @@ namespace RATools.Test.Parser.Internal
 
             var builder = new StringBuilder();
             expr.AppendString(builder);
-            Assert.That(builder.ToString(), Is.EqualTo("if (1)"));
+            Assert.That(builder.ToString(), Is.EqualTo("if (1) { ... }"));
             // NOTE: does not output Expressions block
         }
 

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Parser\Functions\LeaderboardFunctionTests.cs" />
     <Compile Include="Parser\Functions\DisableWhenFunctionTests.cs" />
     <Compile Include="Parser\Functions\AnyOfFunctionTests.cs" />
+    <Compile Include="Parser\Internal\BooleanConstantExpressionTests.cs" />
     <Compile Include="Parser\RichPresenceBuilderTests.cs" />
     <Compile Include="Parser\TriggerBuilderContextTests.cs" />
     <Compile Include="Parser\AchievementBuilderTests.cs" />

--- a/ViewModels/EditorViewModel.cs
+++ b/ViewModels/EditorViewModel.cs
@@ -37,6 +37,7 @@ namespace RATools.ViewModels
 
             foreach (var kvp in _themeColors)
                Style.SetCustomColor((int)kvp.Value, Theme.GetColor(kvp.Key));
+            Style.SetCustomColor((int)ExpressionType.BooleanConstant, Theme.GetColor(Theme.Color.EditorIntegerConstant));
             Style.Background = Theme.GetColor(Theme.Color.Background);
             Style.Foreground = Theme.GetColor(Theme.Color.Foreground);
             Style.Selection = Theme.GetColor(Theme.Color.EditorSelection);
@@ -83,6 +84,10 @@ namespace RATools.ViewModels
                         return;
 
                     Style.SetCustomColor((int)type, e.NewValue);
+
+                    if (type == ExpressionType.IntegerConstant)
+                        Style.SetCustomColor((int)ExpressionType.BooleanConstant, e.NewValue);
+
                     break;
             }
 


### PR DESCRIPTION
Adds explicit `true` and `false` constants. 

These can be used like any other constant: assigned to variables, passed to or returned from functions, and stored in dictionaries or arrays.

They can be used directly in if statements (as return values from functions). `always_true` and `always_false` also behave as `true`/`false` for this purpose (which closes #253), but will still generate a `1==0` condition when used to construct a trigger.

**NOTE**: scripts that already define these will generate errors. In most cases, that can be fixed simply by removing the definitions. In cases where that isn't sufficient, they can be renamed. As variables are case sensitive, TRUE and FALSE or True and False would fix the problem.
