### PR TITLE
allow using bcd() and prev() together

### DIFF
--- a/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -366,6 +366,16 @@ namespace RATools.Parser
                         return new ParseErrorExpression("Function used like a variable", expression);
 
                     return ExecuteAchievementExpression(operand, scope);
+
+                case ExpressionType.BooleanConstant:
+                {
+                    var context = scope.GetContext<TriggerBuilderContext>();
+                    if (((BooleanConstantExpression)expression).Value == true)
+                        context.Trigger.Add(AlwaysTrueFunction.CreateAlwaysTrueRequirement());
+                    else
+                        context.Trigger.Add(AlwaysFalseFunction.CreateAlwaysFalseRequirement());
+                    return null;
+                }
             }
 
             return new ParseErrorExpression("Cannot generate trigger from " + expression.Type, expression);

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -1145,5 +1145,16 @@ namespace RATools.Test.Parser
             Assert.That(d, Is.InstanceOf<IntegerConstantExpression>());
             Assert.That(((IntegerConstantExpression)d).Value, Is.EqualTo(1));
         }
+
+        [Test]
+        public void TestDeltaBCDComparison()
+        {
+            var parser = Parse("function f() => bcd(byte(0x1234))\n" +
+                               "achievement(\"T\", \"D\", 5, f() != prev(f()))\n");
+            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
+
+            var achievement = parser.Achievements.ElementAt(0);
+            Assert.That(GetRequirements(achievement), Is.EqualTo("byte(0x001234) != prev(byte(0x001234))"));
+        }
     }
 }

--- a/Tests/Parser/Functions/PrevPriorFunctionTests.cs
+++ b/Tests/Parser/Functions/PrevPriorFunctionTests.cs
@@ -83,6 +83,18 @@ namespace RATools.Test.Parser.Functions
         }
 
         [Test]
+        public void TestPrevBCD()
+        {
+            // bcd() can be factored out
+            var definition = Process("prev(bcd(byte(0x1234))) == 10");
+            Assert.That(definition, Is.EqualTo("d0xH001234=16"));
+
+            // bcd cannot be factored out
+            var parser = Parse("achievement(\"T\", \"D\", 5, prev(bcd(byte(0x1234))) != byte(0x1234))", false);
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:26 cannot apply multiple modifiers to memory accessor"));
+        }
+
+        [Test]
         public void TestPrevLargeMathematicChain()
         {
             var largeInput = new StringBuilder();

--- a/Tests/Parser/Internal/ComparisonExpressionTests.cs
+++ b/Tests/Parser/Internal/ComparisonExpressionTests.cs
@@ -75,17 +75,18 @@ namespace RATools.Test.Parser.Internal
         [TestCase("byte(1) - prev(byte(1)) == 3", "byte(1) - prev(byte(1)) == 3")] // value increases by 3
         [TestCase("0 + byte(1) + 0 == 9", "byte(1) == 9")] // 0s should be removed without reordering
         [TestCase("0 + byte(1) - 9 == 0", "byte(1) == 9")] // 9 should be moved to right hand side, then 0s removed
+        [TestCase("bcd(byte(1)) == 24", "byte(1) == 36")] // bcd should be factored out
+        [TestCase("byte(1) != bcd(byte(2))", "byte(1) != bcd(byte(2))")] // bcd cannot be factored out
+        [TestCase("bcd(byte(1)) != prev(bcd(byte(1)))", "byte(1) != prev(byte(1))")] // bcd should be factored out
         public void TestReplaceVariables(string input, string expected)
         {
             var tokenizer = Tokenizer.CreateTokenizer(input);
             var expr = ExpressionBase.Parse(new PositionalTokenizer(tokenizer));
 
-            var scope = new InterpreterScope();
+            var scope = new InterpreterScope(RATools.Parser.AchievementScriptInterpreter.GetGlobalScope());
             scope.Context = new RATools.Parser.TriggerBuilderContext();
             scope.AssignVariable(new VariableExpression("variable1"), new IntegerConstantExpression(98));
             scope.AssignVariable(new VariableExpression("variable2"), new IntegerConstantExpression(99));
-            scope.AddFunction(new MemoryAccessorFunction("byte", RATools.Data.FieldSize.Byte));
-            scope.AddFunction(new PrevPriorFunction("prev", Data.FieldType.PreviousValue));
 
             ExpressionBase result;
             if (!expr.ReplaceVariables(scope, out result))


### PR DESCRIPTION
```
function score() => bcd(word(0x1234))
achievement("Score!", "Get at least 50000 points", 5,
    trigger = score() >= 50000 && prev(score()) < 50000
)
```

Previously, `prev(bcd(word(0x1234)))` would have generated an error about `bcd(word(0x1234))` not being a memory accessor.

The optimizer already factors out the `bcd()` call so the `bcd(word(0x1234)) >= 50000` is optimized to `word(0x1234) >= 327680`, but this happens after the script has generated a valid achievement. With this change, the `bcd()` is optimized out when evaluating the comparison (before generating the achievement), allowing the code to generate `prev(word(0x1234)) < 327680`.