### PR TITLE
don't optimize trigger clause too early

### DIFF
--- a/Parser/Functions/TriggerWhenFunction.cs
+++ b/Parser/Functions/TriggerWhenFunction.cs
@@ -10,6 +10,13 @@ namespace RATools.Parser.Functions
         {
         }
 
+        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        {
+            // add another TriggerBuilderContext scope to prevent optimizing the expression at this time
+            var nestedScope = new InterpreterScope(scope) { Context = new TriggerBuilderContext() };
+            return base.BuildTrigger(context, nestedScope, functionCall);
+        }
+
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
             var comparison = GetParameter(scope, "comparison", out result);

--- a/Tests/Parser/Functions/FlagConditionFunctionTests.cs
+++ b/Tests/Parser/Functions/FlagConditionFunctionTests.cs
@@ -256,5 +256,22 @@ namespace RATools.Test.Parser.Functions
             Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.Trigger));
             Assert.That(requirements[0].HitCount, Is.EqualTo(0));
         }
+
+        [Test]
+        public void TestTriggerWhenOnceNever()
+        {
+            var requirements = Evaluate("trigger_when(once(byte(0x1234) == 56 && never(byte(0x2345) == 1)))");
+            Assert.That(requirements.Count, Is.EqualTo(2));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.ResetNextIf));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.Trigger));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(1));
+        }
     }
 }


### PR DESCRIPTION
fixes #272 

The ResetNextIf was being prematurely optimized into a ResetIf.