### PR TITLE
use invariant culture for parsing/generating float values

### DIFF
--- a/Data/Field.cs
+++ b/Data/Field.cs
@@ -109,7 +109,7 @@ namespace RATools.Data
                     break;
 
                 case FieldType.Float:
-                    builder.AppendFormat("{0:0.0#####}", Float);
+                    builder.AppendFormat(System.Globalization.CultureInfo.InvariantCulture, "{0:0.0#####}", Float);
                     break;
 
                 case FieldType.PreviousValue:
@@ -281,7 +281,7 @@ namespace RATools.Data
                     break;
 
                 case FieldType.Float:
-                    builder.AppendFormat("f{0:0.0#####}", Float);
+                    builder.AppendFormat(System.Globalization.CultureInfo.InvariantCulture, "f{0:0.0#####}", Float);
                     return;
 
                 default:
@@ -492,7 +492,7 @@ namespace RATools.Data
             }
 
             var token = tokenizer.ReadNumber();
-            var value = float.Parse(token.ToString());
+            var value = float.Parse(token.ToString(), System.Globalization.CultureInfo.InvariantCulture);
             if (isNegative)
                 value = -value;
 

--- a/Parser/Internal/ExpressionBase.cs
+++ b/Parser/Internal/ExpressionBase.cs
@@ -398,7 +398,7 @@ namespace RATools.Parser.Internal
                     }
 
                     float floatValue;
-                    if (!float.TryParse(number, out floatValue))
+                    if (!float.TryParse(number, System.Globalization.NumberStyles.AllowDecimalPoint, System.Globalization.CultureInfo.InvariantCulture, out floatValue))
                         return new ParseErrorExpression("Number too large");
 
                     var floatExpression = new FloatConstantExpression(floatValue);

--- a/Parser/Internal/FloatConstantExpression.cs
+++ b/Parser/Internal/FloatConstantExpression.cs
@@ -36,7 +36,7 @@ namespace RATools.Parser.Internal
         /// </summary>
         internal override void AppendString(StringBuilder builder)
         {
-            builder.AppendFormat("{0:0.0#####}", Value);
+            builder.AppendFormat(System.Globalization.CultureInfo.InvariantCulture, "{0:0.0#####}", Value);
         }
 
         /// <summary>

--- a/Parser/LocalAssets.cs
+++ b/Parser/LocalAssets.cs
@@ -307,7 +307,7 @@ namespace RATools.Parser
             }
 
             if (version > 0.30)
-                Version = String.Format("{0:F2}", version);
+                Version = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:F2}", version);
 
             using (var writer = new StreamWriter(_fileSystemService.CreateFile(_filename)))
             {

--- a/Parser/TriggerBuilderContext.cs
+++ b/Parser/TriggerBuilderContext.cs
@@ -82,7 +82,7 @@ namespace RATools.Parser
                             // value is a complex number, output the parts
                             builder.Append(term.field.Value);
                             builder.Append('*');
-                            builder.Append(term.multiplier);
+                            builder.AppendFormat(System.Globalization.CultureInfo.InvariantCulture, "{0:0.0#####}", term.multiplier);
                         }
                         break;
 
@@ -91,7 +91,16 @@ namespace RATools.Parser
                         if (term.multiplier != 1.0)
                         {
                             builder.Append('*');
-                            builder.Append(term.multiplier);
+
+                            if ((term.multiplier % 1) == 0)
+                            {
+                                // value is a whole number, just output it
+                                builder.Append((int)term.multiplier);
+                            }
+                            else
+                            {
+                                builder.AppendFormat(System.Globalization.CultureInfo.InvariantCulture, "{0:0.0#####}", term.multiplier);
+                            }
                         }
                         break;
                 }

--- a/Tests/Parser/Internal/FloatConstantExpressionTests.cs
+++ b/Tests/Parser/Internal/FloatConstantExpressionTests.cs
@@ -1,5 +1,7 @@
-﻿using NUnit.Framework;
+﻿using Jamiras.Components;
+using NUnit.Framework;
 using RATools.Parser.Internal;
+using RATools.Tests.Data;
 using System.Text;
 
 namespace RATools.Test.Parser.Internal
@@ -7,6 +9,31 @@ namespace RATools.Test.Parser.Internal
     [TestFixture]
     class FloatConstantExpressionTests
     {
+        [Test]
+        [TestCase("2.0", 2.0f)]
+        [TestCase("3.14", 3.14f)]
+        [TestCase("-6.12345", -6.12345f)]
+        public void TestParseExpression(string input, float expected)
+        {
+            var expr = ExpressionBase.Parse(new PositionalTokenizer(Tokenizer.CreateTokenizer(input)));
+            Assert.That(expr, Is.InstanceOf<FloatConstantExpression>());
+            Assert.That(((FloatConstantExpression)expr).Value, Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase("2.0", 2.0f)]
+        [TestCase("3.14", 3.14f)]
+        [TestCase("-6.12345", -6.12345f)]
+        public void TestParseExpressionCulture(string input, float expected)
+        {
+            using (var cultureOverride = new CultureOverride("fr-FR"))
+            {
+                var expr = ExpressionBase.Parse(new PositionalTokenizer(Tokenizer.CreateTokenizer(input)));
+                Assert.That(expr, Is.InstanceOf<FloatConstantExpression>());
+                Assert.That(((FloatConstantExpression)expr).Value, Is.EqualTo(expected));
+            }
+        }
+
         [Test]
         [TestCase(2.0, "2.0")]
         [TestCase(3.14, "3.14")]
@@ -18,6 +45,22 @@ namespace RATools.Test.Parser.Internal
             var builder = new StringBuilder();
             expr.AppendString(builder);
             Assert.That(builder.ToString(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase(2.0, "2.0")]
+        [TestCase(3.14, "3.14")]
+        [TestCase(-6.12345, "-6.12345")]
+        public void TestAppendStringCulture(double value, string expected)
+        {
+            using (var cultureOverride = new CultureOverride("fr-FR"))
+            {
+                var expr = new FloatConstantExpression((float)value);
+
+                var builder = new StringBuilder();
+                expr.AppendString(builder);
+                Assert.That(builder.ToString(), Is.EqualTo(expected));
+            }
         }
     }
 }

--- a/Tests/Parser/RegressionTests.cs
+++ b/Tests/Parser/RegressionTests.cs
@@ -191,7 +191,7 @@ namespace RATools.Test.Parser
                         {
                             fileWriter.WriteLine("=== Rich Presence ===");
 
-                            var minimumVersion = Double.Parse(localAchievements.Version);
+                            var minimumVersion = Double.Parse(localAchievements.Version, System.Globalization.NumberFormatInfo.InvariantInfo);
                             if (minimumVersion < 0.80)
                             {
                                 interpreter.RichPresenceBuilder.DisableBuiltInMacros = true;

--- a/Tests/Parser/TriggerBuilderContextTests.cs
+++ b/Tests/Parser/TriggerBuilderContextTests.cs
@@ -4,6 +4,7 @@ using RATools.Data;
 using RATools.Parser;
 using RATools.Parser.Functions;
 using RATools.Parser.Internal;
+using RATools.Tests.Data;
 
 namespace RATools.Test.Parser
 {
@@ -51,7 +52,7 @@ namespace RATools.Test.Parser
         [TestCase("byte(0x1234)", "0xH001234")]
         [TestCase("byte(0x1234) * 10", "0xH001234*10")]
         [TestCase("byte(0x1234) / 10", "0xH001234*0.1")]
-        [TestCase("byte(0x1234) * 10 / 3", "0xH001234*3.33333333333333")]
+        [TestCase("byte(0x1234) * 10 / 3", "0xH001234*3.333333")]
         [TestCase("byte(0x1234) + 10", "0xH001234_v10")]
         [TestCase("byte(0x1234) - 10", "0xH001234_v-10")]
         [TestCase("(byte(0) + byte(1)) * 10", "0xH000000*10_0xH000001*10")]
@@ -93,6 +94,29 @@ namespace RATools.Test.Parser
             var result = TriggerBuilderContext.GetValueString(expression, scope, out error);
             Assert.That(error, Is.Null);
             Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase("byte(0x1234) / 10", "0xH001234*0.1")]
+        [TestCase("byte(0x1234) * 10 / 3", "0xH001234*3.333333")]
+        [TestCase("(byte(0) + byte(1)) / 10", "0xH000000*0.1_0xH000001*0.1")]
+        [TestCase("byte(0x1234) * 2.0", "0xH001234*2")]
+        [TestCase("byte(0x1234) / 2", "0xH001234*0.5")]
+        [TestCase("byte(0x1234) * 2 / 100", "0xH001234*0.02")]
+        [TestCase("(byte(0x1234) / (2 * 20)) * 100", "0xH001234*2.5")]
+        public void TestGetValueStringCulture(string input, string expected)
+        {
+            using (var cultureOverride = new CultureOverride("fr-FR"))
+            {
+                ExpressionBase error;
+                InterpreterScope scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+                scope.Context = new TriggerBuilderContext();
+
+                var expression = Parse(input);
+                var result = TriggerBuilderContext.GetValueString(expression, scope, out error);
+                Assert.That(error, Is.Null);
+                Assert.That(result, Is.EqualTo(expected));
+            }
         }
     }
 }

--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -1178,7 +1178,7 @@ namespace RATools.ViewModels
                     else if (operand.Length > 2 && operand[1] == '.' && operand[0] == '0' && builder[builder.Length - 2] == '*')
                     {
                         bool isDivisor = false;
-                        var f = Double.Parse(operand);
+                        var f = Double.Parse(operand, System.Globalization.NumberFormatInfo.InvariantInfo);
                         if (f > 0.0)
                         {
                             var divisor = 1 / f;


### PR DESCRIPTION
fixes #266 

Updates all occurrences of double/float parse/tryparse and converting floats/doubles to strings to use the [InvariantCulture](https://docs.microsoft.com/en-us/dotnet/api/system.globalization.numberformatinfo.invariantinfo?view=net-6.0).