### PR TITLE
fix New Script for game 14772

### DIFF
--- a/Data/Requirement.cs
+++ b/Data/Requirement.cs
@@ -205,7 +205,7 @@ namespace RATools.Data
         private void AppendRepeatedCondition(StringBuilder builder, NumberFormat numberFormat,
             string addSources, string subSources, string addHits, string andNext, string addAddress, string resetNextIf)
         {
-            if (HitCount == 0)
+            if (HitCount == 0 && addHits == null)
             {
                 if (!string.IsNullOrEmpty(andNext) && andNext[0] != '(' &&
                     (andNext.Contains(" && ") || andNext.Contains(" || ")))

--- a/Data/RequirementEx.cs
+++ b/Data/RequirementEx.cs
@@ -221,30 +221,24 @@ namespace RATools.Data
                 }
             }
 
-            while (definition.Length > wrapWidth)
+            while (definition.Length > width)
             {
-                var index = width;
-                while (index > 0 && definition[index] != ' ')
-                    index--;
+                if (width > 0)
+                {
+                    var index = width;
+                    while (index > 0 && definition[index] != ' ')
+                        index--;
 
-                builder.Append(definition.ToString(), 0, index);
-                builder.AppendLine();
-                builder.Append(' ', indent);
-                definition.Remove(0, index);
-                width = wrapWidth - indent;
-            }
+                    builder.Append(definition.ToString(), 0, index);
+                    definition.Remove(0, index);
+                }
 
-            if (width - definition.Length < 0)
-            {
                 builder.AppendLine();
                 builder.Append(' ', indent);
                 width = wrapWidth - indent;
             }
-            else
-            {
-                width -= definition.Length;
-            }
 
+            width -= definition.Length;
             builder.Append(definition.ToString());
         }
 

--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -1840,6 +1840,10 @@ namespace RATools.Parser
                 {
                     if (requirementEx.Requirements.Any(r => r.Type == RequirementType.OrNext))
                     {
+                        // MeasuredIf only applies to the current group, don't split it up
+                        if (requirementEx.Requirements.Last().Type == RequirementType.MeasuredIf)
+                            continue;
+
                         if (orNextGroup != null)
                             return;
 

--- a/Parser/Functions/MeasuredFunction.cs
+++ b/Parser/Functions/MeasuredFunction.cs
@@ -71,14 +71,15 @@ namespace RATools.Parser.Functions
             if (!TriggerBuilderContext.ProcessAchievementConditions(builder, when, scope, out result))
                 return new ParseErrorExpression("when did not evaluate to a valid comparison", when) { InnerError = (ParseErrorExpression)result };
 
-            if (builder.AlternateRequirements.Count > 0)
-                return new ParseErrorExpression(Name.Name + " does not support ||'d conditions", when);
+            error = builder.CollapseForSubClause();
+            if (error != null)
+                return error;
 
             if (builder.CoreRequirements.Count != 1 || builder.CoreRequirements.First().Evaluate() != true)
             {
                 foreach (var requirement in builder.CoreRequirements)
                 {
-                    if (requirement.Type == RequirementType.None)
+                    if (requirement.Type == RequirementType.None || requirement.Type == RequirementType.AndNext)
                         requirement.Type = RequirementType.MeasuredIf;
 
                     context.Trigger.Add(requirement);

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -581,6 +581,8 @@ namespace RATools.Test.Parser
                   "tally(2, once(word(0x001234) >= 284 && word(0x001234) <= 301), always_false())")] // always_false() inside once() is optimized out, but a new one must be added for the tally since very subclause has a hit target
         [TestCase("tally(2, once(byte(0x1234) == 1) || once(byte(0x1234) == 2) || once(byte(0x1234) == 3))",
                   "repeated(2, once(byte(0x001234) == 1) || once(byte(0x001234) == 2) || once(byte(0x001234) == 3) || always_false())")] // always_false has to be added since every subclause has a hit target and should not be eliminated
+        [TestCase("measured(byte(0x1234) == 120, when = (byte(0x2345) == 6 || byte(0x2346) == 7))", // OrNext in MeasuredIf should not be split into alts
+                  "measured(byte(0x001234) == 120, when=(byte(0x002345) == 6 || byte(0x002346) == 7))")]
         public void TestOptimize(string input, string expected)
         {
             var achievement = CreateAchievement(input);

--- a/Tests/Parser/Functions/MeasuredFunctionTests.cs
+++ b/Tests/Parser/Functions/MeasuredFunctionTests.cs
@@ -167,6 +167,28 @@ namespace RATools.Test.Parser.Functions
         }
 
         [Test]
+        public void TestComparisonWhenMultipleOr()
+        {
+            var requirements = Evaluate("measured(byte(0x1234) == 120, when = (byte(0x2345) == 6 || byte(0x2346) == 7))");
+            Assert.That(requirements.Count, Is.EqualTo(3));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("120"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.Measured));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("6"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.OrNext));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("byte(0x002346)"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("7"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.MeasuredIf));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(0));
+        }
+
+        [Test]
         public void TestComparisonFormatRaw()
         {
             var requirements = Evaluate("measured(byte(0x1234) == 120, format=\"raw\")");

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -378,6 +378,37 @@ namespace RATools.Test.Parser.Functions
         }
 
         [Test]
+        public void TestComplexCoreAndAlt()
+        {
+            var requirements = Evaluate("repeated(4, byte(0x1234) == 1 && byte(0x2345) == 2 && (byte(0x3456) == 3 || (byte(0x4567) == 4 && byte(0x5678) == 5))");
+            Assert.That(requirements.Count, Is.EqualTo(5));
+            // complex alt clause will be first
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x004567)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("4"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.AndNext));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x005678)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("5"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.OrNext));
+            // then other alt clause
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("byte(0x003456)"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("3"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.AndNext));
+            // core clauses will be last
+            Assert.That(requirements[3].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[3].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[3].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[3].Type, Is.EqualTo(RequirementType.AndNext));
+            Assert.That(requirements[4].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[4].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[4].Right.ToString(), Is.EqualTo("2"));
+            Assert.That(requirements[4].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[4].HitCount, Is.EqualTo(4));
+        }
+
+        [Test]
         public void TestNestedTally()
         {
             var errorMessage = "tally not allowed in subclause";


### PR DESCRIPTION
Attempting to generate a new script for game 14772 was throwing an "Unhandled exception: Value must be positive." error. This was due to the line wrapping code for a complex expression not adjusting for the joiner (&&) correctly.

Additionally, that particular game used complex AndNext/OrNext chains that couldn't be converted back using the existing code. I've expanded the code to support them.

Finally, it used OrNext within a MeasuredIf, which was being split into alt groups. MeasuredIf only applies to the current group, so I've modified the code to not split it up.