### PR TITLE
ensure source collection is not modified when building RequirementEx

### DIFF
--- a/Parser/AchievementBuilder.cs
+++ b/Parser/AchievementBuilder.cs
@@ -2535,6 +2535,10 @@ namespace RATools.Parser
 
                 if (!hasAndNext)
                 {
+                    // ignore always false alt groups
+                    if (alt.All(r => r.Evaluate() == false))
+                        continue;
+
                     // single clause, just append it
                     newCore.AddRange(alt);
                 }

--- a/Tests/Data/FieldTests.cs
+++ b/Tests/Data/FieldTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Globalization;
 using System.Text;
 
-namespace RATools.Tests.Data
+namespace RATools.Test.Data
 {
     [TestFixture]
     class FieldTests

--- a/Tests/Data/RequirementExTests.cs
+++ b/Tests/Data/RequirementExTests.cs
@@ -1,0 +1,54 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Data;
+using RATools.Parser;
+using System.Text;
+
+namespace RATools.Test.Data
+{
+    [TestFixture]
+    class RequirementExTests
+    {
+        [Test]
+        [TestCase("0xH001234=1", "byte(0x001234) == 1")]
+        [TestCase("0xH001234=1_0xH002345=2", "byte(0x001234) == 1|byte(0x002345) == 2")]
+        [TestCase("A:0xH001234=0_0xH002345=2", "(byte(0x001234) + byte(0x002345)) == 2")]
+        [TestCase("A:0xH001234=0_R:0xH002345=2", "never((byte(0x001234) + byte(0x002345)) == 2)")]
+        [TestCase("I:0x 001234_0xH002345=2", "byte(word(0x001234) + 0x002345) == 2")]
+        [TestCase("O:0xH001234=1_0xH002345=2", "(byte(0x001234) == 1 || byte(0x002345) == 2)")]
+        [TestCase("O:0xH001234=1_0=1", "byte(0x001234) == 1")]
+        [TestCase("O:0=1_0xH002345=2", "byte(0x002345) == 2")]
+        [TestCase("O:0xH001234=1_0=1.15.", "repeated(15, byte(0x001234) == 1)")]
+        [TestCase("O:0=1_0xH002345=2.15.", "repeated(15, byte(0x002345) == 2)")]
+        [TestCase("O:0=1.12._0xH002345=2.15.", "repeated(15, byte(0x002345) == 2)")]
+        [TestCase("O:0xH001234=1.15._0=1", "repeated(15, byte(0x001234) == 1)")]
+        [TestCase("O:0=1.15._0xH002345=2", "byte(0x002345) == 2")]
+        [TestCase("N:0xH001234=1_0xH002345=2", "(byte(0x001234) == 1 && byte(0x002345) == 2)")]
+        [TestCase("N:0xH001234=1_1=1", "byte(0x001234) == 1")]
+        [TestCase("N:1=1_0xH002345=2", "byte(0x002345) == 2")]
+        [TestCase("N:0xH001234=1_1=1.15.", "repeated(15, byte(0x001234) == 1)")]
+        [TestCase("N:1=1_0xH002345=2.15.", "repeated(15, byte(0x002345) == 2)")]
+        [TestCase("N:0xH001234=1.15._1=1", "repeated(15, byte(0x001234) == 1)")]
+        [TestCase("N:1=1.15._0xH002345=2", "(repeated(15, always_true()) && byte(0x002345) == 2)")]
+        public void TestCombine(string input, string expected)
+        {
+            var achievement = new AchievementBuilder();
+            achievement.ParseRequirements(Tokenizer.CreateTokenizer(input));
+            var groups = RequirementEx.Combine(achievement.CoreRequirements);
+
+            var builder = new StringBuilder();
+            foreach (var group in groups)
+            {
+                if (builder.Length > 0)
+                    builder.Append('|');
+
+                group.AppendString(builder, NumberFormat.Decimal);
+            }
+
+            Assert.That(builder.ToString(), Is.EqualTo(expected));
+
+            // make sure we didn't modify the source requirements
+            Assert.That(achievement.SerializeRequirements(), Is.EqualTo(input));
+        }
+    }
+}

--- a/Tests/Data/RequirementTests.cs
+++ b/Tests/Data/RequirementTests.cs
@@ -2,7 +2,7 @@
 using RATools.Data;
 using System.Text;
 
-namespace RATools.Tests.Data
+namespace RATools.Test.Data
 {
     [TestFixture]
     class RequirementTests

--- a/Tests/Parser/Internal/FloatConstantExpressionTests.cs
+++ b/Tests/Parser/Internal/FloatConstantExpressionTests.cs
@@ -1,7 +1,7 @@
 ﻿using Jamiras.Components;
 using NUnit.Framework;
 using RATools.Parser.Internal;
-using RATools.Tests.Data;
+using RATools.Test.Data;
 using System.Text;
 
 namespace RATools.Test.Parser.Internal

--- a/Tests/Parser/LocalAchievementsTests.cs
+++ b/Tests/Parser/LocalAchievementsTests.cs
@@ -3,7 +3,7 @@ using Moq;
 using NUnit.Framework;
 using RATools.Data;
 using RATools.Parser;
-using RATools.Tests.Data;
+using RATools.Test.Data;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/Tests/Parser/TriggerBuilderContextTests.cs
+++ b/Tests/Parser/TriggerBuilderContextTests.cs
@@ -1,10 +1,8 @@
 ﻿using Jamiras.Components;
 using NUnit.Framework;
-using RATools.Data;
 using RATools.Parser;
-using RATools.Parser.Functions;
 using RATools.Parser.Internal;
-using RATools.Tests.Data;
+using RATools.Test.Data;
 
 namespace RATools.Test.Parser
 {

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -129,6 +129,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Data\RequirementExTests.cs" />
     <Compile Include="Data\RequirementTests.cs" />
     <Compile Include="Data\FieldTests.cs" />
     <Compile Include="Parser\Functions\PrevPriorFunctionTests.cs" />


### PR DESCRIPTION
Fixes #277

The changes made in #260 were modifying the source conditions. As a result, an OrNext that was eliminated when removing the `always_false()` would not be present in a future evaluation of the complex condition, resulting in the `always_false()` being AND'ed to the preceding conditions, and then the entire alt group simplifies down to `always_false()`.

This updates the logic introduced in #260 to modify a copy of the requirement. 