### PR TITLE
don't preserve badge 00000 when merging

### DIFF
--- a/Tests/ViewModels/AssetViewModelBaseTests.cs
+++ b/Tests/ViewModels/AssetViewModelBaseTests.cs
@@ -609,6 +609,44 @@ namespace RATools.Test.ViewModels
         }
 
         [Test]
+        public void TestRefreshGeneratedSameAsCoreAndLocalExceptBadge()
+        {
+            var vmAsset = new AssetViewModelBaseHarness();
+            vmAsset.Published.Asset = new TestAsset(1234, "Title", "Description")
+            {
+                BadgeName = "Badge"
+            };
+            vmAsset.Local.Asset = new TestAsset(1234, "Title", "Description")
+            {
+                BadgeName = "00000"
+            };
+            vmAsset.Generated.Asset = new TestAsset(1234, "Title", "Description")
+            {
+                BadgeName = "0",
+                SourceLine = 65
+            };
+
+            vmAsset.Refresh();
+
+            Assert.That(vmAsset.Id, Is.EqualTo(1234));
+            Assert.That(vmAsset.Title, Is.EqualTo("Title"));
+            Assert.That(vmAsset.Description, Is.EqualTo("Description"));
+            Assert.That(vmAsset.IsTitleModified, Is.False);
+            Assert.That(vmAsset.IsDescriptionModified, Is.False);
+            Assert.That(vmAsset.BadgeName, Is.EqualTo("Badge"));
+            Assert.That(vmAsset.CompareState, Is.EqualTo(GeneratedCompareState.Same));
+            Assert.That(vmAsset.ModificationMessage, Is.Null);
+            Assert.That(vmAsset.IsGenerated, Is.True);
+            Assert.That(vmAsset.CanUpdate, Is.False);
+            Assert.That(vmAsset.Other, Is.Null);
+            Assert.That(vmAsset.SourceLine, Is.EqualTo(65));
+            Assert.That(vmAsset.Triggers.Count(), Is.EqualTo(1));
+            Assert.That(vmAsset.Triggers.ElementAt(0), Is.Not.InstanceOf<TriggerComparisonViewModel>());
+            Assert.That(vmAsset.Triggers.ElementAt(0).Label, Is.EqualTo("Trigger1234"));
+            Assert.That(vmAsset.TriggerSource, Is.EqualTo("Generated (Same as Core and Local)"));
+        }
+
+        [Test]
         public void TestRefreshGeneratedSameAsUnofficialAndLocal()
         {
             var vmAsset = new AssetViewModelBaseHarness();

--- a/ViewModels/AssetViewModelBase.cs
+++ b/ViewModels/AssetViewModelBase.cs
@@ -377,6 +377,18 @@ namespace RATools.ViewModels
             return null;
         }
 
+        private static bool IsValidBadgeName(string badgeName)
+        {
+            if (String.IsNullOrEmpty(badgeName))
+                return false;
+            if (badgeName == "0")
+                return false;
+            if (badgeName == "00000")
+                return false;
+
+            return true;
+        }
+
         public override void Refresh()
         {
             var generatedAsset = Generated.Asset;
@@ -400,11 +412,11 @@ namespace RATools.ViewModels
             else
                 Id = Published.Id;
 
-            if (!String.IsNullOrEmpty(Generated.BadgeName) && Generated.BadgeName != "0")
+            if (IsValidBadgeName(Generated.BadgeName))
                 BadgeName = Generated.BadgeName;
-            else if (!String.IsNullOrEmpty(Local.BadgeName) && Local.BadgeName != "0")
+            else if (IsValidBadgeName(Local.BadgeName))
                 BadgeName = Local.BadgeName;
-            else if (!String.IsNullOrEmpty(Published.BadgeName) && Published.BadgeName != "0")
+            else if (IsValidBadgeName(Published.BadgeName))
                 BadgeName = Published.BadgeName;
             else
                 BadgeName = null;


### PR DESCRIPTION
When writing a local achievement without a badge, 00000 is written to the file. After assigning a badge and publishing the achievement, the published badge should be recognized and used. However, the logic was only checking for "0", not "00000".