### PR TITLE
allow alt groups to match when their index changes

### DIFF
--- a/ViewModels/RequirementGroupViewModel.cs
+++ b/ViewModels/RequirementGroupViewModel.cs
@@ -3,6 +3,7 @@ using Jamiras.ViewModels;
 using RATools.Data;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace RATools.ViewModels
 {
@@ -304,6 +305,39 @@ namespace RATools.ViewModels
         {
             foreach (var requirement in Requirements)
                 requirement.OnShowHexValuesChanged(e);
+        }
+
+        public bool RequirementsAreEqual(RequirementGroupViewModel that)
+        {
+            // quick check to make sure the same number of requirements exist
+            if (Requirements.Count() != that.Requirements.Count())
+                return false;
+
+            // convert to requirement clauses and compare
+            var requirementExs = RequirementEx.Combine(Requirements.Select(r => r.Requirement));
+            var compareRequirementExs = RequirementEx.Combine(that.Requirements.Select(r => r.Requirement));
+
+            if (requirementExs.Count != compareRequirementExs.Count)
+                return false;
+
+            foreach (var requirementEx in requirementExs)
+            {
+                bool matched = false;
+                for (int i = 0; i < compareRequirementExs.Count; i++)
+                {
+                    if (compareRequirementExs[i] == requirementEx)
+                    {
+                        compareRequirementExs.RemoveAt(i);
+                        matched = true;
+                        break;
+                    }
+                }
+
+                if (!matched)
+                    return false;
+            }
+
+            return true;
         }
     }
 }

--- a/ViewModels/TriggerComparisonViewModel.cs
+++ b/ViewModels/TriggerComparisonViewModel.cs
@@ -15,7 +15,7 @@ namespace RATools.ViewModels
 
             foreach (var triggerGroup in trigger.Groups)
             {
-                var compareTriggerGroup = compareTriggerGroups.FirstOrDefault(t => t.Label == triggerGroup.Label);
+                var compareTriggerGroup = compareTriggerGroups.FirstOrDefault(t => t.RequirementsAreEqual(triggerGroup));
                 if (compareTriggerGroup != null)
                 {
                     groups.Add(new RequirementGroupViewModel(triggerGroup.Label,


### PR DESCRIPTION
Improves comparison display of triggers when an alt is inserted into the beginning or middle of a logical chain.