### PR TITLE
better diff matching when an AndNext/OrNext chain is split up

### DIFF
--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -184,6 +184,9 @@
     <Compile Include="Parser\RegressionTests.cs" />
     <Compile Include="ViewModels\AssetViewModelBaseTests.cs" />
     <Compile Include="ViewModels\GameViewModelTests.cs" />
+    <Compile Include="ViewModels\RequirementGroupViewModelTests.cs" />
+    <Compile Include="ViewModels\RequirementComparisonViewModelTests.cs" />
+    <Compile Include="ViewModels\RequirementViewModelTests.cs" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(SolutionFileName)' == 'RATools + Core.sln'">

--- a/Tests/ViewModels/RequirementComparisonViewModelTests.cs
+++ b/Tests/ViewModels/RequirementComparisonViewModelTests.cs
@@ -1,0 +1,75 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Data;
+using RATools.Parser;
+using RATools.ViewModels;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RATools.Test.ViewModels
+{
+    [TestFixture]
+    class RequirementComparisonViewModelTests
+    {
+        [Test]
+        [TestCase("1=1", "2=2", "always_true()", "always_true()", false)]
+        [TestCase("1=1", "0=1", "always_true()", "always_false()", true)]
+        [TestCase("0xH1234=7", "0xH1234=7", "byte(0x001234) == 7", "byte(0x001234) == 7", false)]
+        [TestCase("0xH1234=7", "0xH2345=7", "byte(0x001234) == 7", "byte(0x002345) == 7", true)]
+        [TestCase("0xH1234=7", "0xH1234=6", "byte(0x001234) == 7", "byte(0x001234) == 6", true)]
+        [TestCase("0xH1234=7", "0x 1234=7", "byte(0x001234) == 7", "word(0x001234) == 7", true)]
+        [TestCase("0xH1234=7", "R:0xH1234=7", "byte(0x001234) == 7", "never(byte(0x001234) == 7)", true)]
+        [TestCase("0xH1234=7", "0xH1234=7.1.", "byte(0x001234) == 7", "once(byte(0x001234) == 7)", true)]
+        public void TestDefinitions(string leftSerialized, string rightSerialized, 
+            string expectedDefinition, string expectedOtherDefinition, bool expectedModified)
+        {
+            var notes = new Dictionary<int, string>();
+
+            var builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer(leftSerialized));
+            var requirement = builder.ToAchievement().CoreRequirements.First();
+
+            builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer(rightSerialized));
+            var compareRequirement = builder.ToAchievement().CoreRequirements.First();
+
+            var vmRequirement = new RequirementComparisonViewModel(requirement, compareRequirement, NumberFormat.Decimal, notes);
+
+            Assert.That(vmRequirement.Definition, Is.EqualTo(expectedDefinition));
+            Assert.That(vmRequirement.OtherDefinition, Is.EqualTo(expectedOtherDefinition));
+            Assert.That(vmRequirement.IsModified, Is.EqualTo(expectedModified));
+        }
+
+        [Test]
+        public void TestAddedRequirement()
+        {
+            var notes = new Dictionary<int, string>();
+
+            var builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer("0xH1234=7"));
+            var requirement = builder.ToAchievement().CoreRequirements.First();
+
+            var vmRequirement = new RequirementComparisonViewModel(requirement, null, NumberFormat.Decimal, notes);
+
+            Assert.That(vmRequirement.Definition, Is.EqualTo("byte(0x001234) == 7"));
+            Assert.That(vmRequirement.OtherDefinition, Is.EqualTo(""));
+            Assert.That(vmRequirement.IsModified, Is.True);
+        }
+
+        [Test]
+        public void TestRemovedRequirement()
+        {
+            var notes = new Dictionary<int, string>();
+
+            var builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer("0xH1234=7"));
+            var requirement = builder.ToAchievement().CoreRequirements.First();
+
+            var vmRequirement = new RequirementComparisonViewModel(null, requirement, NumberFormat.Decimal, notes);
+
+            Assert.That(vmRequirement.Definition, Is.EqualTo(""));
+            Assert.That(vmRequirement.OtherDefinition, Is.EqualTo("byte(0x001234) == 7"));
+            Assert.That(vmRequirement.IsModified, Is.True);
+        }
+    }
+}

--- a/Tests/ViewModels/RequirementGroupViewModelTests.cs
+++ b/Tests/ViewModels/RequirementGroupViewModelTests.cs
@@ -1,0 +1,69 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Data;
+using RATools.Parser;
+using RATools.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RATools.Test.ViewModels
+{
+    [TestFixture]
+    class RequirementGroupViewModelTests
+    {
+        [Test]
+        [TestCase("1=1", "2=2", "always_true()|always_true()")]
+        [TestCase("1=1", "0=1", "always_true()|always_false()")]
+        [TestCase("0xH1234=7", "0xH1234=7", "byte(0x001234) == 7|byte(0x001234) == 7")]
+        [TestCase("0xH1234=7", "0xH2345=7", "byte(0x001234) == 7|byte(0x002345) == 7")]
+        [TestCase("0xH1234=7", "0xH1234=6", "byte(0x001234) == 7|byte(0x001234) == 6")]
+        [TestCase("0xH1234=7", "0x 1234=7", "byte(0x001234) == 7|word(0x001234) == 7")]
+        [TestCase("0xH1234=7", "R:0xH1234=7", "byte(0x001234) == 7|never(byte(0x001234) == 7)")]
+        [TestCase("0xH1234=7", "0xH1234=7.1.", "byte(0x001234) == 7|once(byte(0x001234) == 7)")]
+        [TestCase("0xH1234=7_0xH1235=6", "0xH1234=6_R:0xH1235=7", // match by address
+            "byte(0x001234) == 7|byte(0x001234) == 6\nbyte(0x001235) == 6|never(byte(0x001235) == 7)")]
+        [TestCase("0xH1234=7_0xH1235=6", "0xH1234=6_R:0x 1235=7", // just a little too different
+            "byte(0x001234) == 7|byte(0x001234) == 6\nbyte(0x001235) == 6|\n|never(word(0x001235) == 7)")]
+        [TestCase("0xH1234=7_0xH1235=6", "0xH1234<7_0xH1238=2", // match first by address, second is unique
+            "byte(0x001234) == 7|byte(0x001234) < 7\nbyte(0x001235) == 6|\n|byte(0x001238) == 2")]
+        [TestCase("0xH1234=7_0xH1235=6", "0xH1235=6_0xH1234=7", // order changed (use left order)
+            "byte(0x001234) == 7|byte(0x001234) == 7\nbyte(0x001235) == 6|byte(0x001235) == 6")]
+        [TestCase("0xH1234=7_0xH1235=6", "0xH1235=6", // item added
+            "byte(0x001234) == 7|\nbyte(0x001235) == 6|byte(0x001235) == 6")]
+        [TestCase("0xH1234=7", "0xH1235=6_0xH1234=7", // item removed (keep original position of removed item)
+            "|byte(0x001235) == 6\nbyte(0x001234) == 7|byte(0x001234) == 7")]
+        [TestCase("P:0xH1234=7_P:0xH1235=6", "O:0xH1234=7_P:0xH1235=6", // unless(a||b) => unless(a) && unless(b)
+            "unless(byte(0x001234) == 7)|OrNext byte(0x001234) == 7\nunless(byte(0x001235) == 6)|unless(byte(0x001235) == 6)")]
+        [TestCase("0xH1234=7_0xH1235=6", "N:0xH1234=7_0xH1235=6", // AndNext a,b => a,b
+            "byte(0x001234) == 7|AndNext byte(0x001234) == 7\nbyte(0x001235) == 6|byte(0x001235) == 6")]
+        public void TestDiff(string leftSerialized, string rightSerialized, string expected)
+        {
+            var notes = new Dictionary<int, string>();
+
+            var builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer(leftSerialized));
+            var leftRequirements = builder.ToAchievement().CoreRequirements;
+
+            builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer(rightSerialized));
+            var rightRequirements = builder.ToAchievement().CoreRequirements;
+
+            var vmRequirementGroup = new RequirementGroupViewModel("Group", leftRequirements, rightRequirements, NumberFormat.Decimal, notes);
+
+            var strBuilder = new StringBuilder();
+            foreach (var vmRequirement in vmRequirementGroup.Requirements)
+            {
+                var vmComparison = vmRequirement as RequirementComparisonViewModel;
+                strBuilder.Append(vmComparison.Definition);
+                strBuilder.Append('|');
+                strBuilder.Append(vmComparison.OtherDefinition);
+                strBuilder.Append('\n');
+            }
+            strBuilder.Length--;
+
+            Assert.That(strBuilder.ToString(), Is.EqualTo(expected));
+        }
+    }
+}

--- a/Tests/ViewModels/RequirementViewModelTests.cs
+++ b/Tests/ViewModels/RequirementViewModelTests.cs
@@ -1,0 +1,63 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Data;
+using RATools.Parser;
+using RATools.ViewModels;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RATools.Test.ViewModels
+{
+    [TestFixture]
+    class RequirementViewModelTests
+    {
+        [Test]
+        [TestCase("1=1", "always_true()")]
+        [TestCase("0xH1234=7", "byte(0x001234) == 7")]
+        [TestCase("R:0xH1234=7", "never(byte(0x001234) == 7)")]
+        [TestCase("A:0xH1234=0_0xH2345=7", "byte(0x001234) + ")]
+        [TestCase("B:0xH1234=0_0xH2345=7", "-byte(0x001234) + ")]
+        [TestCase("C:0xH1234=7_0xH2345=7", "AddHits byte(0x001234) == 7")]
+        [TestCase("D:0xH1234=7_0xH2345=7", "SubHits byte(0x001234) == 7")]
+        [TestCase("N:0xH1234=7_0xH2345=7", "AndNext byte(0x001234) == 7")]
+        [TestCase("O:0xH1234=7_0xH2345=7", "OrNext byte(0x001234) == 7")]
+        public void TestDefinition(string serialized, string expected)
+        {
+            var builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer(serialized));
+
+            var requirement = builder.ToAchievement().CoreRequirements.First();
+            var notes = new Dictionary<int, string>();
+            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes);
+
+            Assert.That(vmRequirement.Definition, Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase("0xH1111=7", "")]
+        [TestCase("0xH1234=7", "Addr1")]
+        [TestCase("7=0xH1234", "Addr1")]
+        [TestCase("0xH1234=d0xH1234", "Addr1")]
+        [TestCase("0xH1234=0xH2345", "0x001234:Addr1\r\n0x002345:Addr2")]
+        [TestCase("0xH1234=0xH1111", "0x001234:Addr1")]
+        [TestCase("0xH1111=0xH1234", "0x001234:Addr1")]
+        [TestCase("0xH2222=0xH1111", "")]
+        [TestCase("0xH3456", "This note is long enough that it will need to be wrapped.")]
+        [TestCase("0xH4567", "This note\nis multiple\nlines.")]
+        public void TestNotes(string serialized, string expected)
+        {
+            var notes = new Dictionary<int, string>();
+            notes[0x1234] = "Addr1";
+            notes[0x2345] = "Addr2";
+            notes[0x3456] = "This note is long enough that it will need to be wrapped.";
+            notes[0x4567] = "This note\nis multiple\nlines.";
+
+            var builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer(serialized));
+            var requirement = builder.ToAchievement().CoreRequirements.First();
+            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes);
+
+            Assert.That(vmRequirement.Notes, Is.EqualTo(expected));
+        }
+    }
+}

--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -1147,6 +1147,7 @@ namespace RATools.ViewModels
         private void DumpRichPresence(StreamWriter stream, RichPresenceMacro displayMacro, DumpAsset dumpRichPresence, NumberFormat numberFormat)
         {
             int index;
+            var notes = new Dictionary<int, string>();
 
             foreach (var line in displayMacro.DisplayLines)
             {
@@ -1162,11 +1163,10 @@ namespace RATools.ViewModels
                         var achievement = new AchievementBuilder();
                         achievement.ParseRequirements(Tokenizer.CreateTokenizer(trigger));
 
-                        var vmAchievement = new AssetSourceViewModel(null, "RichPresence");
-                        vmAchievement.Asset = achievement.ToAchievement();
+                        var vmTrigger = new TriggerViewModel("RichPresence", achievement.ToAchievement(), numberFormat, notes);
 
                         stream.Write("rich_presence_conditional_display(");
-                        DumpTrigger(stream, numberFormat, dumpRichPresence, vmAchievement.TriggerList.First(), 4);
+                        DumpTrigger(stream, numberFormat, dumpRichPresence, vmTrigger, 4);
                         stream.Write(", \"");
                     }
 

--- a/ViewModels/RequirementGroupViewModel.cs
+++ b/ViewModels/RequirementGroupViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using Jamiras.DataModels;
 using Jamiras.ViewModels;
 using RATools.Data;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -52,40 +53,48 @@ namespace RATools.ViewModels
                 score--;
 
             if (left.Operator == right.Operator)
-                score += 3;
-            else
-                score--;
-
-            if (left.HitCount == right.HitCount)
                 score += 2;
             else
                 score--;
 
+            if (left.HitCount == right.HitCount)
+                score += (left.HitCount > 0) ? 4 : 1;
+            else
+                score--;
+
             if (left.Left.Type == right.Left.Type)
-                score += 5;
-            else
-                score--;
+            {
+                if (left.Left.Size == right.Left.Size)
+                    score += 2;
+                else
+                    score--;
 
-            if (left.Left.Size == right.Left.Size)
-                score += 3;
+                if (left.Left.Value == right.Left.Value)
+                    score += 8;
+                else
+                    score -= 2;
+            }
             else
-                score--;
-
-            if (left.Left.Value == right.Left.Value)
-                score += 8;
+            {
+                score -= 3;
+            }
 
             if (left.Right.Type == right.Right.Type)
-                score += 5;
-            else
-                score--;
+            {
+                if (left.Right.Size == right.Right.Size)
+                    score += 2;
+                else
+                    score--;
 
-            if (left.Right.Size == right.Right.Size)
-                score += 3;
+                if (left.Right.Value == right.Right.Value)
+                    score += 8;
+                else
+                    score -= 2;
+            }
             else
-                score--;
-
-            if (left.Right.Value == right.Right.Value)
-                score += 8;
+            {
+                score -= 3;
+            }
 
             return score;
         }
@@ -134,6 +143,42 @@ namespace RATools.ViewModels
             return score;
         }
 
+        private static bool GetBestMerge(List<RequirementViewModel> list, out int leftIndex, out int rightIndex)
+        {
+            int bestScore = MinimumMatchingScore - 1;
+            int bestLeft = -1;
+            int bestRight = -1;
+
+            for (int i = 0; i < list.Count; i++)
+            {
+                var removedRequirement = list[i] as RequirementComparisonViewModel;
+                if (removedRequirement == null || removedRequirement.Requirement != null)
+                    continue;
+
+                for (int j = 0; j < list.Count; j++)
+                {
+                    if (j == i)
+                        continue;
+
+                    var compareRequirement = list[j] as RequirementComparisonViewModel;
+                    if (compareRequirement == null || compareRequirement.CompareRequirement != null)
+                        continue;
+
+                    var score = CalculateScore(removedRequirement.CompareRequirement, compareRequirement.Requirement);
+                    if (score > bestScore)
+                    {
+                        bestScore = score;
+                        bestLeft = j;
+                        bestRight = i;
+                    }
+                }
+            }
+
+            leftIndex = bestLeft;
+            rightIndex = bestRight;
+            return (bestLeft != -1);
+        }
+
         private void AppendRequirements(List<RequirementViewModel> list, RequirementEx left, RequirementEx right, NumberFormat numberFormat, IDictionary<int, string> notes)
         {
             if (right == null)
@@ -177,7 +222,7 @@ namespace RATools.ViewModels
 
                 while (unmatchedRequirements.Count > 0)
                 {
-                    var bestScore = 0;
+                    var bestScore = MinimumMatchingScore - 1;
                     var matchIndex = -1;
                     var compareIndex = -1;
 
@@ -187,7 +232,6 @@ namespace RATools.ViewModels
 
                         for (var j = 0; j < unmatchedCompareRequirements.Count; j++)
                         {
-                            var test = unmatchedCompareRequirements[j];
                             var score = CalculateScore(requirement, unmatchedCompareRequirements[j]); 
                             if (score > bestScore)
                             {
@@ -198,7 +242,7 @@ namespace RATools.ViewModels
                         }
                     }
 
-                    if (bestScore < MinimumMatchingScore)
+                    if (matchIndex == -1)
                         break;
 
                     matches[unmatchedRequirements[matchIndex]] = unmatchedCompareRequirements[compareIndex];
@@ -243,6 +287,7 @@ namespace RATools.ViewModels
             var matches = new Dictionary<RequirementEx, RequirementEx>();
             var unmatchedRequirementExs = new List<RequirementEx>();
 
+            // first pass: find exact matches
             foreach (var requirementEx in requirementExs)
             {
                 bool matched = false;
@@ -261,9 +306,10 @@ namespace RATools.ViewModels
                     unmatchedRequirementExs.Add(requirementEx);
             }
 
+            // second pass: find close matches
             while (unmatchedRequirementExs.Count > 0)
             {
-                var bestScore = 0;
+                var bestScore = MinimumMatchingScore - 1;
                 var matchIndex = -1;
                 var compareIndex = -1;
 
@@ -297,7 +343,7 @@ namespace RATools.ViewModels
                     }
                 }
 
-                if (bestScore < MinimumMatchingScore)
+                if (matchIndex == -1)
                     break;
 
                 matches[unmatchedRequirementExs[matchIndex]] = unmatchedCompareRequirementExs[compareIndex];
@@ -305,67 +351,83 @@ namespace RATools.ViewModels
                 unmatchedCompareRequirementExs.RemoveAt(compareIndex);
             }
 
-            var list = new List<RequirementViewModel>();
+            // construct the output list from the requirements
+            var pairs = new List<Tuple<RequirementEx, RequirementEx>>(matches.Count + unmatchedCompareRequirementExs.Count);
             foreach (var requirementEx in requirementExs)
             {
                 RequirementEx match;
                 matches.TryGetValue(requirementEx, out match);
-                AppendRequirements(list, requirementEx, match, numberFormat, notes);
+                pairs.Add(new Tuple<RequirementEx, RequirementEx>(requirementEx, match));
             }
 
-            // attempt to merge requirements that may have been separated into separate RequirementExs
-            bool merged;
-            do
-            {
-                merged = false;
-                for (int i = 0; i < list.Count; i++)
-                {
-                    var removedRequirement = list[i] as RequirementComparisonViewModel;
-                    if (removedRequirement == null || removedRequirement.Requirement != null)
-                        continue;
-
-                    int bestScore = 0;
-                    int mergeIndex = -1;
-
-                    for (int j = 0; j < list.Count; j++)
-                    {
-                        if (j == i)
-                            continue;
-
-                        var compareRequirement = list[j] as RequirementComparisonViewModel;
-                        if (compareRequirement == null || compareRequirement.CompareRequirement != null)
-                            continue;
-
-                        var score = CalculateScore(removedRequirement.CompareRequirement, compareRequirement.Requirement);
-                        if (score > bestScore)
-                        {
-                            bestScore = score;
-                            mergeIndex = j;
-                        }
-                    }
-
-                    if (mergeIndex != -1)
-                    {
-                        list[i] = new RequirementComparisonViewModel(list[mergeIndex].Requirement, removedRequirement.CompareRequirement, numberFormat, notes);
-                        list.RemoveAt(mergeIndex);
-                        merged = true;
-                        break;
-                    }
-                }
-            } while (merged);
-
             // allow an always_true() group to match an empty group
-            if (list.Count == 0 &&
+            if (pairs.Count == 0 &&
                 unmatchedCompareRequirementExs.Count == 1 &&
                 unmatchedCompareRequirementExs[0].Evaluate() == true)
             {
-                AppendRequirements(list, unmatchedCompareRequirementExs[0], unmatchedCompareRequirementExs[0], numberFormat, notes);
+                pairs.Add(new Tuple<RequirementEx, RequirementEx>(unmatchedCompareRequirementExs[0], unmatchedCompareRequirementExs[0]));
                 unmatchedCompareRequirementExs.Clear();
             }
 
-            // any remaining unmatched items still need to be added
-            foreach (var requirementEx in unmatchedCompareRequirementExs)
-                AppendRequirements(list, null, requirementEx, numberFormat, notes);
+            // third pass: insert any unmatched comparison requirements
+            if (unmatchedCompareRequirementExs.Count > 0)
+            {
+                var indices = new int[compareRequirementExs.Count + 2];
+                for (int i = 1; i < indices.Length - 1; ++i)
+                    indices[i] = -2;
+                indices[0] = -1;
+                indices[compareRequirementExs.Count + 1] = compareRequirementExs.Count + 1;
+                for (int i = 0; i < requirementExs.Count; i++)
+                {
+                    RequirementEx match;
+                    if (matches.TryGetValue(requirementExs[i], out match))
+                        indices[compareRequirementExs.IndexOf(match) + 1] = i;
+                }
+
+                foreach (var requirementEx in unmatchedCompareRequirementExs)
+                {
+                    var insertIndex = pairs.Count;
+
+                    var requirementIndex = compareRequirementExs.IndexOf(requirementEx);
+                    if (requirementIndex < compareRequirementExs.Count - 1)
+                    {
+                        for (int i = 1; i < indices.Length - 1; i++)
+                        {
+                            if (indices[i - 1] == requirementIndex - 1 || indices[i + 1] == requirementIndex + 1)
+                            {
+                                insertIndex = i - 1;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (insertIndex < pairs.Count)
+                    {
+                        for (int i = 0; i < indices.Length; i++)
+                        {
+                            if (indices[i] >= insertIndex)
+                                indices[i]++;
+                        }
+                    }
+
+                    indices[insertIndex + 1] = requirementIndex;
+                    pairs.Insert(insertIndex, new Tuple<RequirementEx, RequirementEx>(null, requirementEx));
+                }
+            }
+
+            // convert RequirementEx pairs to RequirementComparisonViewModels
+            var list = new List<RequirementViewModel>();
+            foreach (var pair in pairs)
+                AppendRequirements(list, pair.Item1, pair.Item2, numberFormat, notes);
+
+            // attempt to merge requirements that may have been separated into separate RequirementExs
+            int leftIndex, rightIndex;
+            while (GetBestMerge(list, out leftIndex, out rightIndex))
+            {
+                list[leftIndex] = new RequirementComparisonViewModel(list[leftIndex].Requirement, 
+                    ((RequirementComparisonViewModel)list[rightIndex]).CompareRequirement, numberFormat, notes);
+                list.RemoveAt(rightIndex);
+            }
 
             Requirements = list;
         }

--- a/ViewModels/RequirementGroupViewModel.cs
+++ b/ViewModels/RequirementGroupViewModel.cs
@@ -96,20 +96,37 @@ namespace RATools.ViewModels
             var unmatchedRequirements = new List<Requirement>(left.Requirements);
             foreach (var requirement in right.Requirements)
             {
-                bool matched = false;
+                int bestScore = 0;
+                int bestIndex = -1;
+
                 for (int i = 0; i < unmatchedRequirements.Count; i++)
                 {
                     if (unmatchedRequirements[i] == requirement)
                     {
-                        unmatchedRequirements.RemoveAt(i);
-                        score += 40;
-                        matched = true;
+                        bestScore = 40;
+                        bestIndex = i;
                         break;
+                    }
+                    else
+                    {
+                        var matchScore = CalculateScore(unmatchedRequirements[i], requirement);
+                        if (matchScore > bestScore)
+                        {
+                            bestScore = matchScore;
+                            bestIndex = i;
+                        }
                     }
                 }
 
-                if (!matched)
+                if (bestIndex == -1)
+                {
                     score -= 10;
+                }
+                else
+                {
+                    score += bestScore;
+                    unmatchedRequirements.RemoveAt(bestIndex);
+                }
             }
 
             score -= unmatchedRequirements.Count * 10;

--- a/ViewModels/RequirementViewModel.cs
+++ b/ViewModels/RequirementViewModel.cs
@@ -54,6 +54,9 @@ namespace RATools.ViewModels
                         Notes = note;
                 }
             }
+
+            if (Notes == null)
+                Notes = String.Empty;
         }
 
         public RequirementViewModel(string definition, string notes)
@@ -64,7 +67,7 @@ namespace RATools.ViewModels
 
         internal Requirement Requirement { get; private set; }
 
-        public static readonly ModelProperty DefinitionProperty = ModelProperty.Register(typeof(RequirementViewModel), "Definition", typeof(string), "");
+        public static readonly ModelProperty DefinitionProperty = ModelProperty.Register(typeof(RequirementViewModel), "Definition", typeof(string), String.Empty);
         public string Definition
         {
             get { return (string)GetValue(DefinitionProperty); }


### PR DESCRIPTION
Handles a case where an "unless(a || b)" gets split into an "unless(a) || unless(b)". Previously, the OrNext requirement would be recognized as a removed requirement and the second PauseIf would be recognized as a new requirement. Now they're recognized as a single modified requirement, making the diff a bit easier to read.