### PR TITLE
Fix "Object reference not set to an instance of an object" when dumping a game that has never received a ticket

### DIFF
--- a/ViewModels/OpenTicketsViewModel.cs
+++ b/ViewModels/OpenTicketsViewModel.cs
@@ -190,7 +190,7 @@ namespace RATools.ViewModels
         {
             var ticketsPage = RAWebCache.Instance.GetOpenTicketsForGame(gameId);
             if (ticketsPage == null)
-                return null;
+                return new Dictionary<int, AchievementTickets>();
 
             var games = new Dictionary<int, GameTickets>();
             var tickets = new Dictionary<int, AchievementTickets>();


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/35675593/154195962-d44a2261-d6d6-4c0b-8681-3d6247ba14ad.png)

(Alternative solution is to add null handling to line 456 of NewScriptDialogViewModel.cs but this solution means you don't have to add that if GetGameTickets is ever referenced again)