### PR TITLE
support for more code note annotations

### DIFF
--- a/Data/CodeNote.cs
+++ b/Data/CodeNote.cs
@@ -1,0 +1,198 @@
+﻿using Jamiras.Components;
+using System;
+using System.Diagnostics;
+
+namespace RATools.Data
+{
+    [DebuggerDisplay("{Address,h}: {Note}")]
+    struct CodeNote
+    {
+        public CodeNote(uint address, string note)
+        {
+            Address = address;
+            Note = note;
+            _length = 0;
+            _fieldSize = FieldSize.None;
+        }
+
+        public string Note { get; set; }
+
+        public uint Address { get; private set; }
+
+        private uint _length;
+        private FieldSize _fieldSize;
+
+        public uint Length
+        {
+            get
+            {
+                if (_length == 0)
+                    CalculateLength();
+
+                return _length;
+            }
+        }
+
+        public FieldSize FieldSize
+        {
+            get
+            {
+                if (_length == 0)
+                    CalculateLength();
+
+                return _fieldSize;
+            }
+        }
+
+        private void CalculateLength()
+        {
+            _length = 1;
+            _fieldSize = FieldSize.None;
+
+            Token token = new Token(Note, 0, Note.Length);
+
+            var bitIndex = token.IndexOf("bit", StringComparison.OrdinalIgnoreCase);
+            var byteIndex = token.IndexOf("byte", StringComparison.OrdinalIgnoreCase);
+            while (bitIndex != -1 || byteIndex != -1)
+            {
+                Token prefix;
+
+                int index;
+                if (bitIndex == -1 || (byteIndex != -1 && byteIndex < bitIndex))
+                {
+                    index = byteIndex;
+                    prefix = token.SubToken(0, index);
+                    token = token.SubToken(index + 4);
+                }
+                else
+                {
+                    index = bitIndex;
+                    prefix = token.SubToken(0, index);
+                    token = token.SubToken(index + 3);
+
+                    // match "bits", but not "bite" even if there is a numeric prefix
+                    if (token.Length > 0)
+                    {
+                        var c = token[0];
+                        if (Char.IsLetter(c) && c != 's' && c != 'S')
+                        {
+                            bitIndex = token.IndexOf("bit", StringComparison.OrdinalIgnoreCase);
+                            continue;
+                        }
+                    }
+                }
+
+                // ignore single space or hyphen preceding "bit" or "byte"
+                if (prefix.EndsWith("-") || prefix.EndsWith(" "))
+                    prefix = prefix.SubToken(0, index - 1);
+
+                // extract the number
+                var scan = prefix.Length;
+                while (scan > 0 && Char.IsDigit(prefix[scan - 1]))
+                    scan--;
+
+                // if a number was found, process it
+                prefix = prefix.SubToken(scan);
+                if (prefix.Length > 0)
+                {
+                    var count = UInt32.Parse(prefix.ToString());
+                    if (index == byteIndex)
+                        count *= 8;
+
+                    _length = (count == 0) ? 1 : (count + 7) / 8;
+
+                    // find the next word after "bits" or "bytes"
+                    scan = 0;
+                    while (scan < token.Length)
+                    {
+                        var c = token[scan];
+                        if (c != ' ' && c != '-' && c != '(' && c != '[' && c != '<')
+                            break;
+                        ++scan;
+                    }
+                    token = token.SubToken(scan);
+
+                    if (token.StartsWith("BE", StringComparison.OrdinalIgnoreCase) ||
+                        token.StartsWith("BigEndian", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (count == 16)
+                            _fieldSize = FieldSize.BigEndianWord;
+                        else if (count == 24)
+                            _fieldSize = FieldSize.BigEndianTByte;
+                        else if (count == 32)
+                            _fieldSize = FieldSize.BigEndianDWord;
+                        else if (count == 8)
+                            _fieldSize = FieldSize.Byte;
+                    }
+                    else if (token.StartsWith("float", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (count == 32)
+                            _fieldSize = FieldSize.Float;
+                    }
+                    else if (token.StartsWith("MBF", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (count == 32 || count == 40)
+                            _fieldSize = FieldSize.MBF32;
+                    }
+                    else
+                    {
+                        if (count == 16)
+                            _fieldSize = FieldSize.Word;
+                        else if (count == 24)
+                            _fieldSize = FieldSize.TByte;
+                        else if (count == 32)
+                            _fieldSize = FieldSize.DWord;
+                        else if (count == 8)
+                            _fieldSize = FieldSize.Byte;
+                    }
+
+                    // if "bytes" were found, we're done. if "bits" were found, it might be indicating
+                    // the size of individual elements. keep searching
+                    if (index == byteIndex)
+                        return;
+                }
+
+                bitIndex = token.IndexOf("bit", StringComparison.OrdinalIgnoreCase);
+                byteIndex = token.IndexOf("byte", StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (_fieldSize != FieldSize.None)
+                return;
+
+            token = new Token(Note, 0, Note.Length);
+            if (token.Contains("MBF32", StringComparison.OrdinalIgnoreCase))
+            {
+                _length = 4;
+                _fieldSize = FieldSize.MBF32;
+                return;
+            }
+
+            if (token.Contains("MBF40", StringComparison.OrdinalIgnoreCase))
+            {
+                // MBF-40 values are 100% compatible with MBF-32. The last 8 bits are
+                // too insignificant to be handled by the runtime, so can be ignored.
+                _length = 5;
+                _fieldSize = FieldSize.MBF32;
+                return;
+            }
+
+            do
+            {
+                var index = token.IndexOf("float", StringComparison.OrdinalIgnoreCase);
+                if (index == -1)
+                    break;
+
+                if (index > 0 && Char.IsLetter(token[index - 1]))
+                    break;
+
+                token = token.SubToken(index + 5);
+                if (token.Length == 0 || token[0] == ']' || token[0] == ')' || token.StartsWith("32"))
+                {
+                    _length = 4;
+                    _fieldSize = FieldSize.Float;
+                    return;
+                }
+            } while (true);
+        }
+    }
+}

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -95,6 +95,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Data\Achievement.cs" />
+    <Compile Include="Data\CodeNote.cs" />
     <Compile Include="Data\Field.cs" />
     <Compile Include="Data\AssetBase.cs" />
     <Compile Include="Data\Leaderboard.cs" />

--- a/Tests/Data/CodeNoteTests.cs
+++ b/Tests/Data/CodeNoteTests.cs
@@ -1,0 +1,97 @@
+﻿using NUnit.Framework;
+using RATools.Data;
+
+namespace RATools.Test.Data
+{
+    [TestFixture]
+    class CodeNoteTests
+    {
+        [Test]
+        [TestCase("", 1, FieldSize.None)]
+        [TestCase("Test", 1, FieldSize.None)]
+        [TestCase("16-bit Test", 2, FieldSize.Word)]
+        [TestCase("Test 16-bit", 2, FieldSize.Word)]
+        [TestCase("Test 16-bi", 1, FieldSize.None)]
+        [TestCase("[16-bit] Test", 2, FieldSize.Word)]
+        [TestCase("[16 bit] Test", 2, FieldSize.Word)]
+        [TestCase("[16 Bit] Test", 2, FieldSize.Word)]
+        [TestCase("[24-bit] Test", 3, FieldSize.TByte)]
+        [TestCase("[32-bit] Test", 4, FieldSize.DWord)]
+        [TestCase("[32 bit] Test", 4, FieldSize.DWord)]
+        [TestCase("[32bit] Test", 4, FieldSize.DWord)]
+        [TestCase("Test [16-bit]", 2, FieldSize.Word)]
+        [TestCase("Test (16-bit)", 2, FieldSize.Word)]
+        [TestCase("Test (16 bits)", 2, FieldSize.Word)]
+        [TestCase("[64-bit] Test", 8, FieldSize.None)]
+        [TestCase("[128-bit] Test", 16, FieldSize.None)]
+        [TestCase("[17-bit] Test", 3, FieldSize.None)]
+        [TestCase("[100-bit] Test", 13, FieldSize.None)]
+        [TestCase("[0-bit] Test", 1, FieldSize.None)]
+        [TestCase("[1-bit] Test", 1, FieldSize.None)]
+        [TestCase("[4-bit] Test", 1, FieldSize.None)]
+        [TestCase("[8-bit] Test", 1, FieldSize.Byte)]
+        [TestCase("[9-bit] Test", 2, FieldSize.None)]
+        [TestCase("bit", 1, FieldSize.None)]
+        [TestCase("9bit", 2, FieldSize.None)]
+        [TestCase("-bit", 1, FieldSize.None)]
+
+        [TestCase("[16-bit BE] Test", 2, FieldSize.BigEndianWord)]
+        [TestCase("[24-bit BE] Test", 3, FieldSize.BigEndianTByte)]
+        [TestCase("[32-bit BE] Test", 4, FieldSize.BigEndianDWord)]
+        [TestCase("Test [32-bit BE]", 4, FieldSize.BigEndianDWord)]
+        [TestCase("Test (32-bit BE)", 4, FieldSize.BigEndianDWord)]
+        [TestCase("Test 32-bit BE", 4, FieldSize.BigEndianDWord)]
+        [TestCase("[16-bit BigEndian] Test", 2, FieldSize.BigEndianWord)]
+        [TestCase("[16-bit-BE] Test", 2, FieldSize.BigEndianWord)]
+        [TestCase("[8-bit BE] Test", 1, FieldSize.Byte)]
+        [TestCase("[4-bit BE] Test", 1, FieldSize.None)]
+
+        [TestCase("8 BYTE Test", 8, FieldSize.None)]
+        [TestCase("Test 8 BYTE", 8, FieldSize.None)]
+        [TestCase("Test 8 BYT", 1, FieldSize.None)]
+        [TestCase("[2 Byte] Test", 2, FieldSize.Word)]
+        [TestCase("[4 Byte] Test", 4, FieldSize.DWord)]
+        [TestCase("[4 Byte - Float] Test", 4, FieldSize.Float)]
+        [TestCase("[8 Byte] Test", 8, FieldSize.None)]
+        [TestCase("[100 Bytes] Test", 100, FieldSize.None)]
+        [TestCase("[2 byte] Test", 2, FieldSize.Word)]
+        [TestCase("[2-byte] Test", 2, FieldSize.Word)]
+        [TestCase("Test (6 bytes)", 6, FieldSize.None)]
+        [TestCase("[2byte] Test", 2, FieldSize.Word)]
+
+        [TestCase("[float] Test", 4, FieldSize.Float)]
+        [TestCase("[float32] Test", 4, FieldSize.Float)]
+        [TestCase("Test float", 4, FieldSize.Float)]
+        [TestCase("Test floa", 1, FieldSize.None)]
+        [TestCase("is floating", 1, FieldSize.None)]
+        [TestCase("has floated", 1, FieldSize.None)]
+        [TestCase("16-afloat", 1, FieldSize.None)]
+
+        [TestCase("[MBF32] Test", 4, FieldSize.MBF32)]
+        [TestCase("[MBF40] Test", 5, FieldSize.MBF32)]
+        [TestCase("[MBF32 float] Test", 4, FieldSize.MBF32)]
+        [TestCase("[MBF80] Test", 1, FieldSize.None)]
+        [TestCase("[MBF-32] Test", 1, FieldSize.None)]
+        [TestCase("[32-bit MBF] Test", 4, FieldSize.MBF32)]
+        [TestCase("[40-bit MBF] Test", 5, FieldSize.MBF32)]
+        [TestCase("[MBF] Test", 1, FieldSize.None)]
+        [TestCase("Test MBF32", 4, FieldSize.MBF32)]
+
+        [TestCase("42=bitten", 1, FieldSize.None)]
+        [TestCase("42-bitten", 1, FieldSize.None)]
+        [TestCase("bit by bit", 1, FieldSize.None)]
+        [TestCase("bit1=chest", 1, FieldSize.None)]
+
+        [TestCase("Bite count (16-bit)", 2, FieldSize.Word)]
+        [TestCase("Number of bits collected (32 bits)", 4, FieldSize.DWord)]
+
+        [TestCase("100 32-bit pointers [400 bytes]", 400, FieldSize.DWord)]
+        [TestCase("[400 bytes] 100 32-bit pointers", 400, FieldSize.None)]
+        public void TestGetSizeFromNote(string note, int expectedLength, FieldSize expectedFieldSize)
+        {
+            var n = new CodeNote(1, note);
+            Assert.That(n.FieldSize, Is.EqualTo(expectedFieldSize));
+            Assert.That(n.Length, Is.EqualTo(expectedLength));
+        }
+    }
+}

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -129,6 +129,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Data\CodeNoteTests.cs" />
     <Compile Include="Data\RequirementExTests.cs" />
     <Compile Include="Data\RequirementTests.cs" />
     <Compile Include="Data\FieldTests.cs" />

--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -216,56 +216,16 @@ namespace RATools.ViewModels
             }
         }
 
-        private static FieldSize CheckForBigEndian(Token token, FieldSize leSize, FieldSize beSize)
-        {
-            if (token.Contains("bit-BE", StringComparison.OrdinalIgnoreCase) ||
-                token.Contains("bit BE", StringComparison.OrdinalIgnoreCase))
-            {
-                return beSize;
-            }
-
-            return leSize;
-        }
-
         private void LoadNotes()
         {
             foreach (var kvp in _game.Notes)
             {
-                FieldSize size = FieldSize.Byte;
-                Token token = new Token(kvp.Value, 0, kvp.Value.Length);
-                if (token.Contains("16-bit", StringComparison.OrdinalIgnoreCase) ||
-                    token.Contains("16 bit", StringComparison.OrdinalIgnoreCase))
-                {
-                    size = CheckForBigEndian(token, FieldSize.Word, FieldSize.BigEndianWord);
-                }
-                else if (token.Contains("32-bit", StringComparison.OrdinalIgnoreCase) ||
-                    token.Contains("32 bit", StringComparison.OrdinalIgnoreCase))
-                {
-                    size = CheckForBigEndian(token, FieldSize.DWord, FieldSize.BigEndianDWord);
-                }
-                else if (token.Contains("24-bit", StringComparison.OrdinalIgnoreCase) ||
-                    token.Contains("24 bit", StringComparison.OrdinalIgnoreCase))
-                {
-                    size = CheckForBigEndian(token, FieldSize.TByte, FieldSize.BigEndianTByte);
-                }
-                else if (token.Contains("float]", StringComparison.OrdinalIgnoreCase) ||
-                    token.Contains("float)", StringComparison.OrdinalIgnoreCase))
-                {
-                    size = FieldSize.Float;
-                }
-                else if (token.Contains("MBF32", StringComparison.OrdinalIgnoreCase) ||
-                    token.Contains("MBF-32", StringComparison.OrdinalIgnoreCase) ||
-                    token.Contains("MBF40", StringComparison.OrdinalIgnoreCase) ||
-                    token.Contains("MBF-40", StringComparison.OrdinalIgnoreCase))
-                {
-                    // MBF-40 values are 100% compatible with MBF-32. The last 8 bits are
-                    // too insignificant to be handled by the runtime, so can be ignored.
-                    size = FieldSize.MBF32;
-                }
-
-                AddMemoryAddress(new Field { Size = size, Type = FieldType.MemoryAddress, Value = (uint)kvp.Key });
+                var note = new CodeNote((uint)kvp.Key, kvp.Value);
+                var size = (note.FieldSize == FieldSize.None) ? FieldSize.Byte : note.FieldSize;
+                AddMemoryAddress(new Field { Size = size, Type = FieldType.MemoryAddress, Value = note.Address });
             }
         }
+
 
         private class RichPresenceMacro
         {


### PR DESCRIPTION
Mimics the DLL's support for parsing code note annotations.

Notably, adds support for sizes without spaces (`[32bit]`) and compound sizes (`[32-bit float]`)