### PR TITLE
Improve requirement merging optimizations

### DIFF
--- a/Parser/Functions/AchievementFunction.cs
+++ b/Parser/Functions/AchievementFunction.cs
@@ -54,6 +54,10 @@ namespace RATools.Parser.Functions
                 return false;
             achievement.Id = integerExpression.Value;
 
+            stringExpression = GetStringParameter(scope, "published", out result);
+            if (stringExpression != null && !string.IsNullOrEmpty(stringExpression.Value))
+                achievement.IsDumped = true;
+
             var trigger = GetParameter(scope, "trigger", out result);
             if (trigger == null)
                 return false;

--- a/Parser/RequirementMerger.cs
+++ b/Parser/RequirementMerger.cs
@@ -1,0 +1,962 @@
+﻿using RATools.Data;
+using RATools.Parser.Functions;
+using RATools.Parser.Internal;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace RATools.Parser
+{
+    internal class RequirementMerger
+    {
+        private enum MoreRestrictiveRequirement
+        {
+            None = 0,
+            Left,
+            Right,
+            Same,
+            Conflict,
+            Everything,
+            LeftMergeOperator,
+            RightMergeOperator,
+        }
+
+        private static MoreRestrictiveRequirement GetMoreRestrictiveRequirement(
+            RequirementOperator comparison1, uint value1, RequirementOperator comparison2, uint value2)
+        {
+            switch (comparison2)                                    //  comp1    comp2  |  comp1    comp2  |  comp1    comp2
+            {                                                       // value1 == value2 | value1 <  value2 | value1 >  value2  
+                case RequirementOperator.Equal:
+                    switch (comparison1)
+                    {
+                        case RequirementOperator.Equal:             // a == 1 && a == 1 | a == 1 && a == 2 | a == 2 && a == 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.Same : MoreRestrictiveRequirement.Conflict;
+                        case RequirementOperator.LessThanOrEqual:   // a <= 1 && a == 1 | a <= 1 && a == 2 | a <= 2 && a == 1
+                            return (value1 < value2) ? MoreRestrictiveRequirement.Conflict : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.GreaterThanOrEqual:// a >= 1 && a == 1 | a >= 1 && a == 2 | a >= 2 && a == 1
+                            return (value1 > value2) ? MoreRestrictiveRequirement.Conflict : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.NotEqual:          // a != 1 && a == 1 | a != 1 && a == 2 | a != 2 && a == 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.Conflict : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.LessThan:          // a <  1 && a == 1 | a <  1 && a == 2 | a <  2 && a == 1
+                            return (value1 <= value2) ? MoreRestrictiveRequirement.Conflict : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.GreaterThan:       // a >  1 && a == 1 | a >  1 && a == 2 | a >  2 && a == 1
+                            return (value1 >= value2) ? MoreRestrictiveRequirement.Conflict : MoreRestrictiveRequirement.Right;
+                        default:
+                            break;
+                    }
+                    break;
+
+                case RequirementOperator.NotEqual:
+                    switch (comparison1)
+                    {
+                        case RequirementOperator.Equal:             // a == 1 && a != 1 | a == 1 && a != 2 | a == 2 && a != 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.Conflict : MoreRestrictiveRequirement.Left;
+                        case RequirementOperator.LessThanOrEqual:   // a <= 1 && a != 1 | a <= 1 && a != 2 | a <= 2 && a != 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.LeftMergeOperator :
+                                (value1 < value2) ? MoreRestrictiveRequirement.Left : MoreRestrictiveRequirement.None;
+                        case RequirementOperator.GreaterThanOrEqual:// a >= 1 && a != 1 | a >= 1 && a != 2 | a >= 2 && a != 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.LeftMergeOperator :
+                                (value1 > value2) ? MoreRestrictiveRequirement.Left : MoreRestrictiveRequirement.None;
+                        case RequirementOperator.NotEqual:          // a != 1 && a != 1 | a != 1 && a != 2 | a != 2 && a != 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.Same : MoreRestrictiveRequirement.None;
+                        case RequirementOperator.LessThan:          // a <  1 && a != 1 | a <  1 && a != 2 | a <  2 && a != 1
+                            return (value1 <= value2) ? MoreRestrictiveRequirement.Left : MoreRestrictiveRequirement.None;
+                        case RequirementOperator.GreaterThan:       // a >  1 && a != 1 | a >  1 && a != 2 | a >  2 && a != 1
+                            return (value1 >= value2) ? MoreRestrictiveRequirement.Left : MoreRestrictiveRequirement.None;
+                        default:
+                            break;
+                    }
+                    break;
+
+                case RequirementOperator.LessThan:
+                    switch (comparison1)
+                    {
+                        case RequirementOperator.Equal:             // a == 1 && a <  1 | a == 1 && a <  2 | a == 2 && a <  1
+                            return (value1 < value2) ? MoreRestrictiveRequirement.Left : MoreRestrictiveRequirement.Conflict;
+                        case RequirementOperator.LessThanOrEqual:   // a <= 1 && a <  1 | a <= 1 && a <  2 | a <= 2 && a <  1
+                            return (value1 < value2) ? MoreRestrictiveRequirement.Left : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.GreaterThanOrEqual:// a >= 1 && a <  1 | a >= 1 && a <  2 | a >= 2 && a <  1
+                            return (value1 < value2) ? MoreRestrictiveRequirement.None : MoreRestrictiveRequirement.Conflict;
+                        case RequirementOperator.NotEqual:          // a != 1 && a <  1 | a != 1 && a <  2 | a != 2 && a <  1
+                            return (value1 < value2) ? MoreRestrictiveRequirement.None : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.LessThan:          // a <  1 && a <  1 | a <  1 && a <  2 | a <  2 && a <  1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.Same :
+                                (value1 < value2) ? MoreRestrictiveRequirement.Left : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.GreaterThan:       // a >  1 && a <  1 | a >  1 && a <  2 | a >  2 && a <  1
+                            return (value1 < value2) ? MoreRestrictiveRequirement.None : MoreRestrictiveRequirement.Conflict;
+                        default:
+                            break;
+                    }
+                    break;
+
+                case RequirementOperator.LessThanOrEqual:
+                    switch (comparison1)
+                    {
+                        case RequirementOperator.Equal:             // a == 1 && a <= 1 | a == 1 && a <= 2 | a == 2 && a <= 1
+                            return (value1 > value2) ? MoreRestrictiveRequirement.Conflict : MoreRestrictiveRequirement.Left;
+                        case RequirementOperator.LessThanOrEqual:   // a <= 1 && a <= 1 | a <= 1 && a <= 2 | a <= 2 && a <= 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.Same :
+                                (value1 < value2) ? MoreRestrictiveRequirement.Left : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.GreaterThanOrEqual:// a >= 1 && a <= 1 | a >= 1 && a <= 2 | a >= 2 && a <= 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.LeftMergeOperator :
+                                (value1 < value2) ? MoreRestrictiveRequirement.None : MoreRestrictiveRequirement.Conflict;
+                        case RequirementOperator.NotEqual:          // a != 1 && a <= 1 | a != 1 && a <= 2 | a != 2 && a <= 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.RightMergeOperator :
+                                (value1 < value2) ? MoreRestrictiveRequirement.None : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.LessThan:          // a <  1 && a <= 1 | a <  1 && a <= 2 | a <  2 && a <= 1
+                            return (value1 > value2) ? MoreRestrictiveRequirement.Right : MoreRestrictiveRequirement.Left;
+                        case RequirementOperator.GreaterThan:       // a >  1 && a <= 1 | a >  1 && a <= 2 | a >  2 && a <= 1
+                            return (value1 < value2) ? MoreRestrictiveRequirement.None : MoreRestrictiveRequirement.Conflict;
+                        default:
+                            break;
+                    }
+                    break;
+
+                case RequirementOperator.GreaterThan:
+                    switch (comparison1)
+                    {
+                        case RequirementOperator.Equal:             // a == 1 && a >  1 | a == 1 && a >  2 | a == 2 && a >  1
+                            return (value1 > value2) ? MoreRestrictiveRequirement.Left : MoreRestrictiveRequirement.Conflict;
+                        case RequirementOperator.LessThanOrEqual:   // a <= 1 && a >  1 | a <= 1 && a >  2 | a <= 2 && a >  1
+                            return (value1 > value2) ? MoreRestrictiveRequirement.None : MoreRestrictiveRequirement.Conflict;
+                        case RequirementOperator.GreaterThanOrEqual:// a >= 1 && a >  1 | a >= 1 && a >  2 | a >= 2 && a >  1
+                            return (value1 > value2) ? MoreRestrictiveRequirement.Left : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.NotEqual:          // a != 1 && a >  1 | a != 1 && a >  2 | a != 2 && a >  1
+                            return (value1 > value2) ? MoreRestrictiveRequirement.None : MoreRestrictiveRequirement.Right;
+                        case RequirementOperator.LessThan:          // a <  1 && a >  1 | a <  1 && a >  2 | a <  2 && a >  1
+                            return (value1 > value2) ? MoreRestrictiveRequirement.None : MoreRestrictiveRequirement.Conflict;
+                        case RequirementOperator.GreaterThan:       // a >  1 && a >  1 | a >  1 && a >  2 | a >  2 && a >  1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.Same :
+                                (value1 < value2) ? MoreRestrictiveRequirement.Right : MoreRestrictiveRequirement.Left;
+                        default:
+                            break;
+                    }
+                    break;
+
+                case RequirementOperator.GreaterThanOrEqual:
+                    switch (comparison1)
+                    {
+                        case RequirementOperator.Equal:             // a == 1 && a >= 1 | a == 1 && a >= 2 | a == 2 && a >= 1
+                            return (value1 < value2) ? MoreRestrictiveRequirement.Conflict : MoreRestrictiveRequirement.Left;
+                        case RequirementOperator.LessThanOrEqual:   // a <= 1 && a >= 1 | a <= 1 && a >= 2 | a <= 2 && a >= 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.LeftMergeOperator :
+                                (value1 < value2) ? MoreRestrictiveRequirement.Conflict : MoreRestrictiveRequirement.None;
+                        case RequirementOperator.GreaterThanOrEqual:// a >= 1 && a >= 1 | a >= 1 && a >= 2 | a >= 2 && a >= 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.Same :
+                                (value1 < value2) ? MoreRestrictiveRequirement.Right : MoreRestrictiveRequirement.Left;
+                        case RequirementOperator.NotEqual:          // a != 1 && a >= 1 | a != 1 && a >= 2 | a != 2 && a >= 1
+                            return (value1 == value2) ? MoreRestrictiveRequirement.RightMergeOperator :
+                                (value1 < value2) ? MoreRestrictiveRequirement.Right : MoreRestrictiveRequirement.None;
+                        case RequirementOperator.LessThan:          // a <  1 && a >= 1 | a <  1 && a >= 2 | a <  2 && a >= 1
+                            return (value1 > value2) ? MoreRestrictiveRequirement.None : MoreRestrictiveRequirement.Conflict;
+                        case RequirementOperator.GreaterThan:       // a >  1 && a >= 1 | a >  1 && a >= 2 | a >  2 && a >= 1
+                            return (value1 < value2) ? MoreRestrictiveRequirement.Right : MoreRestrictiveRequirement.Left;
+                        default:
+                            break;
+                    }
+                    break;
+
+            }
+
+            return MoreRestrictiveRequirement.None;
+        }
+
+        private static RequirementOperator MergeOperatorsAnd(RequirementOperator left, RequirementOperator right)
+        {
+            switch (left)
+            {
+                case RequirementOperator.LessThanOrEqual:
+                    switch (right)
+                    {
+                        case RequirementOperator.NotEqual: return RequirementOperator.LessThan;
+                        case RequirementOperator.Equal:
+                        case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.Equal;
+                        case RequirementOperator.LessThan:
+                        case RequirementOperator.LessThanOrEqual: return RequirementOperator.LessThanOrEqual;
+                        case RequirementOperator.GreaterThan: return RequirementOperator.None;
+                        default: break;
+                    }
+                    break;
+
+                case RequirementOperator.GreaterThanOrEqual:
+                    switch (right)
+                    {
+                        case RequirementOperator.NotEqual: return RequirementOperator.GreaterThan;
+                        case RequirementOperator.Equal:
+                        case RequirementOperator.LessThanOrEqual: return RequirementOperator.Equal;
+                        case RequirementOperator.GreaterThan:
+                        case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.GreaterThanOrEqual;
+                        case RequirementOperator.LessThan: return RequirementOperator.None;
+                        default: break;
+                    }
+                    break;
+
+                case RequirementOperator.NotEqual:
+                    switch (right)
+                    {
+                        case RequirementOperator.Equal: return RequirementOperator.None;
+                        case RequirementOperator.NotEqual: return RequirementOperator.NotEqual;
+                        case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.GreaterThan;
+                        case RequirementOperator.LessThanOrEqual: return RequirementOperator.LessThan;
+                        case RequirementOperator.GreaterThan: return RequirementOperator.GreaterThan;
+                        case RequirementOperator.LessThan: return RequirementOperator.LessThan;
+                        default: break;
+                    }
+                    break;
+
+                case RequirementOperator.Equal:
+                    switch (right)
+                    {
+                        case RequirementOperator.GreaterThanOrEqual:
+                        case RequirementOperator.LessThanOrEqual:
+                        case RequirementOperator.Equal: return RequirementOperator.Equal;
+                        case RequirementOperator.GreaterThan:
+                        case RequirementOperator.LessThan:
+                        case RequirementOperator.NotEqual: return RequirementOperator.None;
+                        default: break;
+                    }
+                    break;
+
+                case RequirementOperator.GreaterThan:
+                    switch (right)
+                    {
+                        case RequirementOperator.NotEqual:
+                        case RequirementOperator.GreaterThan:
+                        case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.GreaterThan;
+                        case RequirementOperator.LessThan:
+                        case RequirementOperator.LessThanOrEqual:
+                        case RequirementOperator.Equal: return RequirementOperator.None;
+                        default: break;
+                    }
+                    break;
+
+                case RequirementOperator.LessThan:
+                    switch (right)
+                    {
+                        case RequirementOperator.NotEqual:
+                        case RequirementOperator.LessThan:
+                        case RequirementOperator.LessThanOrEqual: return RequirementOperator.GreaterThan;
+                        case RequirementOperator.GreaterThan:
+                        case RequirementOperator.GreaterThanOrEqual:
+                        case RequirementOperator.Equal: return RequirementOperator.None;
+                        default: break;
+                    }
+                    break;
+            }
+
+            return RequirementOperator.None;
+        }
+
+        private static RequirementOperator MergeOperatorsOr(RequirementOperator left, RequirementOperator right)
+        {
+            switch (left)
+            {
+                case RequirementOperator.LessThanOrEqual:
+                    switch (right)
+                    {
+                        case RequirementOperator.NotEqual:
+                        case RequirementOperator.GreaterThan:
+                        case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.Multiply; // All
+                        case RequirementOperator.Equal:
+                        case RequirementOperator.LessThan:
+                        case RequirementOperator.LessThanOrEqual: return RequirementOperator.LessThanOrEqual;
+                        default: break;
+                    }
+                    break;
+
+                case RequirementOperator.GreaterThanOrEqual:
+                    switch (right)
+                    {
+                        case RequirementOperator.NotEqual:
+                        case RequirementOperator.LessThan:
+                        case RequirementOperator.LessThanOrEqual: return RequirementOperator.Multiply; // All
+                        case RequirementOperator.Equal:
+                        case RequirementOperator.GreaterThan:
+                        case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.GreaterThanOrEqual;
+                        default: break;
+                    }
+                    break;
+
+                case RequirementOperator.NotEqual:
+                    switch (right)
+                    {
+                        case RequirementOperator.GreaterThanOrEqual:
+                        case RequirementOperator.LessThanOrEqual:
+                        case RequirementOperator.Equal: return RequirementOperator.Multiply; // All
+                        case RequirementOperator.NotEqual: return RequirementOperator.NotEqual;
+                        case RequirementOperator.GreaterThan: return RequirementOperator.GreaterThan;
+                        case RequirementOperator.LessThan: return RequirementOperator.LessThan;
+                        default: break;
+                    }
+                    break;
+
+                case RequirementOperator.Equal:
+                    switch (right)
+                    {
+                        case RequirementOperator.GreaterThan:
+                        case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.GreaterThanOrEqual;
+                        case RequirementOperator.LessThan:
+                        case RequirementOperator.LessThanOrEqual: return RequirementOperator.LessThanOrEqual;
+                        case RequirementOperator.Equal: return RequirementOperator.Equal;
+                        case RequirementOperator.NotEqual: return RequirementOperator.Multiply; // All
+                        default: break;
+                    }
+                    break;
+
+                case RequirementOperator.GreaterThan:
+                    switch (right)
+                    {
+                        case RequirementOperator.LessThan:
+                        case RequirementOperator.NotEqual: return RequirementOperator.NotEqual;
+                        case RequirementOperator.GreaterThan: return RequirementOperator.GreaterThan;
+                        case RequirementOperator.Equal:
+                        case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.GreaterThanOrEqual;
+                        case RequirementOperator.LessThanOrEqual: return RequirementOperator.Multiply; // All
+                        default: break;
+                    }
+                    break;
+
+                case RequirementOperator.LessThan:
+                    switch (right)
+                    {
+                        case RequirementOperator.GreaterThan:
+                        case RequirementOperator.NotEqual: return RequirementOperator.NotEqual;
+                        case RequirementOperator.LessThan: return RequirementOperator.LessThan;
+                        case RequirementOperator.Equal:
+                        case RequirementOperator.LessThanOrEqual: return RequirementOperator.LessThanOrEqual;
+                        case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.Multiply; //All
+                        default: break;
+                    }
+                    break;
+            }
+
+            return RequirementOperator.None;
+        }
+
+        private static Requirement MergeRequirements(Requirement left, Requirement right, MoreRestrictiveRequirement moreRestrictive)
+        {
+            // create a copy that we can modify
+            var merged = new Requirement
+            {
+                Type = left.Type,
+                Left = left.Left,
+                HitCount = Math.Max(left.HitCount, right.HitCount)
+            };
+
+            switch (moreRestrictive)
+            {
+                case MoreRestrictiveRequirement.None:
+                    // can't be merged
+                    return null;
+
+                case MoreRestrictiveRequirement.Conflict:
+                    // these are allowed to conflict with each other
+                    if (left.HitCount > 0 || right.HitCount > 0)
+                        return null;
+                    if (left.Type == RequirementType.PauseIf)
+                        return null;
+                    if (left.Type == RequirementType.ResetIf)
+                        return null;
+
+                    // conditions conflict with each other, trigger is impossible
+                    return AlwaysFalseFunction.CreateAlwaysFalseRequirement();
+
+                case MoreRestrictiveRequirement.Same:
+                case MoreRestrictiveRequirement.Left:
+                    merged.Operator = left.Operator;
+                    merged.Right = left.Right;
+                    return merged;
+
+                case MoreRestrictiveRequirement.Right:
+                    merged.Operator = right.Operator;
+                    merged.Right = right.Right;
+                    return merged;
+
+                case MoreRestrictiveRequirement.LeftMergeOperator:
+                    merged.Operator = MergeOperatorsAnd(left.Operator, right.Operator);
+                    merged.Right = left.Right;
+                    return merged;
+
+                case MoreRestrictiveRequirement.RightMergeOperator:
+                    merged.Operator = MergeOperatorsAnd(left.Operator, right.Operator);
+                    merged.Right = right.Right;
+                    return merged;
+
+                default:
+                    return null;
+            }
+        }
+
+        private static MoreRestrictiveRequirement MergeRequirements(Requirement left, Requirement right, ConditionalOperation condition, out Requirement merged)
+        {
+            merged = null;
+
+            // only allow merging if doing a comparison where both left sides are the same and have the same flag
+            if (left.Type != right.Type || left.Left != right.Left || !left.IsComparison)
+                return MoreRestrictiveRequirement.None;
+
+            if (left.HitCount != right.HitCount)
+            {
+                // cannot merge hit counts if either of them is infinite
+                // otherwise, the higher of the two will be selected when doing the merge
+                if (left.HitCount == 0 || right.HitCount == 0)
+                    return MoreRestrictiveRequirement.None;
+            }
+            else if (left.Operator == right.Operator && left.Right == right.Right)
+            {
+                // 100% match, use it
+                merged = left;
+                return MoreRestrictiveRequirement.Same;
+            }
+
+            // when processing never() [ResetIf], invert the conditional operation as we expect the
+            // conditions to be false when the achievement triggers
+            if (left.Type == RequirementType.ResetIf)
+            {
+                switch (condition)
+                {
+                    case ConditionalOperation.And:
+                        // "never(A) && never(B)" => "never(A || B)"
+                        condition = ConditionalOperation.Or;
+                        break;
+                    case ConditionalOperation.Or:
+                        // "never(A) || never(B)" => "never(A && B)"
+                        condition = ConditionalOperation.And;
+                        break;
+                }
+            }
+
+            MoreRestrictiveRequirement moreRestrictive = MoreRestrictiveRequirement.None;
+            if (left.Right.Type != FieldType.Value || right.Right.Type != FieldType.Value)
+            {
+                // if either right is not a value field, then we can't merge
+                merged = null;
+
+                if (left.Right == right.Right)
+                {
+                    // unless they're the same value, then we can merge operators
+                    RequirementOperator mergedOperator;
+                    if (condition == ConditionalOperation.And)
+                        mergedOperator = MergeOperatorsAnd(left.Operator, right.Operator);
+                    else
+                        mergedOperator = MergeOperatorsOr(left.Operator, right.Operator);
+
+                    if (mergedOperator == RequirementOperator.Multiply)
+                    {
+                        merged = AlwaysTrueFunction.CreateAlwaysTrueRequirement();
+                        moreRestrictive = MoreRestrictiveRequirement.Everything;
+                    }
+                    else if (mergedOperator != RequirementOperator.None)
+                    {
+                        merged = MergeRequirements(left, right, MoreRestrictiveRequirement.Same);
+                        merged.Operator = mergedOperator;
+
+                        if (mergedOperator == left.Operator)
+                            moreRestrictive = MoreRestrictiveRequirement.Left;
+                        else if (mergedOperator == right.Operator)
+                            moreRestrictive = MoreRestrictiveRequirement.Right;
+                        else
+                            moreRestrictive = MoreRestrictiveRequirement.LeftMergeOperator;
+                    }
+                    else if (condition == ConditionalOperation.And)
+                    {
+                        merged = AlwaysFalseFunction.CreateAlwaysFalseRequirement();
+                        moreRestrictive = MoreRestrictiveRequirement.Conflict;
+                    }
+                }
+            }
+            else
+            {
+                // both right fields are values, see if there's overlap
+                if (condition == ConditionalOperation.And)
+                {
+                    // AND logic is straightforward
+                    moreRestrictive = GetMoreRestrictiveRequirement(left.Operator, left.Right.Value, right.Operator, right.Right.Value);
+                    merged = MergeRequirements(left, right, moreRestrictive);
+
+                    if (merged == null) // merge could not be performed
+                        moreRestrictive = MoreRestrictiveRequirement.None;
+                }
+                else
+                {
+                    // OR logic has to be doubly inverted:   A || B  ~>  !A && !B  ~>  C  ~>  !C
+                    var notLeft = new Requirement
+                    {
+                        Type = left.Type,
+                        Left = left.Left,
+                        Operator = Requirement.GetOpposingOperator(left.Operator),
+                        Right = left.Right,
+                        HitCount = left.HitCount
+                    };
+
+                    var notRight = new Requirement
+                    {
+                        Type = right.Type,
+                        Left = right.Left,
+                        Operator = Requirement.GetOpposingOperator(right.Operator),
+                        Right = right.Right,
+                        HitCount = right.HitCount
+                    };
+
+                    moreRestrictive = GetMoreRestrictiveRequirement(notLeft.Operator, notLeft.Right.Value, notRight.Operator, notRight.Right.Value);
+                    merged = MergeRequirements(notLeft, notRight, moreRestrictive);
+
+                    if (merged == null)
+                    {
+                        // merge could not be performed
+                        moreRestrictive = MoreRestrictiveRequirement.None;
+                    }
+                    else
+                    {
+                        if (moreRestrictive == MoreRestrictiveRequirement.Conflict)
+                        {
+                            // a conflict with the opposing conditions means all values will match when we invert again
+                            // expect merged to be the always_false() function and convert it to always_true()
+                            System.Diagnostics.Debug.Assert(merged.Evaluate() == false);
+                            merged = AlwaysTrueFunction.CreateAlwaysTrueRequirement();
+                            moreRestrictive = MoreRestrictiveRequirement.Everything;
+                        }
+                        else
+                        {
+                            merged.Operator = Requirement.GetOpposingOperator(merged.Operator);
+                        }
+                    }
+                }
+            }
+
+            return moreRestrictive;
+        }
+
+        public static RequirementEx MergeRequirements(RequirementEx first, RequirementEx second, ConditionalOperation condition)
+        {
+            RequirementEx merged;
+            MergeRequirements(first, second, condition, out merged);
+            return merged;
+        }
+
+        private static MoreRestrictiveRequirement MergeRequirements(RequirementEx first, RequirementEx second, ConditionalOperation condition, out RequirementEx merged)
+        {
+            merged = null;
+
+            if (first.Requirements.Count != second.Requirements.Count)
+                return MoreRestrictiveRequirement.Conflict;
+
+            Requirement mergedRequirement;
+            var result = new RequirementEx();
+
+            bool hasMerge = false;
+            bool hasMoreRestrictiveLeft = false;
+            bool hasMoreRestrictiveRight = false;
+            bool hasConflict = false;
+            bool hasEverything = false;
+            for (int i = 0; i < first.Requirements.Count; i++)
+            {
+                var moreRestrictive = MergeRequirements(first.Requirements[i], second.Requirements[i], condition, out mergedRequirement);
+                switch (moreRestrictive)
+                {
+                    case MoreRestrictiveRequirement.None:
+                        // could not be merged
+                        return MoreRestrictiveRequirement.None;
+
+                    case MoreRestrictiveRequirement.Conflict:
+                        hasConflict = true;
+                        break;
+
+                    case MoreRestrictiveRequirement.Everything:
+                        hasEverything = true;
+                        break;
+
+                    case MoreRestrictiveRequirement.LeftMergeOperator:
+                        hasMerge = true;
+                        goto case MoreRestrictiveRequirement.Left;
+
+                    case MoreRestrictiveRequirement.Left:
+                        if (hasMoreRestrictiveRight) // can only normalize to one side or the other
+                        {
+                            hasConflict = true;
+                            break;
+                        }
+                        hasMoreRestrictiveLeft = true;
+                        break;
+
+                    case MoreRestrictiveRequirement.RightMergeOperator:
+                        hasMerge = true;
+                        goto case MoreRestrictiveRequirement.Right;
+
+                    case MoreRestrictiveRequirement.Right:
+                        if (hasMoreRestrictiveLeft) // can only normalize to one side or the other
+                        {
+                            hasConflict = true;
+                            break;
+                        }
+                        hasMoreRestrictiveRight = true;
+                        break;
+
+                    case MoreRestrictiveRequirement.Same:
+                        break;
+
+                    default:
+                        if (mergedRequirement == null)
+                            return MoreRestrictiveRequirement.None;
+                        break;
+                }
+
+                result.Requirements.Add(mergedRequirement);
+            }
+
+            merged = result;
+
+            if (hasConflict)
+            {
+                result.Requirements.Clear();
+                result.Requirements.Add(AlwaysFalseFunction.CreateAlwaysFalseRequirement());
+                return MoreRestrictiveRequirement.Conflict;
+            }
+
+            if (hasEverything)
+            {
+                result.Requirements.Clear();
+                result.Requirements.Add(AlwaysTrueFunction.CreateAlwaysTrueRequirement());
+                return MoreRestrictiveRequirement.Everything;
+            }
+
+            if (hasMoreRestrictiveLeft)
+                return (hasMerge) ? MoreRestrictiveRequirement.LeftMergeOperator : MoreRestrictiveRequirement.Left;
+            if (hasMoreRestrictiveRight)
+                return (hasMerge) ? MoreRestrictiveRequirement.RightMergeOperator: MoreRestrictiveRequirement.Right;
+            return MoreRestrictiveRequirement.Same;
+        }
+
+        [DebuggerDisplay("Requirements.Count={Requirements.Count}, IsMergeable={IsMergeable}")]
+        private class RequirementGroupInfo
+        {
+            public RequirementGroupInfo(List<RequirementEx> requirements)
+            {
+                Requirements = requirements;
+                Addresses = new HashSet<uint>();
+                IsMergeable = true;
+            }
+
+            public List<RequirementEx> Requirements { get; private set; }
+            public HashSet<uint> Addresses { get; private set; }
+
+            public bool IsMergeable { get; set; }
+        }
+
+        private static MoreRestrictiveRequirement MergeRequirementGroups(RequirementGroupInfo left, RequirementGroupInfo right, ConditionalOperation condition)
+        {
+            // if one group has more requirements, make sure it's on the right
+            if (left.Requirements.Count > right.Requirements.Count)
+            {
+                var result = MergeRequirementGroups(right, left, condition);
+                switch (result)
+                {
+                    case MoreRestrictiveRequirement.Left:
+                        return MoreRestrictiveRequirement.Right;
+                    case MoreRestrictiveRequirement.Right:
+                        return MoreRestrictiveRequirement.Left;
+                    default:
+                        return result;
+                }
+            }
+
+            // make sure the smaller group is dependent on the same set of addresses as the larger group
+            if (!left.Addresses.All(a => right.Addresses.Contains(a)))
+                return MoreRestrictiveRequirement.Conflict;
+
+            // try to merge them
+            bool hasMerge = false;
+            bool hasConflict = false;
+            bool hasEverything = false;
+            MoreRestrictiveRequirement moreRestrictive = MoreRestrictiveRequirement.Same;
+            RequirementEx[] merged = new RequirementEx[left.Requirements.Count];
+            bool[] matches = new bool[right.Requirements.Count];
+
+            for (int i = 0; i < left.Requirements.Count; i++)
+            {
+                bool matched = false;
+
+                for (int j = 0; j < right.Requirements.Count; j++)
+                {
+                    if (matches[j]) // already matched this item, ignore it
+                        continue;
+
+                    var moreRestrictiveRequirement = RequirementMerger.MergeRequirements(
+                        left.Requirements[i], right.Requirements[j], condition, out merged[i]);
+                    switch (moreRestrictiveRequirement)
+                    {
+                        case MoreRestrictiveRequirement.LeftMergeOperator:
+                            if (hasMerge) // only allowed to merge operator at a time
+                                hasConflict = true;
+                            hasMerge = true;
+                            goto case MoreRestrictiveRequirement.Left;
+
+                        case MoreRestrictiveRequirement.Left:
+                            if (moreRestrictive == MoreRestrictiveRequirement.Right)
+                                return MoreRestrictiveRequirement.Conflict;
+                            moreRestrictive = MoreRestrictiveRequirement.Left;
+                            break;
+
+                        case MoreRestrictiveRequirement.RightMergeOperator:
+                            if (hasMerge) // only allowed to merge operator at a time
+                                hasConflict = true;
+                            hasMerge = true;
+                            goto case MoreRestrictiveRequirement.Right;
+
+                        case MoreRestrictiveRequirement.Right:
+                            if (moreRestrictive == MoreRestrictiveRequirement.Left)
+                                return MoreRestrictiveRequirement.Conflict;
+                            moreRestrictive = MoreRestrictiveRequirement.Right;
+                            break;
+
+                        case MoreRestrictiveRequirement.Same:
+                            break;
+
+                        case MoreRestrictiveRequirement.Conflict:
+                            hasConflict = true;
+                            break;
+
+                        case MoreRestrictiveRequirement.Everything:
+                            hasEverything = true;
+                            break;
+
+                        default:
+                            continue;
+                    }
+
+                    matched = true;
+                    matches[j] = true;
+                    break;
+                }
+
+                if (!matched)
+                    return MoreRestrictiveRequirement.None;
+            }
+
+            // the smaller group can be merged into the larger group
+            if (right.Requirements.Count > left.Requirements.Count)
+            {
+                // if one or more conditions conflicts with its partner, we have to assume the extra
+                // conditions are differentiators and we can't merge
+                if (hasEverything || hasConflict)
+                    return MoreRestrictiveRequirement.None;
+
+                switch (moreRestrictive)
+                {
+                    case MoreRestrictiveRequirement.Same:
+                        moreRestrictive = MoreRestrictiveRequirement.Left;
+                        break;
+
+                    case MoreRestrictiveRequirement.Left:
+                        // if left fully encompasses the matched conditions of right, we can discard the
+                        // extra conditions. if an operator had to be changed (hasMerge=true), we cannot.
+                        if (hasMerge)
+                            return MoreRestrictiveRequirement.None;
+                        break;
+
+                    case MoreRestrictiveRequirement.Right:
+                        // if a subset of the right side fully encompasses the left, it's still more
+                        // restrictive due to the extra conditions.
+                        return MoreRestrictiveRequirement.None;
+
+                    default:
+                        return MoreRestrictiveRequirement.Conflict;
+                }
+            }
+
+            // all conditions matched. if there was a Conflict, the whole thing failed
+            if (hasConflict)
+                return MoreRestrictiveRequirement.Conflict;
+
+            // success, replace the more restrictive group's contents with the merged results
+            RequirementGroupInfo resultGroup = left;
+            switch (moreRestrictive)
+            {
+                case MoreRestrictiveRequirement.Same:
+                    if (hasEverything)
+                    {
+                        // if at least one requirement was merged into an always_true, replace the left
+                        moreRestrictive = MoreRestrictiveRequirement.Left;
+                        goto case MoreRestrictiveRequirement.Left;
+                    }
+                    break;
+
+                case MoreRestrictiveRequirement.Left:
+                    left.Requirements.Clear();
+                    left.Requirements.AddRange(merged);
+                    break;
+
+                case MoreRestrictiveRequirement.Right:
+                    resultGroup = right;
+                    right.Requirements.Clear();
+                    right.Requirements.AddRange(merged);
+                    break;
+            }
+
+            // remove any always_true conditions. if nothing is left, return Everything so the parent
+            // can replace both groups with a single always_true.
+            if (hasEverything)
+            {
+                resultGroup.Requirements.RemoveAll(r => r.Evaluate() == true);
+                if (resultGroup.Requirements.Count == 0)
+                {
+                    var requirementEx = new RequirementEx();
+                    requirementEx.Requirements.Add(AlwaysTrueFunction.CreateAlwaysTrueRequirement());
+                    resultGroup.Requirements.Add(requirementEx);
+                    return MoreRestrictiveRequirement.Everything;
+                }
+            }
+
+            return moreRestrictive;
+        }
+
+        public static void MergeRequirementGroups(List<List<RequirementEx>> groups)
+        {
+            // determine which addresses each group depends on and how many groups depend on each address
+            var memoryReferences = new Dictionary<uint, uint>();
+            var mergeableGroups = new List<RequirementGroupInfo>();
+            foreach (var group in groups.Skip(1)) // ASSERT:groups[0] is core and should be ignored
+            {
+                var info = new RequirementGroupInfo(group);
+                foreach (var requirementEx in group)
+                {
+                    foreach (var requirement in requirementEx.Requirements)
+                    {
+                        if (requirement.Left.IsMemoryReference)
+                            info.Addresses.Add(requirement.Left.Value);
+                        if (requirement.Right.IsMemoryReference)
+                            info.Addresses.Add(requirement.Right.Value);
+                    }
+                }
+                foreach (var address in info.Addresses)
+                {
+                    uint count;
+                    memoryReferences.TryGetValue(address, out count);
+                    memoryReferences[address] = ++count;
+                }
+                mergeableGroups.Add(info);
+            }
+
+            // groups that only have unique addresses cannot be merged
+            for (int i = mergeableGroups.Count - 1; i >= 0; --i)
+            {
+                var info = mergeableGroups[i];
+                if (info.Addresses.Count > 0 && info.Addresses.All(a => memoryReferences[a] == 1))
+                    info.IsMergeable = false;
+            }
+
+            // if two alt groups are exactly identical, or can otherwise be represented by merging their
+            // logic, eliminate the redundant group.
+            for (int rightIndex = mergeableGroups.Count - 1; rightIndex > 0; rightIndex--)
+            {
+                // if all addresses that this group depends on are not used by at least one other group, it can't be merged
+                var rightGroup = mergeableGroups[rightIndex];
+                if (!rightGroup.IsMergeable)
+                    continue;
+
+                for (int leftIndex = rightIndex - 1; leftIndex >= 0; leftIndex--)
+                {
+                    var leftGroup = mergeableGroups[leftIndex];
+                    if (!leftGroup.IsMergeable)
+                        continue;
+
+                    var moreRestrictive = MergeRequirementGroups(leftGroup, rightGroup, ConditionalOperation.Or);
+                    switch (moreRestrictive)
+                    {
+                        case MoreRestrictiveRequirement.Same:
+                        case MoreRestrictiveRequirement.Left:
+                            rightGroup.IsMergeable = false;
+                            groups.Remove(rightGroup.Requirements);
+                            break;
+
+                        case MoreRestrictiveRequirement.Right:
+                            leftGroup.IsMergeable = false;
+                            groups.Remove(leftGroup.Requirements);
+                            break;
+
+                        case MoreRestrictiveRequirement.Everything:
+                            // union of these two groups encompasses all values, replace one with always_true()
+                            rightGroup.IsMergeable = false;
+                            groups.Remove(rightGroup.Requirements);
+
+                            var index = groups.IndexOf(leftGroup.Requirements);
+                            leftGroup.IsMergeable = false;
+                            groups.Remove(leftGroup.Requirements);
+
+                            var newGroup = new RequirementEx();
+                            newGroup.Requirements.Add(AlwaysTrueFunction.CreateAlwaysTrueRequirement());
+                            groups.Insert(index, new List<RequirementEx> { newGroup });
+                            break;
+
+                        default:
+                            break;
+                    }
+
+                    if (!rightGroup.IsMergeable)
+                        break;
+                }
+            }
+
+            // if at least two alt groups still exist, check for always_true and always_false placeholders
+            if (groups.Count > 2)
+            {
+                bool hasAlwaysTrue = false;
+
+                for (int j = groups.Count - 1; j >= 1; j--)
+                {
+                    if (groups[j].Count == 1)
+                    {
+                        var result = groups[j][0].Evaluate();
+                        if (result == false)
+                        {
+                            // an always_false alt group will not affect the logic, remove it
+                            groups.RemoveAt(j);
+                        }
+                        else if (result == true)
+                        {
+                            // an always_true alt group supercedes all other alt groups.
+                            // if we see one, keep track of that and we'll process it later.
+                            hasAlwaysTrue = true;
+                        }
+                    }
+                }
+
+                // if a trigger contains an always_true alt group, remove any other alt groups that don't
+                // have PauseIf or ResetIf conditions as they are unimportant
+                if (hasAlwaysTrue)
+                {
+                    bool alwaysTrueKept = false;
+                    for (int j = groups.Count - 1; j >= 1; j--)
+                    {
+                        if (groups[j].Count == 1 && groups[j][0].Evaluate() == true)
+                        {
+                            if (!alwaysTrueKept)
+                                alwaysTrueKept = true;
+                            else
+                                groups.RemoveAt(j);
+                            continue;
+                        }
+
+                        if (groups[j].All(r => r.Type != RequirementType.ResetIf && r.Type != RequirementType.PauseIf))
+                            groups.RemoveAt(j);
+                    }
+
+                    // if only the always_true group is left, get rid of it
+                    if (groups.Count == 2)
+                    {
+                        groups.RemoveAt(1);
+
+                        // if the core group is empty, add an explicit always_true
+                        if (groups[0].Count == 0)
+                        {
+                            var requirementEx = new RequirementEx();
+                            requirementEx.Requirements.Add(AlwaysTrueFunction.CreateAlwaysTrueRequirement());
+                            groups[0].Add(requirementEx);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Parser\Internal\FloatConstantExpression.cs" />
     <Compile Include="Parser\Internal\KeywordExpression.cs" />
     <Compile Include="Parser\Internal\LeftRightExpressionBase.cs" />
+    <Compile Include="Parser\RequirementMerger.cs" />
     <Compile Include="Parser\RichPresenceBuilder.cs" />
     <Compile Include="Parser\ScriptInterpreterAchievementBuilder.cs" />
     <Compile Include="Parser\TriggerBuilderContext.cs" />

--- a/Tests/Parser/Functions/FlagConditionFunctionTests.cs
+++ b/Tests/Parser/Functions/FlagConditionFunctionTests.cs
@@ -230,7 +230,7 @@ namespace RATools.Test.Parser.Functions
             // the hit target will prevent the optimizer from inverting the inner logic,
             // so the inner clause will retain its PauseIf. PauseIf and ResetIf are
             // mutually exclusive, so expect an error.
-            Evaluate("never(unless(byte(0x1234) == 56 && once(byte(0x2345) == 67)))", 
+            Evaluate("never(unless(byte(0x1234) == 56) && once(byte(0x2345) == 67))", 
                 "Cannot apply 'never' to condition already flagged with PauseIf");
         }
 

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -420,7 +420,6 @@ namespace RATools.Test.Parser.Functions
         {
             var errorMessage = "Modifier not allowed in subclause";
             Evaluate("repeated(4, never(byte(0x1234) == 5) || once(byte(0x1234) == 34))", errorMessage);
-            Evaluate("repeated(4, unless(byte(0x1234) == 5) || once(byte(0x1234) == 34))", errorMessage);
             Evaluate("repeated(4, measured(repeated(6, byte(0x1234) == 5)) || byte(0x1234) == 34)", errorMessage);
         }
 

--- a/Tests/Parser/Functions/TallyFunctionTests.cs
+++ b/Tests/Parser/Functions/TallyFunctionTests.cs
@@ -83,6 +83,50 @@ namespace RATools.Test.Parser.Functions
         }
 
         [Test]
+        public void TestMultipleLimited()
+        {
+            var requirements = Evaluate("tally(4, once(byte(0x1234) == 56), once(byte(0x1234) == 67))");
+            Assert.That(requirements.Count, Is.EqualTo(3));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.AddHits));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(1));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("67"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.AddHits));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(1));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("0"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void TestMultipleOr()
+        {
+            var requirements = Evaluate("tally(4, once(byte(0x1234) == 56) || once(byte(0x1234) == 67))");
+            Assert.That(requirements.Count, Is.EqualTo(3));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("56"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.OrNext));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(1));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("67"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.OrNext));
+            Assert.That(requirements[1].HitCount, Is.EqualTo(1));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("0"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(4));
+        }
+
+        [Test]
         public void TestNonConditionConstant()
         {
             Evaluate("tally(4, 6+2)", "comparison did not evaluate to a valid comparison");
@@ -410,7 +454,6 @@ namespace RATools.Test.Parser.Functions
         {
             var errorMessage = "Modifier not allowed in subclause";
             Evaluate("tally(4, never(byte(0x1234) == 5) || once(byte(0x1234) == 34))", errorMessage);
-            Evaluate("tally(4, unless(byte(0x1234) == 5) || once(byte(0x1234) == 34))", errorMessage);
             Evaluate("tally(4, measured(repeated(6, byte(0x1234) == 5)) || byte(0x1234) == 34)", errorMessage);
         }
 

--- a/Tests/Parser/RequirementMergerTests.cs
+++ b/Tests/Parser/RequirementMergerTests.cs
@@ -1,0 +1,230 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Parser;
+using RATools.Parser.Internal;
+
+namespace RATools.Test.Parser
+{
+    [TestFixture]
+    class RequirementMergerTests
+    {
+        private static AchievementBuilder CreateAchievement(string input, string expectedError = null)
+        {
+            // NOTE: these are integration tests as they rely on ExpressionBase.Parse and 
+            // AchievementScriptInterpreter.ScriptInterpreterAchievementBuilder, but using string 
+            // inputs /output makes reading the tests and validating the behavior easier for humans.
+            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
+            var expression = ExpressionBase.Parse(tokenizer);
+            if (expression is ParseErrorExpression)
+                Assert.Fail(((ParseErrorExpression)expression).Message);
+
+            var achievement = new ScriptInterpreterAchievementBuilder();
+            var error = achievement.PopulateFromExpression(expression);
+            if (expectedError != null)
+                Assert.That(error, Is.EqualTo(expectedError));
+            else
+                Assert.That(error, Is.Null.Or.Empty);
+
+            return achievement;
+        }
+
+        private void AssertLogicalMerge(string input, string y, string expected)
+        {
+            input = input.Replace("X", "6");
+            input = input.Replace("Y", y);
+            var logic = input;
+
+            input = input.Replace("A", "byte(0x00000A)");
+            input = input.Replace("B", "byte(0x00000B)");
+            input = input.Replace("C", "byte(0x00000C)");
+
+            var achievement = CreateAchievement(input);
+            achievement.Optimize();
+
+            var result = achievement.RequirementsDebugString;
+            result = result.Replace("byte(0x00000A)", "A");
+            result = result.Replace("byte(0x00000B)", "B");
+            result = result.Replace("byte(0x00000C)", "C");
+
+            if (expected == "ignore")
+            {
+                expected = logic;
+            }
+            else if (expected == "false ")
+            {
+                expected = "always_false()";
+            }
+            else if (expected == "true  ")
+            {
+                expected = "always_true()";
+            }
+            else
+            {
+                expected = expected.Replace("  ", " ");
+                expected = expected.Replace("X", "6");
+                expected = expected.Replace("Y", y);
+            }
+
+            Assert.That(result, Is.EqualTo(expected), logic);
+        }
+
+        [Test] //                      X == Y    X <  Y    X >  Y
+        [TestCase("A == X && A == Y", "A == X", "false ", "false ")]
+        [TestCase("A == X && A != Y", "false ", "A == X", "A == X")]
+        [TestCase("A == X && A <  Y", "false ", "A == X", "false ")]
+        [TestCase("A == X && A <= Y", "A == X", "A == X", "false ")]
+        [TestCase("A == X && A >  Y", "false ", "false ", "A == X")]
+        [TestCase("A == X && A >= Y", "A == X", "false ", "A == X")]
+        [TestCase("A != X && A == Y", "false ", "A == Y", "A == Y")]
+        [TestCase("A != X && A != Y", "A != X", "ignore", "ignore")]
+        [TestCase("A != X && A <  Y", "A <  Y", "ignore", "A <  Y")]
+        [TestCase("A != X && A <= Y", "A <  X", "ignore", "A <= Y")]
+        [TestCase("A != X && A >  Y", "A >  Y", "A >  Y", "ignore")]
+        [TestCase("A != X && A >= Y", "A >  Y", "A >= Y", "ignore")]
+        [TestCase("A >  X && A == Y", "false ", "A == Y", "false ")]
+        [TestCase("A >  X && A != Y", "A >  X", "ignore", "A >  X")]
+        [TestCase("A >  X && A <  Y", "false ", "ignore", "false ")]
+        [TestCase("A >  X && A <= Y", "false ", "ignore", "false ")]
+        [TestCase("A >  X && A >  Y", "A >  X", "A >  Y", "A >  X")]
+        [TestCase("A >  X && A >= Y", "A >  X", "A >= Y", "A >  X")]
+        [TestCase("A >= X && A == Y", "A == Y", "A == Y", "false ")]
+        [TestCase("A >= X && A != Y", "A >  X", "ignore", "A >= X")]
+        [TestCase("A >= X && A <  Y", "false ", "ignore", "false ")]
+        [TestCase("A >= X && A <= Y", "A == X", "ignore", "false ")]
+        [TestCase("A >= X && A >  Y", "A >  X", "A >  Y", "A >= X")]
+        [TestCase("A >= X && A >= Y", "A >= X", "A >= Y", "A >= X")]
+        [TestCase("A <  X && A == Y", "false ", "false ", "A == Y")]
+        [TestCase("A <  X && A != Y", "A <  X", "A <  X", "ignore")]
+        [TestCase("A <  X && A <  Y", "A <  X", "A <  X", "A <  Y")]
+        [TestCase("A <  X && A <= Y", "A <  X", "A <  X", "A <= Y")]
+        [TestCase("A <  X && A >  Y", "false ", "false ", "ignore")]
+        [TestCase("A <  X && A >= Y", "false ", "false ", "ignore")]
+        [TestCase("A <= X && A == Y", "A == Y", "false ", "A == Y")]
+        [TestCase("A <= X && A != Y", "A <  X", "A <= X", "ignore")]
+        [TestCase("A <= X && A <  Y", "A <  Y", "A <= X", "A <  Y")]
+        [TestCase("A <= X && A <= Y", "A <= X", "A <= X", "A <= Y")]
+        [TestCase("A <= X && A >  Y", "false ", "false ", "ignore")]
+        [TestCase("A <= X && A >= Y", "A == X", "false ", "ignore")]
+        public void TestMergeRequirementsAnd(string input, string expectedXEqualsY, string expectedXLessY, string expectedXGreaterY)
+        {
+            input = input.Replace("  ", " ");
+            AssertLogicalMerge(input, "6", expectedXEqualsY);
+            AssertLogicalMerge(input, "8", expectedXLessY);
+            AssertLogicalMerge(input, "4", expectedXGreaterY);
+        }
+
+        [Test] //                      X == Y    X <  Y    X >  Y
+        [TestCase("A == X || A == Y", "A == X", "ignore", "ignore")]
+        [TestCase("A == X || A != Y", "true  ", "A != Y", "A != Y")]
+        [TestCase("A == X || A <  Y", "A <= X", "A <  Y", "ignore")]
+        [TestCase("A == X || A <= Y", "A <= Y", "A <= Y", "ignore")]
+        [TestCase("A == X || A >  Y", "A >= X", "ignore", "A >  Y")]
+        [TestCase("A == X || A >= Y", "A >= Y", "ignore", "A >= Y")]
+        [TestCase("A != X || A == Y", "true  ", "A != X", "A != X")]
+        [TestCase("A != X || A != Y", "A != Y", "true  ", "true  ")]
+        [TestCase("A != X || A <  Y", "A != X", "true  ", "A != X")]
+        [TestCase("A != X || A <= Y", "true  ", "true  ", "A != X")]
+        [TestCase("A != X || A >  Y", "A != X", "A != X", "true  ")]
+        [TestCase("A != X || A >= Y", "true  ", "A != X", "true  ")]
+        [TestCase("A >  X || A == Y", "A >= X", "A >  X", "ignore")]
+        [TestCase("A >  X || A != Y", "A != Y", "true  ", "A != Y")]
+        [TestCase("A >  X || A <  Y", "A != X", "true  ", "ignore")]
+        [TestCase("A >  X || A <= Y", "true  ", "true  ", "ignore")]
+        [TestCase("A >  X || A >  Y", "A >  X", "A >  X", "A >  Y")]
+        [TestCase("A >  X || A >= Y", "A >= Y", "A >  X", "A >= Y")]
+        [TestCase("A >= X || A == Y", "A >= X", "A >= X", "ignore")]
+        [TestCase("A >= X || A != Y", "true  ", "true  ", "A != Y")]
+        [TestCase("A >= X || A <  Y", "true  ", "true  ", "ignore")]
+        [TestCase("A >= X || A <= Y", "true  ", "true  ", "ignore")]
+        [TestCase("A >= X || A >  Y", "A >= X", "A >= X", "A >  Y")]
+        [TestCase("A >= X || A >= Y", "A >= X", "A >= X", "A >= Y")]
+        [TestCase("A <  X || A == Y", "A <= X", "ignore", "A <  X")]
+        [TestCase("A <  X || A != Y", "A != Y", "A != Y", "true  ")]
+        [TestCase("A <  X || A <  Y", "A <  X", "A <  Y", "A <  X")]
+        [TestCase("A <  X || A <= Y", "A <= X", "A <= Y", "A <  X")]
+        [TestCase("A <  X || A >  Y", "A != X", "ignore", "true  ")]
+        [TestCase("A <  X || A >= Y", "true  ", "ignore", "true  ")]
+        [TestCase("A <= X || A == Y", "A <= X", "ignore", "A <= X")]
+        [TestCase("A <= X || A != Y", "true  ", "A != Y", "true  ")]
+        [TestCase("A <= X || A <  Y", "A <= X", "A <  Y", "A <= X")]
+        [TestCase("A <= X || A <= Y", "A <= X", "A <= Y", "A <= X")]
+        [TestCase("A <= X || A >  Y", "true  ", "ignore", "true  ")]
+        [TestCase("A <= X || A >= Y", "true  ", "ignore", "true  ")]
+        public void TestMergeRequirementsOr(string input, string expectedXEqualsY, string expectedXLessY, string expectedXGreaterY)
+        {
+            input = input.Replace("  ", " ");
+            AssertLogicalMerge(input, "6", expectedXEqualsY);
+            AssertLogicalMerge(input, "8", expectedXLessY);
+            AssertLogicalMerge(input, "4", expectedXGreaterY);
+        }
+
+        [Test]
+        [TestCase("A == B && A == B", "A == B")]
+        [TestCase("A == B && A != B", "false ")]
+        [TestCase("A == B && A >= B", "A == B")]
+        [TestCase("A == B && A >  B", "false ")]
+        [TestCase("A == B && A <= B", "A == B")]
+        [TestCase("A == B && A <  B", "false ")]
+        [TestCase("A == B && A == X", "ignore")]
+        [TestCase("A == B || A == B", "A == B")]
+        [TestCase("A == B || A != B", "true  ")]
+        [TestCase("A == B || A >= B", "A >= B")]
+        [TestCase("A == B || A >  B", "A >= B")]
+        [TestCase("A == B || A <= B", "A <= B")]
+        [TestCase("A == B || A <  B", "A <= B")]
+        [TestCase("A == B || A == X", "ignore")]
+        [TestCase("A == B && A != prev(B)", "ignore")]
+        [TestCase("A == X && prev(A) != X", "ignore")]
+        [TestCase("A == X && prev(A) == X", "ignore")]
+        public void TestMergeRequirementsNonValue(string input, string expected)
+        {
+            input = input.Replace("  ", " ");
+            AssertLogicalMerge(input, "8", expected);
+        }
+
+        [Test]
+        [TestCase("once(A == 1) && once(A == 2)", "ignore")] // once() should not cause a conflict
+        [TestCase("(A != 255 && B == 5 && A < 6)", "B == 5 && A < 6")] // A != 255 is handled by A < 6
+        [TestCase("once(C == 18 && A == 0 && B == 1) && never(A > 5)", "ignore")] // reset condition should not be merged into andnext chain
+        [TestCase("never((once(A == 0 && B == 1) && A > 5))", "ignore")] // hitcount on once(A/B) should prevent merge of A>5
+        [TestCase("never((once(once(C == 18) && A == 0 && B == 1) && A > 5))", "ignore")] // hitcount on once(A/B) should prevent merge of A>5
+        [TestCase("once(A == 0 && B == 1) && once(A == 0 && B == 1 && C == 2) && A > 5", "ignore")] // hitcount on once(A/B) should prevent merge of A>5
+        [TestCase("once(A == 0 && B == 1) && never((once(A == 0 && B == 1 && C == 2) && A > 5))", "ignore")] // hitcount on once(A/B) should prevent merge of A>5
+        [TestCase("(A == prev(B) && C > prev(C)) || (A != prev(B) && C > 1)", "ignore")]
+        [TestCase("(A > prev(A) && B > prev(B)) || (A == prev(A) && B == prev(B))", "ignore")]
+        public void TestMergeRequirementsComplex(string input, string expected)
+        {
+            AssertLogicalMerge(input, "8", expected);
+        }
+
+        [Test]
+        [TestCase("(A < 5 && B == 5) || (A < 5 && B == 5)", "A < 5 && B == 5")] // both are identical
+        [TestCase("(A < 5 && B == 5) || (A > 5 && B == 5)", "A != 5 && B == 5")] // B is identical, A can be merged
+        [TestCase("(A < 5 && B == 5) || (A > 5 && B == 6)", "ignore")] // B is not identical, A should not be merged
+        [TestCase("(A < 5 && B == 5) || (A <= 5 && B <= 6)", "A <= 5 && B <= 6")] // first group is a subset of second
+        [TestCase("(A < 5 && B >= 5) || (A <= 5 && B == 6)", "ignore")] // A is a subset of left, B is a subset of right, can't merge
+        [TestCase("(A < 5 && B == 5) || (A <= 5 && B >= 6 && C <= 7)", "ignore")] // A is a subset, but not B or C
+        [TestCase("(A < 5 && B == 5) || (A <= 5 && B <= 6 && C <= 7)", "ignore")] // A and B are a subset, but C is more restrictive
+        [TestCase("(A < 5 && B == 5) || A < 5", "A < 5")] // B is superfluous
+        [TestCase("(A < 5 && B == 5) || A <= 6", "A <= 6")] // B is superfluous
+        [TestCase("(A < 5 && B == 5) || A < 4", "ignore")] // B matters for A == 4
+        [TestCase("(A < 5 && B == 5) || B == 5", "B == 5")] // A is superfluous
+        [TestCase("(A < 5 && B == 5) || B < 6", "B < 6")] // A is superfluous
+        [TestCase("(A < 5 && B == 5) || B > 6", "ignore")] // A matters for B == 5
+        [TestCase("A > 7 || (A == 7 && B > 5)", "ignore")] // B matters for A == 7
+        [TestCase("(A == 7 && B > 5) || A > 7", "ignore")] // B matters for A == 7
+        [TestCase("(A <= 5 && B <= 6 && C <= 7) || (A < 5 && B == 5)", "ignore")] // A and B are a subset, but C is more restrictive
+        [TestCase("(A <= 5 && B <= 6) || (A < 5 && B == 5 && C <= 7)", "A <= 5 && B <= 6")] // A and B are a superset, so more restrive C can be discarded
+        [TestCase("(A < 5 && B == 5 && C <= 7) || (A <= 5 && B <= 6)", "A <= 5 && B <= 6")] // A and B are a superset, so more restrive C can be discarded
+        [TestCase("(A < 5 && B == 5) || (A <= 5 && B <= 6) || (A == 2 && B <= 8)", "(A <= 5 && B <= 6) || (A == 2 && B <= 8)")] // third group cannot be handled by second
+        [TestCase("(A < 5 && B == 5) || (A == 2 && B <= 4) || (A <= 5 && B <= 6)", "A <= 5 && B <= 6")] // double merge
+        [TestCase("(A < 5 && B == 5) || (A <= 5 && B <= 6) || (A == 2 && B <= 4)", "A <= 5 && B <= 6")] // double merge
+        [TestCase("(A <= 5 && B <= 6) || (A < 5 && B == 5) || (A == 2 && B <= 4)", "A <= 5 && B <= 6")] // double merge
+        [TestCase("(A == 1 && B == 2 && C == 3) || (A == 1 && B != 2 && C == 3)", "A == 1 && C == 3")] // conflicting Bs cancel each other out
+        [TestCase("(A == 1 && B == 2 && C == 3) || (A == 1 && B != 2 && C == 4)", "A == 1 && ((B == 2 && C == 3) || (B != 2 && C == 4))")] // unique Cs prevent merger, but A can still be extracted
+        public void TestMergeRequirementGroups(string input, string expected)
+        {
+            AssertLogicalMerge(input, "8", expected);
+        }
+    }
+}

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Parser\Functions\AnyOfFunctionTests.cs" />
     <Compile Include="Parser\Internal\BooleanConstantExpressionTests.cs" />
     <Compile Include="Parser\Internal\FloatConstantExpressionTests.cs" />
+    <Compile Include="Parser\RequirementMergerTests.cs" />
     <Compile Include="Parser\RichPresenceBuilderTests.cs" />
     <Compile Include="Parser\TriggerBuilderContextTests.cs" />
     <Compile Include="Parser\AchievementBuilderTests.cs" />


### PR DESCRIPTION
Makes requirement merging slightly more aggressive. Allowing for things like "A < 1 || A > 1" to be turned into "A != 1".

Also improves logic for detecting when its safe to invert ResetIf and PauseIf conditions, allowing them to be more aggressively optimized.