### PR TITLE
prevent IndexOutOfRangeException if RP macro has no parameter

### DIFF
--- a/ViewModels/NewScriptDialogViewModel.cs
+++ b/ViewModels/NewScriptDialogViewModel.cs
@@ -375,7 +375,7 @@ namespace RATools.ViewModels
                 if (macro == null)
                     macro = displayRichPresence;
 
-                if (parameter[1] == ':')
+                if (!String.IsNullOrEmpty(parameter) && parameter[1] == ':')
                 {
                     var achievement = new AchievementBuilder();
                     achievement.ParseRequirements(Tokenizer.CreateTokenizer(parameter));
@@ -1174,7 +1174,13 @@ namespace RATools.ViewModels
                     stream.Write("    ");
 
                     var macro = _macros.FirstOrDefault(m => m.Name == kvp.Key);
-                    if (macro.LookupEntries != null)
+                    if (macro == null)
+                    {
+                        stream.Write("rich_presence_value(\"");
+                        stream.Write(kvp.Key);
+                        stream.Write("\", ");
+                    }
+                    else if (macro.LookupEntries != null)
                     {
                         stream.Write("rich_presence_lookup(\"");
                         stream.Write(macro.Name);
@@ -1188,7 +1194,11 @@ namespace RATools.ViewModels
                     }
 
                     var parameter = kvp.Value;
-                    if (parameter[1] == ':')
+                    if (String.IsNullOrEmpty(parameter))
+                    {
+                        stream.Write("0");
+                    }
+                    else if (parameter[1] == ':')
                     {
                         var achievement = new AchievementBuilder();
                         achievement.ParseRequirements(Tokenizer.CreateTokenizer(parameter));
@@ -1206,7 +1216,11 @@ namespace RATools.ViewModels
                         DumpLegacyExpression(stream, parameter, dumpRichPresence);
                     }
 
-                    if (macro.LookupEntries != null)
+                    if (macro == null)
+                    {
+                        stream.Write(')');
+                    }
+                    else if (macro.LookupEntries != null)
                     { 
                         stream.Write(", ");
                         stream.Write(macro.Name);


### PR DESCRIPTION
Invalid input RP:
```
Display:
Rayman was last seen at @Loc() with @lives() lives and @ting() ting's
```
When creating a New Script with that RP, the attempt to extract the parameters was failing. After fixing that, the attempt to create the code was failing. Both have been fixed, and the following is now generated:
```
rich_presence_display("Rayman was last seen at {0} with {1} lives and {2} ting's",
    rich_presence_value("Loc", 0),
    rich_presence_value("lives", 0),
    rich_presence_value("ting", 0)
)
```