### PR TITLE
add array_map and tally_of functions

### DIFF
--- a/Data/RequirementEx.cs
+++ b/Data/RequirementEx.cs
@@ -267,7 +267,16 @@ namespace RATools.Data
 
             // finish with the final subclause
             var numParentheses = (requirements.Last().Type != RequirementType.None) ? 2 : 1;
-            builder.Append(repeatedString, index, repeatedString.Length - index - numParentheses);
+            var finalClause = repeatedString.Substring(index, repeatedString.Length - index - numParentheses);
+            if (finalClause == "always_false()")
+            {
+                // always_false() final clause separates tally target from individual condition targets
+                builder.Length -= 2; // remove ", "
+            }
+            else
+            {
+                builder.Append(finalClause);
+            }
 
             if (wrapWidth != Int32.MaxValue)
             {

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -132,6 +132,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new LengthFunction());
                 _globalScope.AddFunction(new ArrayPushFunction());
                 _globalScope.AddFunction(new ArrayPopFunction());
+                _globalScope.AddFunction(new ArrayMapFunction());
             }
 
             return _globalScope;

--- a/Parser/AchievementScriptInterpreter.cs
+++ b/Parser/AchievementScriptInterpreter.cs
@@ -126,6 +126,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new AnyOfFunction());
                 _globalScope.AddFunction(new NoneOfFunction());
                 _globalScope.AddFunction(new SumOfFunction());
+                _globalScope.AddFunction(new TallyOfFunction());
 
                 _globalScope.AddFunction(new RangeFunction());
                 _globalScope.AddFunction(new FormatFunction());

--- a/Parser/Functions/ArrayMapFunction.cs
+++ b/Parser/Functions/ArrayMapFunction.cs
@@ -9,6 +9,11 @@ namespace RATools.Parser.Functions
         {
         }
 
+        protected ArrayMapFunction(string name)
+            : base(name)
+        {
+        }
+
         protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
         {
             var array = left as ArrayExpression;

--- a/Parser/Functions/ArrayMapFunction.cs
+++ b/Parser/Functions/ArrayMapFunction.cs
@@ -1,0 +1,27 @@
+﻿using RATools.Parser.Internal;
+
+namespace RATools.Parser.Functions
+{
+    internal class ArrayMapFunction : IterableJoiningFunction
+    {
+        public ArrayMapFunction()
+            : base("array_map")
+        {
+        }
+
+        protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
+        {
+            var array = left as ArrayExpression;
+            if (array == null)
+                array = new ArrayExpression();
+
+            array.Entries.Add(right);
+            return array;
+        }
+
+        protected override ExpressionBase GenerateEmptyResult()
+        {
+            return new ArrayExpression();
+        }
+    }
+}

--- a/Parser/Functions/TallyOfFunction.cs
+++ b/Parser/Functions/TallyOfFunction.cs
@@ -1,0 +1,30 @@
+﻿using RATools.Parser.Internal;
+
+namespace RATools.Parser.Functions
+{
+    internal class TallyOfFunction : ArrayMapFunction
+    {
+        public TallyOfFunction()
+            : base("tally_of")
+        {
+            Parameters.Clear();
+            Parameters.Add(new VariableDefinitionExpression("inputs"));
+            Parameters.Add(new VariableDefinitionExpression("count"));
+            Parameters.Add(new VariableDefinitionExpression("predicate"));
+        }
+
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            var count = GetIntegerParameter(scope, "count", out result);
+            if (count == null)
+                return false;
+
+            if (!base.ReplaceVariables(scope, out result))
+                return false;
+
+            result = new FunctionCallExpression("tally", new ExpressionBase[] { count, result });
+            CopyLocation(result);
+            return true;
+        }
+    }
+}

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Data\Requirement.cs" />
     <Compile Include="Data\RequirementEx.cs" />
     <Compile Include="Parser\AchievementScriptContext.cs" />
+    <Compile Include="Parser\Functions\ArrayMapFunction.cs" />
     <Compile Include="Parser\Functions\RichPresenceMacroFunction.cs" />
     <Compile Include="Parser\Functions\UnlessFunction.cs" />
     <Compile Include="Parser\Functions\NeverFunction.cs" />

--- a/RATools.csproj
+++ b/RATools.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Parser\AchievementScriptContext.cs" />
     <Compile Include="Parser\Functions\ArrayMapFunction.cs" />
     <Compile Include="Parser\Functions\RichPresenceMacroFunction.cs" />
+    <Compile Include="Parser\Functions\TallyOfFunction.cs" />
     <Compile Include="Parser\Functions\UnlessFunction.cs" />
     <Compile Include="Parser\Functions\NeverFunction.cs" />
     <Compile Include="Parser\Functions\TriggerWhenFunction.cs" />

--- a/Tests/Data/RequirementExTests.cs
+++ b/Tests/Data/RequirementExTests.cs
@@ -38,8 +38,9 @@ namespace RATools.Test.Data
         [TestCase("Z:0xH002345=2_0xH001234=1.2.", "repeated(2, byte(0x001234) == 1 && never(byte(0x002345) == 2))")]
         [TestCase("Z:0xH002345=2_P:0xH001234=1.1.", "disable_when(byte(0x001234) == 1, until=byte(0x002345) == 2)")]
         [TestCase("Z:0xH002345=2_P:0xH001234=1.2.", "disable_when(repeated(2, byte(0x001234) == 1), until=byte(0x002345) == 2)")]
-        [TestCase("A:10_T:d0xH001234<=0xH001234.70.", "trigger_when(repeated(70, (10 + prev(byte(0x001234))) <= byte(0x001234)))")]
+        [TestCase("C:0xH001234=1.10._C:0xH001234=2.10._0=1.15.", "tally(15, repeated(10, byte(0x001234) == 1), repeated(10, byte(0x001234) == 2))")]
         [TestCase("A:9=0_C:d0xH001234<=0xH001234_A:10=0_d0xH001234<=0xH001234.70.", "tally(70, (9 + prev(byte(0x001234))) <= byte(0x001234), (10 + prev(byte(0x001234))) <= byte(0x001234))")]
+        [TestCase("A:10_T:d0xH001234<=0xH001234.70.", "trigger_when(repeated(70, (10 + prev(byte(0x001234))) <= byte(0x001234)))")]
         [TestCase("A:9_C:d0xH001234<=0xH001234_A:10_T:d0xH001234<=0xH001234.70.", "trigger_when(tally(70, (9 + prev(byte(0x001234))) <= byte(0x001234), (10 + prev(byte(0x001234))) <= byte(0x001234)))")]
         [TestCase("N:0xU001234=d0xU001234_C:d0xL001234<=0xL001234_T:d0xH001234<=0xH001234.70.",
                   "trigger_when(tally(70, (high4(0x001234) == prev(high4(0x001234)) && prev(low4(0x001234)) <= low4(0x001234)), prev(byte(0x001234)) <= byte(0x001234)))")]

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -593,7 +593,7 @@ namespace RATools.Test.Parser
         [TestCase("always_true() || byte(0x001234) == 2 || (byte(0x001234) == 3 && unless(byte(0x002345) == 1)) || (once(byte(0x001234) == 4) && never(byte(0x002345) == 1))",
             "always_true() || (once(byte(0x001234) == 4) && never(byte(0x002345) == 1))")] // always_true alt causes groups without pauseif or resetif to be removed
         [TestCase("tally(2, once(byte(0x1111) == 1 && byte(0x2222) == 0), once(byte(0x1111) == 2 && byte(0x2222) == 0))",
-            "tally(2, once(byte(0x001111) == 1 && byte(0x002222) == 0), once(byte(0x001111) == 2 && byte(0x002222) == 0), always_false())")]
+            "tally(2, once(byte(0x001111) == 1 && byte(0x002222) == 0), once(byte(0x001111) == 2 && byte(0x002222) == 0))")]
         public void TestOptimizeMergeDuplicateAlts(string input, string expected)
         {
             var achievement = CreateAchievement(input);
@@ -664,7 +664,7 @@ namespace RATools.Test.Parser
         [TestCase("once(always_false() || word(0x1234) >= 284 && word(0x1234) <= 301)",
                   "once(word(0x001234) >= 284 && word(0x001234) <= 301)")] // OrNext will move always_false to end, which will have the HitCount, HitCount should be kept when always_false is eliminated
         [TestCase("tally(2, once(always_false() || word(0x1234) >= 284 && word(0x1234) <= 301))",
-                  "tally(2, once(word(0x001234) >= 284 && word(0x001234) <= 301), always_false())")] // always_false() inside once() is optimized out, but a new one must be added for the tally since very subclause has a hit target
+                  "tally(2, once(word(0x001234) >= 284 && word(0x001234) <= 301))")] // always_false() inside once() is optimized out
         [TestCase("tally(2, once(byte(0x1234) == 1) || once(byte(0x1234) == 2) || once(byte(0x1234) == 3))",
                   "repeated(2, once(byte(0x001234) == 1) || once(byte(0x001234) == 2) || once(byte(0x001234) == 3) || always_false())")] // always_false has to be added since every subclause has a hit target and should not be eliminated
         [TestCase("measured(byte(0x1234) == 120, when = (byte(0x2345) == 6 || byte(0x2346) == 7))", // OrNext in MeasuredIf should not be split into alts

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -149,14 +149,6 @@ namespace RATools.Test.Parser
         }
 
         [Test]
-        public void TestEmptyTrigger()
-        {
-            // tally() of empty array will result in to conditions for the trigger
-            var parser = Parse("achievement(\"T\", \"D\", 5, tally(4, []))", false);
-            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:26 Incomplete trigger condition"));
-        }
-
-        [Test]
         public void TestDictionaryLookup()
         {
             var parser = Parse("dict = { 1: \"T\", 2: \"D\" }\n" +

--- a/Tests/Parser/Functions/ArrayMapFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayMapFunctionTests.cs
@@ -1,0 +1,111 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Parser;
+using RATools.Parser.Functions;
+using RATools.Parser.Internal;
+using System.Linq;
+
+namespace RATools.Test.Parser.Functions
+{
+    [TestFixture]
+    class ArrayMapFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new ArrayMapFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("array_map"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(2));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("inputs"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("predicate"));
+        }
+
+        private static string Evaluate(string input)
+        {
+            var tokenizer = Tokenizer.CreateTokenizer(input);
+            var expr = ExpressionBase.Parse(new PositionalTokenizer(tokenizer));
+            var funcCall = expr as FunctionCallExpression;
+            if (funcCall != null)
+            {
+                var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+                scope.Context = new AssignmentExpression(new VariableExpression("t"), expr);
+                if (funcCall.Evaluate(scope, out expr))
+                {
+                    var builder = new System.Text.StringBuilder();
+                    expr.AppendString(builder);
+                    return builder.ToString();
+                }
+            }
+
+            var error = expr as ParseErrorExpression;
+            if (error != null)
+                return error.InnermostError.Message;
+
+            return expr.ToString();
+        }
+
+        [Test]
+        public void TestSimple()
+        {
+            Assert.That(Evaluate("array_map([1, 2, 3], a => byte(a))"),
+                Is.EqualTo("[byte(1), byte(2), byte(3)]"));
+        }
+
+        [Test]
+        public void TestSingleElement()
+        {
+            Assert.That(Evaluate("array_map([1], a => a + 2)"),
+                Is.EqualTo("[3]"));
+        }
+
+        [Test]
+        public void TestNonIterable()
+        {
+            Assert.That(Evaluate("array_map(1, a => byte(a))"),
+                Is.EqualTo("Cannot iterate over IntegerConstant: 1"));
+        }
+
+        [Test]
+        public void TestNoElements()
+        {
+            Assert.That(Evaluate("array_map([], a => byte(a))"),
+                Is.EqualTo("[]"));
+        }
+
+        [Test]
+        public void TestLogic()
+        {
+            // if the predicate returns false, ignore the item
+            Assert.That(Evaluate("array_map([1, 2, 3], (a) { if (a % 2 == 0) { return byte(a) } else { return false }})"),
+                Is.EqualTo("[false, byte(2), false]"));
+        }
+
+        [Test]
+        public void TestRange()
+        {
+            Assert.That(Evaluate("array_map(range(1,5,2), a => byte(a))"),
+                Is.EqualTo("[byte(1), byte(3), byte(5)]"));
+        }
+
+        [Test]
+        public void TestDictionary()
+        {
+            Assert.That(Evaluate("array_map({1:\"One\",2:\"Two\",3:\"Three\"}, a => byte(a))"),
+                Is.EqualTo("[byte(1), byte(2), byte(3)]"));
+        }
+
+        [Test]
+        public void TestPredicateWithNoParameters()
+        {
+            Assert.That(Evaluate("array_map([1], () => byte(0x1234))"),
+                Is.EqualTo("predicate function must accept a single parameter"));
+        }
+
+        [Test]
+        public void TestPredicateWithExtraParameters()
+        {
+            Assert.That(Evaluate("array_map([1], (a, b) => byte(a))"),
+                Is.EqualTo("predicate function must accept a single parameter"));
+        }
+    }
+}

--- a/Tests/Parser/Functions/TallyOfFunctionTests.cs
+++ b/Tests/Parser/Functions/TallyOfFunctionTests.cs
@@ -12,7 +12,7 @@ namespace RATools.Test.Parser.Functions
         [Test]
         public void TestDefinition()
         {
-            var def = new SumOfFunction();
+            var def = new TallyOfFunction();
             Assert.That(def.Name.Name, Is.EqualTo("tally_of"));
             Assert.That(def.Parameters.Count, Is.EqualTo(3));
             Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("inputs"));
@@ -46,37 +46,37 @@ namespace RATools.Test.Parser.Functions
         [Test]
         public void TestSingleElement()
         {
-            Assert.That(Evaluate("sum_of([1], a => byte(a)) == 9"),
-                Is.EqualTo("byte(0x000001) == 9"));
+            Assert.That(Evaluate("tally_of([1], 99, a => byte(a) == 9)"),
+                Is.EqualTo("repeated(99, byte(0x000001) == 9)"));
         }
 
         [Test]
         public void TestNoElements()
         {
-            Assert.That(Evaluate("sum_of([], a => byte(a)) == byte(9)"),
-                Is.EqualTo("byte(0x000009) == 0"));
+            Assert.That(Evaluate("tally_of([], 4, a => byte(a) == 9) && byte(0x2345) == 6"),
+                Is.EqualTo("tally requires at least one non-deducted item"));
         }
 
         [Test]
         public void TestLogic()
         {
             // always_false() elements returned by predicate will be optimized out by the AchievementScriptInterpreter
-            Assert.That(Evaluate("sum_of([1, 2, 3], (a) { if (a % 2 == 0) { return byte(a) } else { return 0 }}) == 9"),
-                Is.EqualTo("byte(0x000002) == 9"));
+            Assert.That(Evaluate("tally_of([1, 2, 3], 7, (a) { if (a % 2 == 0) { return byte(a) == 9 } else { return always_false() }})"),
+                Is.EqualTo("repeated(7, byte(0x000002) == 9)"));
         }
 
         [Test]
         public void TestRange()
         {
-            Assert.That(Evaluate("sum_of(range(1,5,2), a => byte(a)) == 9"),
-                Is.EqualTo("(byte(0x000001) + byte(0x000003) + byte(0x000005)) == 9"));
+            Assert.That(Evaluate("tally_of(range(1,5,2), 11, a => byte(a) == 9)"),
+                Is.EqualTo("tally(11, byte(0x000001) == 9, byte(0x000003) == 9, byte(0x000005) == 9)"));
         }
 
         [Test]
         public void TestDictionary()
         {
-            Assert.That(Evaluate("sum_of({1:\"One\",2:\"Two\",3:\"Three\"}, a => byte(a)) == 9"),
-                Is.EqualTo("(byte(0x000001) + byte(0x000002) + byte(0x000003)) == 9"));
+            Assert.That(Evaluate("tally_of({1:\"One\",2:\"Two\",3:\"Three\"}, 11, a => byte(a) == 9)"),
+                Is.EqualTo("tally(11, byte(0x000001) == 9, byte(0x000002) == 9, byte(0x000003) == 9)"));
         }
     }
 }

--- a/Tests/Parser/Functions/TallyOfFunctionTests.cs
+++ b/Tests/Parser/Functions/TallyOfFunctionTests.cs
@@ -1,0 +1,82 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Parser;
+using RATools.Parser.Functions;
+using System.Linq;
+
+namespace RATools.Test.Parser.Functions
+{
+    [TestFixture]
+    class TallyOfFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new SumOfFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("tally_of"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(3));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("inputs"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("count"));
+            Assert.That(def.Parameters.ElementAt(2).Name, Is.EqualTo("predicate"));
+        }
+
+        private static string Evaluate(string input)
+        {
+            var script = "achievement(\"title\", \"desc\", 5,\n" + input + "\n)";
+            var tokenizer = Tokenizer.CreateTokenizer(script);
+            var parser = new AchievementScriptInterpreter();
+
+            if (parser.Run(tokenizer))
+            {
+                var achievement = parser.Achievements.First();
+                var builder = new AchievementBuilder(achievement);
+                return builder.RequirementsDebugString;
+            }
+
+            return parser.Error.InnermostError.Message;
+        }
+
+        [Test]
+        public void TestSimple()
+        {
+            Assert.That(Evaluate("tally_of([1, 2, 3], 3, a => once(byte(a) == 9))"),
+                Is.EqualTo("tally(3, once(byte(0x000001) == 9), once(byte(0x000002) == 9), once(byte(0x000003) == 9))"));
+        }
+
+        [Test]
+        public void TestSingleElement()
+        {
+            Assert.That(Evaluate("sum_of([1], a => byte(a)) == 9"),
+                Is.EqualTo("byte(0x000001) == 9"));
+        }
+
+        [Test]
+        public void TestNoElements()
+        {
+            Assert.That(Evaluate("sum_of([], a => byte(a)) == byte(9)"),
+                Is.EqualTo("byte(0x000009) == 0"));
+        }
+
+        [Test]
+        public void TestLogic()
+        {
+            // always_false() elements returned by predicate will be optimized out by the AchievementScriptInterpreter
+            Assert.That(Evaluate("sum_of([1, 2, 3], (a) { if (a % 2 == 0) { return byte(a) } else { return 0 }}) == 9"),
+                Is.EqualTo("byte(0x000002) == 9"));
+        }
+
+        [Test]
+        public void TestRange()
+        {
+            Assert.That(Evaluate("sum_of(range(1,5,2), a => byte(a)) == 9"),
+                Is.EqualTo("(byte(0x000001) + byte(0x000003) + byte(0x000005)) == 9"));
+        }
+
+        [Test]
+        public void TestDictionary()
+        {
+            Assert.That(Evaluate("sum_of({1:\"One\",2:\"Two\",3:\"Three\"}, a => byte(a)) == 9"),
+                Is.EqualTo("(byte(0x000001) + byte(0x000002) + byte(0x000003)) == 9"));
+        }
+    }
+}

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Parser\Functions\ArrayMapFunctionTests.cs" />
     <Compile Include="Parser\Functions\PrevPriorFunctionTests.cs" />
     <Compile Include="Parser\Functions\RichPresenceMacroFunctionTests.cs" />
+    <Compile Include="Parser\Functions\TallyOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\SumOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\NoneOfFunctionTests.cs" />
     <Compile Include="Parser\Functions\AllOfFunctionTests.cs" />

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Data\RequirementTests.cs" />
     <Compile Include="Data\FieldTests.cs" />
     <Compile Include="Parser\Functions\AchievementFunctionTests.cs" />
+    <Compile Include="Parser\Functions\ArrayMapFunctionTests.cs" />
     <Compile Include="Parser\Functions\PrevPriorFunctionTests.cs" />
     <Compile Include="Parser\Functions\RichPresenceMacroFunctionTests.cs" />
     <Compile Include="Parser\Functions\SumOfFunctionTests.cs" />


### PR DESCRIPTION
`array_map(array, predicate)` converts each element of array by passing it through the predicate function:
```
array_map([1,2,3], a => a*2)  =>  [2,4,6]
```

`tally_of(array, count, predicate)` creates a `tally` call by passing `array` through `predicate`:
```
tally_of([1,2,3], 2, a => once(byte(0x1234) == a))
=>
tally(2, once(byte(0x1234) == 1), once(byte(0x1234) == 2), once(byte(0x1234) == 3))
```