### PR TITLE
support for OrNext in ResetNextIf clause

### DIFF
--- a/Data/Requirement.cs
+++ b/Data/Requirement.cs
@@ -252,12 +252,20 @@ namespace RATools.Data
                 if (resetNextIf != null)
                 {
                     builder.Append(" && never(");
-                    builder.Append(resetNextIf);
+                    builder.Append(RemoveOuterParentheses(resetNextIf));
                     builder.Append(")");
                 }
 
                 builder.Append(')');
             }
+        }
+
+        private static string RemoveOuterParentheses(string input)
+        {
+            while (input.Length > 2 && input[0] == '(' && input[input.Length - 1] == ')')
+                input = input.Substring(1, input.Length - 2);
+
+            return input;
         }
 
         internal void AppendCondition(StringBuilder builder, NumberFormat numberFormat, 

--- a/Data/RequirementEx.cs
+++ b/Data/RequirementEx.cs
@@ -350,6 +350,9 @@ namespace RATools.Data
                         // remove "resetnext_if(" and ")" - they'll get converted to "never()" when resetNextIf is used
                         resetNextIf.Length--;
                         resetNextIf.Remove(0, 13);
+
+                        andNext.Clear();
+                        lastAndNext = null;
                         break;
 
                     default:

--- a/Tests/Data/RequirementExTests.cs
+++ b/Tests/Data/RequirementExTests.cs
@@ -48,6 +48,10 @@ namespace RATools.Test.Data
                   "trigger_when(tally(70, (high4(0x001234) == prev(high4(0x001234)) && (2 + prev(low4(0x001234))) <= low4(0x001234)), prev(byte(0x001234)) <= byte(0x001234)))")]
         [TestCase("A:2_C:d0xL001234<=0xL001234_N:0xU001234=d0xU001234_T:d0xH001234<=0xH001234.70.",
                   "trigger_when(tally(70, (2 + prev(low4(0x001234))) <= low4(0x001234), high4(0x001234) == prev(high4(0x001234)) && prev(byte(0x001234)) <= byte(0x001234)))")]
+        [TestCase("R:0xH001234<5_R:0xH001234>8_N:0xH002345=1_0xH003456=2.10.",
+                  "never(byte(0x001234) < 5)|never(byte(0x001234) > 8)|repeated(10, byte(0x002345) == 1 && byte(0x003456) == 2)")]
+        [TestCase("O:0xH001234<5_Z:0xH001234>8_N:0xH002345=1_0xH003456=2.10.",
+                  "repeated(10, byte(0x002345) == 1 && byte(0x003456) == 2 && never(byte(0x001234) < 5 || byte(0x001234) > 8))")]
         public void TestAppendString(string input, string expected)
         {
             var achievement = new AchievementBuilder();

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -645,12 +645,18 @@ namespace RATools.Test.Parser
 
         [TestCase("repeated(2, byte(0x1234) == 120 || byte(0x1234) == 126)",
                   "repeated(2, byte(0x001234) == 120 || byte(0x001234) == 126)")]
+        [TestCase("repeated(2, byte(0x1234) == 120 || byte(0x1234) == 126)",
+                  "repeated(2, byte(0x001234) == 120 || byte(0x001234) == 126)")]
         [TestCase("measured(repeated(2, byte(0x1234) == 120 || byte(0x1234) == 126))",
                   "measured(repeated(2, byte(0x001234) == 120 || byte(0x001234) == 126))")]
         [TestCase("once(byte(0x2345) == 1) && never(!(byte(0x1234) <= 8 && byte(0x1234) >= 6))",
                   "once(byte(0x002345) == 1) && never(byte(0x001234) > 8) && never(byte(0x001234) < 6)")]
         [TestCase("never(!(byte(0x1234) <= 8 && byte(0x1234) >= 6) && byte(0x2345) >= 10)", 
                   "never((byte(0x001234) > 8 || byte(0x001234) < 6) && byte(0x002345) >= 10)")]
+        [TestCase("repeated(10, byte(0x2345) == 1 && byte(0x3456) == 2 && never(byte(0x1234) < 5 || byte(0x1234) > 8))", // never will be converted to a ResetNextIf (before repeated), which will be further converted to two ResetIfs
+                  "never(byte(0x001234) < 5) && never(byte(0x001234) > 8) && repeated(10, byte(0x002345) == 1 && byte(0x003456) == 2)")]
+        [TestCase("repeated(10, byte(0x2345) == 1 && byte(0x3456) == 2 && never(byte(0x1234) < 5 || byte(0x1234) > 8)) && once(byte(0x5678) == 2)",
+                  "repeated(10, byte(0x002345) == 1 && byte(0x003456) == 2 && never(byte(0x001234) < 5 || byte(0x001234) > 8)) && once(byte(0x005678) == 2)")]
         public void TestOptimizeDenormalizeOrNexts(string input, string expected)
         {
             var achievement = CreateAchievement(input);

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -461,5 +461,32 @@ namespace RATools.Test.Parser.Functions
             Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.None));
             Assert.That(requirements[2].HitCount, Is.EqualTo(2));
         }
+
+        [Test]
+        public void TestNeverOr()
+        {
+            var requirements = Evaluate("repeated(10, byte(0x002345) == 1 && byte(0x003456) == 2 && never(byte(0x001234) < 5 || byte(0x001234) > 8))");
+            Assert.That(requirements.Count, Is.EqualTo(4));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.LessThan));
+            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("5"));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.OrNext)); // optimizer was not called
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.GreaterThan));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("8"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.ResetNextIf)); // optimizer was not called
+            Assert.That(requirements[1].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[2].Left.ToString(), Is.EqualTo("byte(0x002345)"));
+            Assert.That(requirements[2].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[2].Right.ToString(), Is.EqualTo("1"));
+            Assert.That(requirements[2].Type, Is.EqualTo(RequirementType.AndNext));
+            Assert.That(requirements[2].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[3].Left.ToString(), Is.EqualTo("byte(0x003456)"));
+            Assert.That(requirements[3].Operator, Is.EqualTo(RequirementOperator.Equal));
+            Assert.That(requirements[3].Right.ToString(), Is.EqualTo("2"));
+            Assert.That(requirements[3].Type, Is.EqualTo(RequirementType.None));
+            Assert.That(requirements[3].HitCount, Is.EqualTo(10));
+        }
     }
 }


### PR DESCRIPTION
fixes "only one never() clause" error when doing `repeated(3, b==1 && never(a==6 || a==7))`