### PR TITLE
add API Key to settings dialog

### DIFF
--- a/Source/ViewModels/OptionsDialogViewModel.cs
+++ b/Source/ViewModels/OptionsDialogViewModel.cs
@@ -5,6 +5,7 @@ using Jamiras.Services;
 using Jamiras.ViewModels;
 using Jamiras.ViewModels.Fields;
 using RATools.Services;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -28,6 +29,11 @@ namespace RATools.ViewModels
 
             UserName = new TextFieldViewModel("UserName", 80);
             UserName.Text = settings.UserName;
+
+            ApiKey = new SecretTextFieldViewModel("ApiKey", 32);
+            ApiKey.SecretText = settings.ApiKey;
+
+            SettingsLinkCommand = new DelegateCommand(OpenSettingsLink);
 
             Directories = new ObservableCollection<DirectoryViewModel>();
             foreach (var path in settings.EmulatorDirectories)
@@ -74,6 +80,15 @@ namespace RATools.ViewModels
 
         public TextFieldViewModel UserName { get; private set; }
 
+        public SecretTextFieldViewModel ApiKey { get; private set; }
+
+        public CommandBase SettingsLinkCommand { get; private set; }
+
+        private void OpenSettingsLink()
+        {
+            ServiceRepository.Instance.FindService<IBrowserService>().OpenUrl("https://retroachievements.org/controlpanel.php");
+        }
+
         public class DirectoryViewModel
         {
             public string Path { get; set; }
@@ -94,6 +109,7 @@ namespace RATools.ViewModels
         {
             var settings = (Settings)_settings;
             settings.UserName = UserName.Text;
+            settings.ApiKey = ApiKey.SecretText;
 
             settings.EmulatorDirectories.Clear();
             foreach (var directoryViewModel in Directories)

--- a/Source/Views/OptionsDialog.xaml
+++ b/Source/Views/OptionsDialog.xaml
@@ -3,14 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:RATools"
              xmlns:jamiras="clr-namespace:Jamiras.Controls;assembly=Jamiras.Core"
              mc:Ignorable="d" 
-             Width="600" Height="312">
+             Width="600" Height="325">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/Jamiras.Core;component/Controls/Styles/FieldStyles.xaml" />
+                <ResourceDictionary Source="/Jamiras.Core;component/Controls/Styles/SubtleHyperlink.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
@@ -18,6 +18,7 @@
         <TabItem Header="General">
             <Grid Margin="4">
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
@@ -29,7 +30,28 @@
                     </StackPanel>
                 </GroupBox>
 
-                <GroupBox Grid.Row="1" Header="Emulator Directories">
+                <GroupBox Grid.Row="1" Header="Web API Key">
+                    <StackPanel>
+                        <TextBlock Margin="2" FontSize="11">
+                            <Run>Only needed for some of the Analysis tools. Can be found on the</Run>
+                            <Hyperlink Command="{Binding SettingsLinkCommand}" Style="{StaticResource subtleHyperlink}">
+                                <TextBlock Text="Settings" />
+                            </Hyperlink>
+                            <Run>page of the website.</Run>
+                        </TextBlock>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding ApiKey.Text}" Margin="2" MaxLength="{Binding ApiKey.MaxLength}" />
+                            <ToggleButton Grid.Column="1" HorizontalAlignment="Right" Content="&#x1F441;" Margin="0,0,2,0"
+                                          Height="18" Padding="0,-4,0,-2" IsChecked="{Binding ApiKey.IsUnmasked}" />
+                        </Grid>
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox Grid.Row="2" Header="Emulator Directories">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -68,7 +90,7 @@
                             </ListView.ItemTemplate>
                         </ListView>
 
-                        <Button Grid.Row="2" HorizontalAlignment="Left" Width="80" 
+                        <Button Grid.Row="3" HorizontalAlignment="Left" Width="80" 
                                 Content="Remove" Command="{Binding RemoveDirectoryCommand}">
                             <Button.Style>
                                 <Style TargetType="{x:Type Button}">
@@ -81,7 +103,7 @@
                             </Button.Style>
                         </Button>
 
-                        <Button Grid.Row="2" HorizontalAlignment="Right" Width="80" 
+                        <Button Grid.Row="3" HorizontalAlignment="Right" Width="80" 
                                 Content="Add" Command="{Binding AddDirectoryCommand}" />
                     </Grid>
                 </GroupBox>


### PR DESCRIPTION
Adds a new field to the General tab of the Settings dialog for the user's API Key. Previously, the user had to manually add this to their ini file.

![image](https://user-images.githubusercontent.com/32680403/168445541-e9b88c91-9c26-4c11-aaf1-83c01c442eaa.png)
