### PR TITLE
fix value constant of 0; optimize out rich_presence_lookup of constants

### DIFF
--- a/Source/Parser/Functions/RichPresenceLookupFunction.cs
+++ b/Source/Parser/Functions/RichPresenceLookupFunction.cs
@@ -34,6 +34,21 @@ namespace RATools.Parser.Functions
             if (fallback == null)
                 return false;
 
+            var integer = expression as IntegerConstantExpression;
+            if (integer != null)
+            {
+                var entry = dictionary.GetEntry(integer);
+                if (entry == null)
+                    entry = fallback;
+
+                var stringValue = entry as StringConstantExpression;
+                if (stringValue != null)
+                {
+                    result = stringValue;
+                    return true;
+                }
+            }
+
             var value = TriggerBuilderContext.GetValueString(expression, scope, out result);
             if (value == null)
                 return false;

--- a/Source/Parser/TriggerBuilderContext.cs
+++ b/Source/Parser/TriggerBuilderContext.cs
@@ -107,6 +107,9 @@ namespace RATools.Parser
                 }
             }
 
+            if (builder.Length == 0)
+                return "v0";
+
             return builder.ToString();
         }
 

--- a/Tests/Parser/Functions/RichPresenceLookupFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceLookupFunctionTests.cs
@@ -1,0 +1,165 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Parser;
+using RATools.Parser.Functions;
+using RATools.Parser.Internal;
+using System.Linq;
+
+namespace RATools.Test.Parser.Functions
+{
+    [TestFixture]
+    class RichPresenceLookupFunctionTests
+    {
+        class RichPresenceLookupFunctionHarness
+        {
+            public RichPresenceLookupFunctionHarness()
+            {
+                Scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+            }
+
+            public InterpreterScope Scope { get; private set; }
+
+            public RichPresenceBuilder Evaluate(string input, string expectedError = null)
+            {
+                var funcDef = new RichPresenceLookupFunction();
+
+                var expression = ExpressionBase.Parse(new PositionalTokenizer(Tokenizer.CreateTokenizer(input)));
+                Assert.That(expression, Is.InstanceOf<FunctionCallExpression>());
+                var funcCall = (FunctionCallExpression)expression;
+
+                ExpressionBase error;
+                var scope = funcCall.GetParameters(funcDef, Scope, out error);
+                var context = new RichPresenceDisplayFunction.RichPresenceDisplayContext { RichPresence = new RichPresenceBuilder() };
+                scope.Context = context;
+
+                ExpressionBase evaluated;
+                if (expectedError != null && expectedError.EndsWith(" format"))
+                {
+                    Assert.That(funcDef.ReplaceVariables(scope, out evaluated), Is.False);
+                    var parseError = evaluated as ParseErrorExpression;
+                    Assert.That(parseError, Is.Not.Null);
+                    Assert.That(parseError.Message, Is.EqualTo(expectedError));
+                    return context.RichPresence;
+                }
+
+                ExpressionBase result;
+                Assert.That(funcDef.ReplaceVariables(scope, out evaluated), Is.True);
+                if (expectedError == null)
+                {
+                    Assert.That(funcDef.BuildMacro(context, scope, out result), Is.True);
+                    context.RichPresence.DisplayString = ((StringConstantExpression)result).Value;
+                }
+                else
+                {
+                    Assert.That(funcDef.BuildMacro(context, scope, out result), Is.False);
+                    Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
+                    Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo(expectedError));
+                }
+
+                return context.RichPresence;
+            }
+
+            public DictionaryExpression DefineLookup(string name)
+            {
+                var dict = new DictionaryExpression();
+                Scope.DefineVariable(new VariableDefinitionExpression(name), dict);
+                return dict;
+            }
+        }
+
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new RichPresenceLookupFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("rich_presence_lookup"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(4));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("name"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("expression"));
+            Assert.That(def.Parameters.ElementAt(2).Name, Is.EqualTo("dictionary"));
+            Assert.That(def.Parameters.ElementAt(3).Name, Is.EqualTo("fallback"));
+
+            Assert.That(def.DefaultParameters["fallback"], Is.EqualTo(new StringConstantExpression("")));
+        }
+
+        [Test]
+        public void TestSimple()
+        {
+            var rp = new RichPresenceLookupFunctionHarness();
+            var lookup = rp.DefineLookup("lookup");
+            lookup.Add(new IntegerConstantExpression(0), new StringConstantExpression("False"));
+            lookup.Add(new IntegerConstantExpression(1), new StringConstantExpression("True"));
+
+            var builder = rp.Evaluate("rich_presence_lookup(\"Name\", byte(0x1234), lookup)");
+            Assert.That(builder.ToString(), Is.EqualTo("Lookup:Name\r\n0=False\r\n1=True\r\n\r\nDisplay:\r\n@Name(0xH001234)\r\n"));
+        }
+
+        [Test]
+        public void TestExplicitCall()
+        {
+            // not providing a RichPresenceDisplayContext simulates calling the function at a global scope
+            var funcDef = new RichPresenceLookupFunction();
+
+            var input = "rich_presence_lookup(\"Name\", byte(0x1234), lookup)";
+            var expression = ExpressionBase.Parse(new PositionalTokenizer(Tokenizer.CreateTokenizer(input)));
+            Assert.That(expression, Is.InstanceOf<FunctionCallExpression>());
+            var funcCall = (FunctionCallExpression)expression;
+
+            var parentScope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+            var dict = new DictionaryExpression();
+            parentScope.DefineVariable(new VariableDefinitionExpression("lookup"), dict);
+
+            ExpressionBase error;
+            var scope = funcCall.GetParameters(funcDef, parentScope, out error);
+            Assert.That(funcDef.Evaluate(scope, out error), Is.False);
+            Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
+            Assert.That(((ParseErrorExpression)error).Message, Is.EqualTo("rich_presence_lookup has no meaning outside of a rich_presence_display call"));
+        }
+
+        [Test]
+        public void TestValueExpression()
+        {
+            // more expressions are validated via TriggerBuilderTests.TestGetValueString
+            var rp = new RichPresenceLookupFunctionHarness();
+            var lookup = rp.DefineLookup("lookup");
+            lookup.Add(new IntegerConstantExpression(0), new StringConstantExpression("False"));
+
+            var builder = rp.Evaluate("rich_presence_lookup(\"Name\", byte(0x1234) + 1, lookup)");
+            var rpString = builder.ToString();
+            var index = rpString.IndexOf("@Name(");
+            if (index == -1)
+            {
+                Assert.Fail("Could not find Name macro");
+            }
+            else
+            {
+                var index2 = rpString.LastIndexOf(")");
+                var subString = rpString.Substring(index + 6, index2 - index - 6);
+                Assert.That(subString, Is.EqualTo("0xH001234_v1"));
+            }
+        }
+
+        [Test]
+        public void TestValueConstant()
+        {
+            var rp = new RichPresenceLookupFunctionHarness();
+            var lookup = rp.DefineLookup("lookup");
+            lookup.Add(new IntegerConstantExpression(0), new StringConstantExpression("False"));
+            lookup.Add(new IntegerConstantExpression(1), new StringConstantExpression("True"));
+
+            var builder = rp.Evaluate("rich_presence_lookup(\"Name\", 1, lookup)");
+            Assert.That(builder.ToString(), Is.EqualTo("Display:\r\nTrue\r\n"));
+        }
+
+        [Test]
+        public void TestValueConstantFallback()
+        {
+            var rp = new RichPresenceLookupFunctionHarness();
+            var lookup = rp.DefineLookup("lookup");
+            lookup.Add(new IntegerConstantExpression(0), new StringConstantExpression("False"));
+            lookup.Add(new IntegerConstantExpression(1), new StringConstantExpression("True"));
+
+            var builder = rp.Evaluate("rich_presence_lookup(\"Name\", 2, lookup, \"Fallback\")");
+            Assert.That(builder.ToString(), Is.EqualTo("Display:\r\nFallback\r\n"));
+        }
+    }
+}

--- a/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
@@ -108,6 +108,13 @@ namespace RATools.Test.Parser.Functions
         }
 
         [Test]
+        public void TestValueConstant()
+        {
+            var rp = Evaluate("rich_presence_value(\"Name\", 1)");
+            Assert.That(rp.ToString(), Is.EqualTo("Format:Name\r\nFormatType=VALUE\r\n\r\nDisplay:\r\n@Name(v1)\r\n"));
+        }
+
+        [Test]
         public void TestFormat()
         {
             var rp = Evaluate("rich_presence_value(\"Name\", byte(0x1234), format=\"FRAMES\")");

--- a/Tests/Parser/TriggerBuilderContextTests.cs
+++ b/Tests/Parser/TriggerBuilderContextTests.cs
@@ -44,6 +44,7 @@ namespace RATools.Test.Parser
         }
 
         [Test]
+        [TestCase("0", "v0")]
         [TestCase("1", "v1")]
         [TestCase("1 + 7", "v8")]
         [TestCase("1 + 3 * 2", "v7")]


### PR DESCRIPTION
fixes #312 (constant "0" being converted to "" instead of "v0")

also detects a `rich_presence_lookup` of a constant and just evaluates it at compile time.

```
bools = {
    0: "False",
    1: "True"
}

rich_presence_display("1 is {0}",
    rich_presence_lookup("Bools", 1, bools))
)
```

will generate
```
Display:
1 is True
```

without defining the lookup or the macro.