### PR TITLE
fix dumping measured(tally(), when=)

### DIFF
--- a/Source/Data/RequirementEx.cs
+++ b/Source/Data/RequirementEx.cs
@@ -283,23 +283,13 @@ namespace RATools.Data
                 }
             }
 
-            if (wrapWidth != Int32.MaxValue)
+            // always_false() final clause separates tally target from individual condition targets
+            // it can be safely removed. any other final clause must be preserved
+            var remaining = repeatedString.Substring(index);
+            if (remaining.StartsWith("always_false()"))
             {
-                builder.AppendLine();
-                builder.Append(' ', indent);
-            }
-
-            // finish with the final subclause
-            var numParentheses = (requirements.Last().Type != RequirementType.None) ? 2 : 1;
-            var finalClause = repeatedString.Substring(index, repeatedString.Length - index - numParentheses);
-            if (finalClause == "always_false()")
-            {
-                // always_false() final clause separates tally target from individual condition targets
                 builder.Length -= 2; // remove ", "
-            }
-            else
-            {
-                builder.Append(finalClause);
+                remaining = remaining.Substring(14);
             }
 
             if (wrapWidth != Int32.MaxValue)
@@ -309,8 +299,8 @@ namespace RATools.Data
                 builder.Append(' ', indent);
             }
 
-            builder.Append(')', numParentheses);
-            width = wrapWidth - indent + numParentheses;
+            builder.Append(remaining);
+            width = wrapWidth - indent - remaining.Length;
         }
 
         private static void AppendString(StringBuilder builder, IEnumerable<Requirement> requirements, 

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -188,6 +188,8 @@ namespace RATools.Test.Parser
         [TestCase("C:0xN20770f=0_0xO20770f=0.4.", "tally(4, bit1(0x20770F) == 0, bit2(0x20770F) == 0)")]
         [TestCase("O:0xN20770f=0_0xO20770f=0.4.", "repeated(4, bit1(0x20770F) == 0 || bit2(0x20770F) == 0)")]
         [TestCase("N:0xN20770f=0_0xO20770f=0.1.", "once(bit1(0x20770F) == 0 && bit2(0x20770F) == 0)")]
+        [TestCase("C:0xH464a70>d0xH464a70.1._M:0=1.8._I:0xW5b9624_Q:0xM000612=0",
+                  "measured(tally(8, once(byte(0x464A70) > prev(byte(0x464A70)))), when=bit0(tbyte(0x5B9624) + 0x000612) == 0)")]
         public void TestParseRequirements(string input, string expected)
         {
             var builder = new AchievementBuilder();


### PR DESCRIPTION
fixes #318 

modifies the logic that removes the `always_false()` from the `tally()` to search forward, instead of backward, preventing the removal of part of the `when` clause.