### PR TITLE
rename ParseErrorExpression to ErrorExpression

### DIFF
--- a/Source/Parser/AchievementBuilder.cs
+++ b/Source/Parser/AchievementBuilder.cs
@@ -2262,7 +2262,7 @@ namespace RATools.Parser
         /// <summary>
         /// Squashes alt groups into the core group using AndNexts and OrNexts.
         /// </summary>
-        internal ParseErrorExpression CollapseForSubClause()
+        internal ErrorExpression CollapseForSubClause()
         {
             var newCore = new List<Requirement>();
 
@@ -2277,7 +2277,7 @@ namespace RATools.Parser
             foreach (var alt in _alts)
             {
                 if (alt.Last().Type != RequirementType.None)
-                    return new ParseErrorExpression(alt.Last().Type + " modifier not allowed in subclause");
+                    return new ErrorExpression(alt.Last().Type + " modifier not allowed in subclause");
 
                 alt.Last().Type = RequirementType.OrNext;
 
@@ -2304,7 +2304,7 @@ namespace RATools.Parser
                 {
                     // only one AndNext group allowed
                     if (andNextAlt != null)
-                        return new ParseErrorExpression("Combination of &&s and ||s is too complex for subclause");
+                        return new ErrorExpression("Combination of &&s and ||s is too complex for subclause");
 
                     andNextAlt = alt;
 

--- a/Source/Parser/Functions/AchievementFunction.cs
+++ b/Source/Parser/Functions/AchievementFunction.cs
@@ -66,8 +66,8 @@ namespace RATools.Parser.Functions
             {
                 if (result.Location.Start != trigger.Location.Start || result.Location.End != trigger.Location.End)
                 {
-                    var error = (ParseErrorExpression)result;
-                    result = new ParseErrorExpression(error.Message, trigger) { InnerError = error };
+                    var error = (ErrorExpression)result;
+                    result = new ErrorExpression(error.Message, trigger) { InnerError = error };
                 }
 
                 return false;

--- a/Source/Parser/Functions/AlwaysFalseFunction.cs
+++ b/Source/Parser/Functions/AlwaysFalseFunction.cs
@@ -10,7 +10,7 @@ namespace RATools.Parser.Functions
         {
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             context.Trigger.Add(CreateAlwaysFalseRequirement());
             return null;

--- a/Source/Parser/Functions/AlwaysTrueFunction.cs
+++ b/Source/Parser/Functions/AlwaysTrueFunction.cs
@@ -10,7 +10,7 @@ namespace RATools.Parser.Functions
         {
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             context.Trigger.Add(CreateAlwaysTrueRequirement());
             return null;

--- a/Source/Parser/Functions/ArrayPopFunction.cs
+++ b/Source/Parser/Functions/ArrayPopFunction.cs
@@ -19,7 +19,7 @@ namespace RATools.Parser.Functions
             var array = arrayExpression.Expression as ArrayExpression;
             if (array == null)
             {
-                result = new ParseErrorExpression("array did not evaluate to an array", arrayExpression);
+                result = new ErrorExpression("array did not evaluate to an array", arrayExpression);
                 return false;
             }
 

--- a/Source/Parser/Functions/ArrayPushFunction.cs
+++ b/Source/Parser/Functions/ArrayPushFunction.cs
@@ -20,7 +20,7 @@ namespace RATools.Parser.Functions
             var array = arrayExpression.Expression as ArrayExpression;
             if (array == null)
             {
-                result = new ParseErrorExpression("array did not evaluate to an array", arrayExpression);
+                result = new ErrorExpression("array did not evaluate to an array", arrayExpression);
                 return false;
             }
 

--- a/Source/Parser/Functions/BitFunction.cs
+++ b/Source/Parser/Functions/BitFunction.cs
@@ -14,7 +14,7 @@ namespace RATools.Parser.Functions
             Parameters.Add(new VariableDefinitionExpression("address"));
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var address = functionCall.Parameters.ElementAt(1);
             var result = BuildTrigger(context, scope, functionCall, address);
@@ -23,7 +23,7 @@ namespace RATools.Parser.Functions
 
             var index = ((IntegerConstantExpression)functionCall.Parameters.First()).Value;
             if (index < 0 || index > 31)
-                return new ParseErrorExpression("index must be between 0 and 31", functionCall.Parameters.First());
+                return new ErrorExpression("index must be between 0 and 31", functionCall.Parameters.First());
 
             var offset = (uint)index / 8;
             index %= 8;

--- a/Source/Parser/Functions/ComparisonModificationFunction.cs
+++ b/Source/Parser/Functions/ComparisonModificationFunction.cs
@@ -11,13 +11,13 @@ namespace RATools.Parser.Functions
             Parameters.Add(new VariableDefinitionExpression("comparison"));
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var comparison = functionCall.Parameters.First();
             return BuildTriggerCondition(context, scope, comparison);
         }
 
-        protected ParseErrorExpression BuildTriggerCondition(TriggerBuilderContext context, InterpreterScope scope, ExpressionBase condition)
+        protected ErrorExpression BuildTriggerCondition(TriggerBuilderContext context, InterpreterScope scope, ExpressionBase condition)
         { 
             var builder = new ScriptInterpreterAchievementBuilder();
             ExpressionBase result;
@@ -28,21 +28,21 @@ namespace RATools.Parser.Functions
                     case ExpressionType.Conditional:
                     case ExpressionType.Comparison:
                         // allowed constructs should only report the inner error
-                        return (ParseErrorExpression)result;
+                        return (ErrorExpression)result;
 
                     default:
                         // non-allowed construct
-                        return new ParseErrorExpression("comparison did not evaluate to a valid comparison", condition) { InnerError = (ParseErrorExpression)result };
+                        return new ErrorExpression("comparison did not evaluate to a valid comparison", condition) { InnerError = (ErrorExpression)result };
                 }
             }
 
             var error = builder.CollapseForSubClause();
             if (error != null)
-                return new ParseErrorExpression(error.Message, condition);
+                return new ErrorExpression(error.Message, condition);
 
             error = ModifyRequirements(builder);
             if (error != null)
-                return new ParseErrorExpression(error.Message, condition);
+                return new ErrorExpression(error.Message, condition);
 
             foreach (var requirement in builder.CoreRequirements)
                 context.Trigger.Add(requirement);
@@ -50,6 +50,6 @@ namespace RATools.Parser.Functions
             return null;
         }
 
-        protected abstract ParseErrorExpression ModifyRequirements(AchievementBuilder builder);
+        protected abstract ErrorExpression ModifyRequirements(AchievementBuilder builder);
     }
 }

--- a/Source/Parser/Functions/DisableWhenFunction.cs
+++ b/Source/Parser/Functions/DisableWhenFunction.cs
@@ -31,7 +31,7 @@ namespace RATools.Parser.Functions
             return true;
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var until = functionCall.Parameters.ElementAt(1);
 
@@ -39,11 +39,11 @@ namespace RATools.Parser.Functions
             var builder = new ScriptInterpreterAchievementBuilder();
             ExpressionBase result;
             if (!TriggerBuilderContext.ProcessAchievementConditions(builder, until, scope, out result))
-                return new ParseErrorExpression("until did not evaluate to a valid comparison", until) { InnerError = (ParseErrorExpression)result };
+                return new ErrorExpression("until did not evaluate to a valid comparison", until) { InnerError = (ErrorExpression)result };
 
             var error = builder.CollapseForSubClause();
             if (error != null)
-                return new ParseErrorExpression(error.Message, until);
+                return new ErrorExpression(error.Message, until);
 
             var resetNextClause = new List<Requirement>();
             if (builder.CoreRequirements.Count > 0 && builder.CoreRequirements.First().Evaluate() != false)

--- a/Source/Parser/Functions/FlagConditionFunction.cs
+++ b/Source/Parser/Functions/FlagConditionFunction.cs
@@ -74,14 +74,14 @@ namespace RATools.Parser.Functions
             return true;
         }
 
-        protected override ParseErrorExpression ModifyRequirements(AchievementBuilder builder)
+        protected override ErrorExpression ModifyRequirements(AchievementBuilder builder)
         {
             var requirementsEx = RequirementEx.Combine(builder.CoreRequirements);
             foreach (var requirementEx in requirementsEx)
             {
                 var lastCondition = requirementEx.Requirements.Last();
                 if (lastCondition.Type != RequirementType.None)
-                    return new ParseErrorExpression(string.Format("Cannot apply '{0}' to condition already flagged with {1}", Name.Name, lastCondition.Type));
+                    return new ErrorExpression(string.Format("Cannot apply '{0}' to condition already flagged with {1}", Name.Name, lastCondition.Type));
 
                 lastCondition.Type = _type;
             }

--- a/Source/Parser/Functions/FormatFunction.cs
+++ b/Source/Parser/Functions/FormatFunction.cs
@@ -33,8 +33,8 @@ namespace RATools.Parser.Functions
             var varargs = GetParameter(scope, "varargs", out result) as ArrayExpression;
             if (varargs == null)
             {
-                if (!(result is ParseErrorExpression))
-                    result = new ParseErrorExpression("unexpected varargs", stringExpression);
+                if (!(result is ErrorExpression))
+                    result = new ErrorExpression("unexpected varargs", stringExpression);
                 return false;
             }
 
@@ -53,7 +53,7 @@ namespace RATools.Parser.Functions
                 tokenizer.Advance();
                 if (tokenizer.NextChar == '}')
                 {
-                    result = new ParseErrorExpression("Empty parameter index",
+                    result = new ErrorExpression("Empty parameter index",
                                                       stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + positionalTokenColumn,
                                                       stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + tokenizer.Column - 1);
                     return false;
@@ -61,7 +61,7 @@ namespace RATools.Parser.Functions
                 var index = tokenizer.ReadNumber();
                 if (tokenizer.NextChar != '}')
                 {
-                    result = new ParseErrorExpression("Invalid positional token",
+                    result = new ErrorExpression("Invalid positional token",
                                                       stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + positionalTokenColumn,
                                                       stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + tokenizer.Column - 1);
                     return false;
@@ -72,7 +72,7 @@ namespace RATools.Parser.Functions
                 if (!Int32.TryParse(index.ToString(), out parameterIndex)
                     || parameterIndex < 0 || parameterIndex >= varargs.Entries.Count)
                 {
-                    result = new ParseErrorExpression("Invalid parameter index: " + index.ToString(),
+                    result = new ErrorExpression("Invalid parameter index: " + index.ToString(),
                                                       stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + positionalTokenColumn,
                                                       stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + tokenizer.Column - 1);
                     return false;
@@ -92,7 +92,7 @@ namespace RATools.Parser.Functions
                 }
                 else
                 {
-                    result = new ParseErrorExpression("Cannot convert expression to string", result);
+                    result = new ErrorExpression("Cannot convert expression to string", result);
                     return false;
                 }
             }

--- a/Source/Parser/Functions/IterableJoiningFunction.cs
+++ b/Source/Parser/Functions/IterableJoiningFunction.cs
@@ -25,7 +25,7 @@ namespace RATools.Parser.Functions
             var inputs = result as IIterableExpression;
             if (inputs == null)
             {
-                result = new ParseErrorExpression("Cannot iterate over " + result.ToString(), result);
+                result = new ErrorExpression("Cannot iterate over " + result.ToString(), result);
                 return false;
             }
 
@@ -35,7 +35,7 @@ namespace RATools.Parser.Functions
 
             if ((predicate.Parameters.Count - predicate.DefaultParameters.Count) != 1)
             {
-                result = new ParseErrorExpression("predicate function must accept a single parameter");
+                result = new ErrorExpression("predicate function must accept a single parameter");
                 return false;
             }
 
@@ -57,7 +57,7 @@ namespace RATools.Parser.Functions
                     return false;
 
                 expression = Combine(expression, result);
-                if (expression.Type == ExpressionType.ParseError)
+                if (expression.Type == ExpressionType.Error)
                 {
                     result = expression;
                     return false;

--- a/Source/Parser/Functions/LeaderboardFunction.cs
+++ b/Source/Parser/Functions/LeaderboardFunction.cs
@@ -65,7 +65,7 @@ namespace RATools.Parser.Functions
             leaderboard.Format = Leaderboard.ParseFormat(format.Value);
             if (leaderboard.Format == ValueFormat.None)
             {
-                result = new ParseErrorExpression(format.Value + " is not a supported leaderboard format", format);
+                result = new ErrorExpression(format.Value + " is not a supported leaderboard format", format);
                 return false;
             }
 
@@ -139,8 +139,8 @@ namespace RATools.Parser.Functions
             var varargs = GetParameter(scope, "varargs", out result) as ArrayExpression;
             if (varargs == null)
             {
-                if (!(result is ParseErrorExpression))
-                    result = new ParseErrorExpression("unexpected varargs");
+                if (!(result is ErrorExpression))
+                    result = new ErrorExpression("unexpected varargs");
                 return false;
             }
 

--- a/Source/Parser/Functions/LengthFunction.cs
+++ b/Source/Parser/Functions/LengthFunction.cs
@@ -36,7 +36,7 @@ namespace RATools.Parser.Functions
                     return true;
 
                 default:
-                    result = new ParseErrorExpression("Cannot calculate length of " + obj.Type);
+                    result = new ErrorExpression("Cannot calculate length of " + obj.Type);
                     return false;
             }
         }

--- a/Source/Parser/Functions/MeasuredFunction.cs
+++ b/Source/Parser/Functions/MeasuredFunction.cs
@@ -16,7 +16,7 @@ namespace RATools.Parser.Functions
             DefaultParameters["format"] = new StringConstantExpression("raw");
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var error = base.BuildTrigger(context, scope, functionCall);
             if (error != null)
@@ -25,28 +25,28 @@ namespace RATools.Parser.Functions
             ExpressionBase result;
             var format = functionCall.Parameters.ElementAt(2);
             if (!format.ReplaceVariables(scope, out result))
-                return (ParseErrorExpression)result;
+                return (ErrorExpression)result;
 
             StringConstantExpression formatStr = result as StringConstantExpression;
             if (formatStr == null)
-                return new ParseErrorExpression("format is not a string", format);
+                return new ErrorExpression("format is not a string", format);
 
             if (formatStr.Value != "raw")
             {
                 if (scope.GetContext<ValueBuilderContext>() != null)
-                    return new ParseErrorExpression("Value fields only support raw measured values", format);
+                    return new ErrorExpression("Value fields only support raw measured values", format);
 
                 if (formatStr.Value == "percent")
                     context.LastRequirement.Type = RequirementType.MeasuredPercent;
                 else
-                    return new ParseErrorExpression("Unknown format: " + formatStr.Value, format);
+                    return new ErrorExpression("Unknown format: " + formatStr.Value, format);
             }
 
             var when = functionCall.Parameters.ElementAt(1);
 
             var builder = new ScriptInterpreterAchievementBuilder();
             if (!TriggerBuilderContext.ProcessAchievementConditions(builder, when, scope, out result))
-                return new ParseErrorExpression("when did not evaluate to a valid comparison", when) { InnerError = (ParseErrorExpression)result };
+                return new ErrorExpression("when did not evaluate to a valid comparison", when) { InnerError = (ErrorExpression)result };
 
             error = builder.CollapseForSubClause();
             if (error != null)

--- a/Source/Parser/Functions/MemoryAccessorFunction.cs
+++ b/Source/Parser/Functions/MemoryAccessorFunction.cs
@@ -60,13 +60,13 @@ namespace RATools.Parser.Functions
             return 0;
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var address = functionCall.Parameters.First();
             return BuildTrigger(context, scope, functionCall, address);
         }
 
-        protected ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall, ExpressionBase address)
+        protected ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall, ExpressionBase address)
         {
             var requirement = new Requirement();
             var integerConstant = address as IntegerConstantExpression;
@@ -90,7 +90,7 @@ namespace RATools.Parser.Functions
                     (mathematic.Operation == MathematicOperation.Add || mathematic.Operation == MathematicOperation.Subtract))
                 {
                     if (CountMathematicMemoryAccessors(mathematic, 2) >= 2)
-                        return new ParseErrorExpression("Cannot construct single address lookup from multiple memory references", address);
+                        return new ErrorExpression("Cannot construct single address lookup from multiple memory references", address);
 
                     offsetConstant = mathematic.Right as IntegerConstantExpression;
                     if (offsetConstant != null)
@@ -192,7 +192,7 @@ namespace RATools.Parser.Functions
             builder.Append("Cannot convert to an address: ");
             originalAddress.AppendString(builder);
 
-            return new ParseErrorExpression(builder.ToString(), address);
+            return new ErrorExpression(builder.ToString(), address);
         }
     }
 }

--- a/Source/Parser/Functions/NoneOfFunction.cs
+++ b/Source/Parser/Functions/NoneOfFunction.cs
@@ -12,7 +12,7 @@ namespace RATools.Parser.Functions
         protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
         {
             right = ConditionalExpression.InvertExpression(right);
-            if (right.Type == ExpressionType.ParseError)
+            if (right.Type == ExpressionType.Error)
                 return right;
 
             right.IsLogicalUnit = true;

--- a/Source/Parser/Functions/OnceFunction.cs
+++ b/Source/Parser/Functions/OnceFunction.cs
@@ -10,7 +10,7 @@ namespace RATools.Parser.Functions
         {
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var comparison = functionCall.Parameters.First();
             return BuildTriggerConditions(context, scope, comparison, 1);

--- a/Source/Parser/Functions/PrevPriorFunction.cs
+++ b/Source/Parser/Functions/PrevPriorFunction.cs
@@ -81,7 +81,7 @@ namespace RATools.Parser.Functions
             var functionCall = expression as FunctionCallExpression;
             if (functionCall == null)
             {
-                result = new ParseErrorExpression("accessor did not evaluate to a memory accessor", expression);
+                result = new ErrorExpression("accessor did not evaluate to a memory accessor", expression);
                 return false;
             }
 
@@ -91,7 +91,7 @@ namespace RATools.Parser.Functions
             {
                 if (!(functionDefinition is PrevPriorFunction))
                 {
-                    result = new ParseErrorExpression("accessor did not evaluate to a memory accessor", expression);
+                    result = new ErrorExpression("accessor did not evaluate to a memory accessor", expression);
                     return false;
                 }
 
@@ -111,7 +111,7 @@ namespace RATools.Parser.Functions
                 }
                 else
                 {
-                    result = new ParseErrorExpression("cannot apply multiple modifiers to memory accessor", expression);
+                    result = new ErrorExpression("cannot apply multiple modifiers to memory accessor", expression);
                     return false;
                 }
             }
@@ -121,7 +121,7 @@ namespace RATools.Parser.Functions
             return true;
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var accessor = (FunctionCallExpression)functionCall.Parameters.First();
             var error = context.CallFunction(accessor, scope);
@@ -130,7 +130,7 @@ namespace RATools.Parser.Functions
 
             var left = context.LastRequirement.Left;
             if (left.Type != FieldType.MemoryAddress)
-                return new ParseErrorExpression("cannot apply multiple modifiers to memory accessor", functionCall);
+                return new ErrorExpression("cannot apply multiple modifiers to memory accessor", functionCall);
 
             context.LastRequirement.Left = new Field { Size = left.Size, Type = _fieldType, Value = left.Value };
             return null;

--- a/Source/Parser/Functions/RangeFunction.cs
+++ b/Source/Parser/Functions/RangeFunction.cs
@@ -37,7 +37,7 @@ namespace RATools.Parser.Functions
 
             if (step.Value == 0)
             {
-                result = new ParseErrorExpression("step must not be 0", step);
+                result = new ErrorExpression("step must not be 0", step);
                 return false;
             }
 
@@ -47,7 +47,7 @@ namespace RATools.Parser.Functions
             {
                 if (step.Value > 0)
                 {
-                    result = new ParseErrorExpression("step must be negative if start is after stop", step.Location.Start.Line > 0 ? step : stop);
+                    result = new ErrorExpression("step must be negative if start is after stop", step.Location.Start.Line > 0 ? step : stop);
                     return false;
                 }
 
@@ -58,7 +58,7 @@ namespace RATools.Parser.Functions
             {
                 if (step.Value < 0)
                 {
-                    result = new ParseErrorExpression("step must be positive if stop is after start", step);
+                    result = new ErrorExpression("step must be positive if stop is after start", step);
                     return false;
                 }
 

--- a/Source/Parser/Functions/RepeatedFunction.cs
+++ b/Source/Parser/Functions/RepeatedFunction.cs
@@ -20,21 +20,21 @@ namespace RATools.Parser.Functions
         {
         }
 
-        protected override ParseErrorExpression ModifyRequirements(AchievementBuilder builder)
+        protected override ErrorExpression ModifyRequirements(AchievementBuilder builder)
         {
             // not actually modifying requirements, but allows us to do some validation
             foreach (var requirement in builder.CoreRequirements)
             {
                 if (requirement.Type == RequirementType.AddHits)
-                    return new ParseErrorExpression("tally not allowed in subclause");
+                    return new ErrorExpression("tally not allowed in subclause");
                 if (requirement.Type == RequirementType.SubHits)
-                    return new ParseErrorExpression("tally not allowed in subclause");
+                    return new ErrorExpression("tally not allowed in subclause");
             }
 
             return null;
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var count = (IntegerConstantExpression)functionCall.Parameters.First();
             var comparison = functionCall.Parameters.ElementAt(1);
@@ -42,9 +42,9 @@ namespace RATools.Parser.Functions
             return BuildTriggerConditions(context, scope, comparison, count.Value);
         }
 
-        protected ParseErrorExpression BuildTriggerConditions(TriggerBuilderContext context, InterpreterScope scope, ExpressionBase comparison, int count)
+        protected ErrorExpression BuildTriggerConditions(TriggerBuilderContext context, InterpreterScope scope, ExpressionBase comparison, int count)
         {
-            ParseErrorExpression error;
+            ErrorExpression error;
 
             var condition = comparison as ConditionalExpression;
             if (condition != null && condition.Operation == ConditionalOperation.And)
@@ -119,7 +119,7 @@ namespace RATools.Parser.Functions
             return null;
         }
 
-        private static ParseErrorExpression ProcessOrNextSubClause(ICollection<Requirement> requirements)
+        private static ErrorExpression ProcessOrNextSubClause(ICollection<Requirement> requirements)
         {
             if (requirements.Count == 0)
                 return null;
@@ -127,7 +127,7 @@ namespace RATools.Parser.Functions
             int i = requirements.Count - 1;
             var requirement = requirements.ElementAt(i);
             if (requirement.Type != RequirementType.None)
-                return new ParseErrorExpression("Modifier not allowed in multi-condition repeated clause");
+                return new ErrorExpression("Modifier not allowed in multi-condition repeated clause");
 
             while (i > 0)
             {
@@ -143,7 +143,7 @@ namespace RATools.Parser.Functions
                     default:
                         // non-constructing conditions are not allowed within the AddHits clause
                         if (!requirement.IsCombining)
-                            return new ParseErrorExpression("Modifier not allowed in multi-condition repeated clause");
+                            return new ErrorExpression("Modifier not allowed in multi-condition repeated clause");
                         break;
                 }
             }
@@ -151,13 +151,13 @@ namespace RATools.Parser.Functions
             return null;
         }
 
-        protected ParseErrorExpression EvaluateCondition(TriggerBuilderContext context, InterpreterScope scope, ConditionalExpression condition)
+        protected ErrorExpression EvaluateCondition(TriggerBuilderContext context, InterpreterScope scope, ConditionalExpression condition)
         {
             ExpressionBase result;
 
             var builder = new ScriptInterpreterAchievementBuilder();
             if (!TriggerBuilderContext.ProcessAchievementConditions(builder, condition, scope, out result))
-                return (ParseErrorExpression)result;
+                return (ErrorExpression)result;
 
             if (builder.CoreRequirements.Any())
             {
@@ -245,7 +245,7 @@ namespace RATools.Parser.Functions
                 for (int i = 1; i < requirements.Count; ++i)
                 {
                     if (requirements[i].Any(r => r.Type == RequirementType.AndNext))
-                        return new ParseErrorExpression("Cannot join multiple AndNext chains with OrNext");
+                        return new ErrorExpression("Cannot join multiple AndNext chains with OrNext");
                 }
             }
 

--- a/Source/Parser/Functions/RichPresenceDisplayFunction.cs
+++ b/Source/Parser/Functions/RichPresenceDisplayFunction.cs
@@ -21,7 +21,7 @@ namespace RATools.Parser.Functions
             var context = scope.GetContext<AchievementScriptContext>();
             if (context == null)
             {
-                result = new ParseErrorExpression(Name.Name + " has no meaning outside of an achievement script");
+                result = new ErrorExpression(Name.Name + " has no meaning outside of an achievement script");
                 return false;
             }
 
@@ -70,7 +70,7 @@ namespace RATools.Parser.Functions
                 var context = scope.GetContext<RichPresenceDisplayContext>();
                 if (context == null)
                 {
-                    result = new ParseErrorExpression(Name.Name + " has no meaning outside of a rich_presence_display call");
+                    result = new ErrorExpression(Name.Name + " has no meaning outside of a rich_presence_display call");
                     return false;
                 }
 

--- a/Source/Parser/Functions/RichPresenceMacroFunction.cs
+++ b/Source/Parser/Functions/RichPresenceMacroFunction.cs
@@ -69,7 +69,7 @@ namespace RATools.Parser.Functions
 
             if (GetValueFormat(macro.Value) == ValueFormat.None)
             {
-                result = new ParseErrorExpression("Unknown rich presence macro: " + macro.Value);
+                result = new ErrorExpression("Unknown rich presence macro: " + macro.Value);
                 return false;
             }
 

--- a/Source/Parser/Functions/RichPresenceValueFunction.cs
+++ b/Source/Parser/Functions/RichPresenceValueFunction.cs
@@ -57,7 +57,7 @@ namespace RATools.Parser.Functions
             var valueFormat = ParseFormat(format.Value);
             if (valueFormat == ValueFormat.None)
             {
-                result = new ParseErrorExpression(format.Value + " is not a supported rich_presence_value format", format);
+                result = new ErrorExpression(format.Value + " is not a supported rich_presence_value format", format);
                 return false;
             }
 

--- a/Source/Parser/Functions/TriggerWhenFunction.cs
+++ b/Source/Parser/Functions/TriggerWhenFunction.cs
@@ -10,7 +10,7 @@ namespace RATools.Parser.Functions
         {
         }
 
-        public override ParseErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+        public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             // add another TriggerBuilderContext scope to prevent optimizing the expression at this time
             var nestedScope = new InterpreterScope(scope) { Context = new TriggerBuilderContext() };

--- a/Source/Parser/Internal/ArrayExpression.cs
+++ b/Source/Parser/Internal/ArrayExpression.cs
@@ -42,7 +42,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ErrorExpression" />.
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {

--- a/Source/Parser/Internal/AssignmentExpression.cs
+++ b/Source/Parser/Internal/AssignmentExpression.cs
@@ -46,7 +46,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ErrorExpression" />.
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
@@ -68,9 +68,9 @@ namespace RATools.Parser.Internal
         /// </summary>
         /// <param name="scope">The scope object containing variable values and function parameters.</param>
         /// <returns>
-        ///   <c>null</c> if successful, or a <see cref="ParseErrorExpression" /> if not.
+        ///   <c>null</c> if successful, or a <see cref="ErrorExpression" /> if not.
         /// </returns>
-        public ParseErrorExpression Evaluate(InterpreterScope scope)
+        public ErrorExpression Evaluate(InterpreterScope scope)
         {
             var assignmentScope = new InterpreterScope(scope) { Context = this };
             ExpressionBase result;
@@ -84,7 +84,7 @@ namespace RATools.Parser.Internal
             else
             {
                 if (!Value.ReplaceVariables(assignmentScope, out result))
-                    return (ParseErrorExpression)result;
+                    return (ErrorExpression)result;
             }
 
             return scope.AssignVariable(Variable, result);

--- a/Source/Parser/Internal/BooleanConstantExpression.cs
+++ b/Source/Parser/Internal/BooleanConstantExpression.cs
@@ -59,7 +59,7 @@ namespace RATools.Parser.Internal
             return (that != null && Value == that.Value);
         }
 
-        public override bool? IsTrue(InterpreterScope scope, out ParseErrorExpression error)
+        public override bool? IsTrue(InterpreterScope scope, out ErrorExpression error)
         {
             error = null;
             return Value;

--- a/Source/Parser/Internal/ComparisonExpression.cs
+++ b/Source/Parser/Internal/ComparisonExpression.cs
@@ -239,12 +239,12 @@ namespace RATools.Parser.Internal
             {
                 case ComparisonOperation.Equal:
                     // a * 10 == 9999 can never be true
-                    result = new ParseErrorExpression("Result can never be true using integer math", comparison);
+                    result = new ErrorExpression("Result can never be true using integer math", comparison);
                     return false;
 
                 case ComparisonOperation.NotEqual:
                     // a * 10 != 9999 is always true
-                    result = new ParseErrorExpression("Result is always true using integer math", comparison);
+                    result = new ErrorExpression("Result is always true using integer math", comparison);
                     return false;
 
                 case ComparisonOperation.LessThan:
@@ -851,7 +851,7 @@ namespace RATools.Parser.Internal
                 else
                 {
                     // no 32-bit reads, and no subtraction - the comparison will never be true
-                    result = new ParseErrorExpression("Expression can never be true");
+                    result = new ErrorExpression("Expression can never be true");
                     return false;
                 }
             }
@@ -1018,7 +1018,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ErrorExpression" />.
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
@@ -1090,7 +1090,7 @@ namespace RATools.Parser.Internal
             }
 
             // if the expression can be fully evaluated, do so
-            ParseErrorExpression error;
+            ErrorExpression error;
             var comparisonResult = comparison.IsTrue(scope, out error);
             if (error != null)
             {
@@ -1122,18 +1122,18 @@ namespace RATools.Parser.Internal
         /// <returns>
         /// The result of evaluating the expression
         /// </returns>
-        public override bool? IsTrue(InterpreterScope scope, out ParseErrorExpression error)
+        public override bool? IsTrue(InterpreterScope scope, out ErrorExpression error)
         {
             ExpressionBase left, right;
             if (!Left.ReplaceVariables(scope, out left))
             {
-                error = left as ParseErrorExpression;
+                error = left as ErrorExpression;
                 return null;
             }
 
             if (!Right.ReplaceVariables(scope, out right))
             {
-                error = right as ParseErrorExpression;
+                error = right as ErrorExpression;
                 return null;
             }
 
@@ -1207,7 +1207,7 @@ namespace RATools.Parser.Internal
                     case ComparisonOperation.NotEqual:
                         return booleanLeft.Value != booleanRight.Value;
                     default:
-                        error = new ParseErrorExpression("Cannot perform relative comparison on boolean values", this);
+                        error = new ErrorExpression("Cannot perform relative comparison on boolean values", this);
                         return null;
                 }
             }

--- a/Source/Parser/Internal/ConditionalExpression.cs
+++ b/Source/Parser/Internal/ConditionalExpression.cs
@@ -155,7 +155,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ErrorExpression" />.
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
@@ -221,7 +221,7 @@ namespace RATools.Parser.Internal
                     else
                     {
                         result = InvertExpression(updatedConditions[0]);
-                        if (result.Type == ExpressionType.ParseError)
+                        if (result.Type == ExpressionType.Error)
                             return false;
 
                         CopyLocation(result);
@@ -355,7 +355,7 @@ namespace RATools.Parser.Internal
             }
 
             // unsupported inversion
-            return new ParseErrorExpression("! operator cannot be applied to " + expression.Type, expression);
+            return new ErrorExpression("! operator cannot be applied to " + expression.Type, expression);
         }
 
         /// <summary>
@@ -366,7 +366,7 @@ namespace RATools.Parser.Internal
         /// <returns>
         /// The result of evaluating the expression
         /// </returns>
-        public override bool? IsTrue(InterpreterScope scope, out ParseErrorExpression error)
+        public override bool? IsTrue(InterpreterScope scope, out ErrorExpression error)
         {
             bool? isTrue;
 

--- a/Source/Parser/Internal/DictionaryExpression.cs
+++ b/Source/Parser/Internal/DictionaryExpression.cs
@@ -105,11 +105,11 @@ namespace RATools.Parser.Internal
             return (entry != null) ? entry.Value : null;
         }
 
-        internal ParseErrorExpression Assign(ExpressionBase key, ExpressionBase value)
+        internal ErrorExpression Assign(ExpressionBase key, ExpressionBase value)
         {
             var entry = GetEntry(key, true);
 
-            var error = entry.Value as ParseErrorExpression;
+            var error = entry.Value as ErrorExpression;
             if (error != null)
                 return error;
 
@@ -171,7 +171,7 @@ namespace RATools.Parser.Internal
             while (tokenizer.NextChar != '}')
             {
                 var key = ExpressionBase.ParseClause(tokenizer);
-                if (key.Type == ExpressionType.ParseError)
+                if (key.Type == ExpressionType.Error)
                     return key;
 
                 SkipWhitespace(tokenizer);
@@ -184,7 +184,7 @@ namespace RATools.Parser.Internal
                 SkipWhitespace(tokenizer);
 
                 var value = ExpressionBase.ParseClause(tokenizer);
-                if (value.Type == ExpressionType.ParseError)
+                if (value.Type == ExpressionType.Error)
                     break;
 
                 dict.Add(key, value);
@@ -216,7 +216,7 @@ namespace RATools.Parser.Internal
             _state = DictionaryState.Unprocessed;
         }
 
-        private ParseErrorExpression UpdateState()
+        private ErrorExpression UpdateState()
         {
             if (_entries.Count == 0)
             {
@@ -237,7 +237,7 @@ namespace RATools.Parser.Internal
                         StringBuilder builder = new StringBuilder();
                         entry.Key.AppendString(builder);
                         builder.Append(" already exists in dictionary");
-                        return new ParseErrorExpression(builder.ToString(), entry.Key);
+                        return new ErrorExpression(builder.ToString(), entry.Key);
                     }
                 }
 
@@ -261,7 +261,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ErrorExpression" />.
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
@@ -303,7 +303,7 @@ namespace RATools.Parser.Internal
 
                     if (!value.IsConstant)
                     {
-                        result = new ParseErrorExpression("Dictionary key must evaluate to a constant", key);
+                        result = new ErrorExpression("Dictionary key must evaluate to a constant", key);
                         return false;
                     }
 
@@ -343,7 +343,7 @@ namespace RATools.Parser.Internal
                         StringBuilder builder = new StringBuilder();
                         key.AppendString(builder);
                         builder.Append(" already exists in dictionary");
-                        result = new ParseErrorExpression(builder.ToString(), entry.Key);
+                        result = new ErrorExpression(builder.ToString(), entry.Key);
                         return false;
                     }
 

--- a/Source/Parser/Internal/ExpressionGroup.cs
+++ b/Source/Parser/Internal/ExpressionGroup.cs
@@ -12,7 +12,7 @@ namespace RATools.Parser.Internal
         {
         }
 
-        private List<ParseErrorExpression> _parseErrors;
+        private List<ErrorExpression> _parseErrors;
         private List<ExpressionBase> _expressions;
         private ExpressionBase _expression;
         private HashSet<string> _dependencies;
@@ -43,21 +43,21 @@ namespace RATools.Parser.Internal
             NeedsEvaluated = false;
         }
 
-        public IEnumerable<ParseErrorExpression> ParseErrors
+        public IEnumerable<ErrorExpression> ParseErrors
         {
             get
             {
                 if (_parseErrors != null)
                     return _parseErrors;
 
-                return Enumerable.Empty<ParseErrorExpression>();
+                return Enumerable.Empty<ErrorExpression>();
             }
         }
 
-        public void AddParseError(ParseErrorExpression error)
+        public void AddParseError(ErrorExpression error)
         {
             if (_parseErrors == null)
-                _parseErrors = new List<ParseErrorExpression>();
+                _parseErrors = new List<ErrorExpression>();
 
             _parseErrors.Add(error);
         }

--- a/Source/Parser/Internal/ExpressionGroupCollection.cs
+++ b/Source/Parser/Internal/ExpressionGroupCollection.cs
@@ -13,13 +13,13 @@ namespace RATools.Parser.Internal
         public ExpressionGroupCollection()
         {
             Groups = new List<ExpressionGroup>();
-            _evaluationErrors = new List<ParseErrorExpression>();
+            _evaluationErrors = new List<ErrorExpression>();
         }
 
         public List<ExpressionGroup> Groups { get; private set; }
         public InterpreterScope Scope { get; set; }
 
-        private readonly List<ParseErrorExpression> _evaluationErrors;
+        private readonly List<ErrorExpression> _evaluationErrors;
 
         public void Parse(Tokenizer tokenizer)
         {
@@ -64,7 +64,7 @@ namespace RATools.Parser.Internal
                 if (commentGroup != null)
                     groups.Add(commentGroup);
 
-                if (expression.Type != ExpressionType.ParseError)
+                if (expression.Type != ExpressionType.Error)
                     newGroup.AddExpression(expression);
             }
 
@@ -376,7 +376,7 @@ namespace RATools.Parser.Internal
             get {  return _evaluationErrors.Count > 0; }
         }
 
-        public void AddEvaluationError(ParseErrorExpression error)
+        public void AddEvaluationError(ErrorExpression error)
         {
             lock (_evaluationErrors)
             {
@@ -392,7 +392,7 @@ namespace RATools.Parser.Internal
             }
         }
 
-        public IEnumerable<ParseErrorExpression> Errors
+        public IEnumerable<ErrorExpression> Errors
         {
             get
             {
@@ -428,7 +428,7 @@ namespace RATools.Parser.Internal
                         result = true;
                     }
 
-                    ParseErrorExpression mostSignificantError = null;
+                    ErrorExpression mostSignificantError = null;
                     var scan = error;
                     do
                     {

--- a/Source/Parser/Internal/ExpressionTokenizer.cs
+++ b/Source/Parser/Internal/ExpressionTokenizer.cs
@@ -23,7 +23,7 @@ namespace RATools.Parser.Internal
             _expressionGroup.AddExpression(comment);
         }
 
-        public void AddError(ParseErrorExpression error)
+        public void AddError(ErrorExpression error)
         {
             _expressionGroup.AddParseError(error);
         }

--- a/Source/Parser/Internal/FloatConstantExpression.cs
+++ b/Source/Parser/Internal/FloatConstantExpression.cs
@@ -56,7 +56,7 @@ namespace RATools.Parser.Internal
         /// Attempts to convert an expression to a <see cref="FloatConstantExpression"/>.
         /// </summary>
         /// <param name="expression">The expression to convert.</param>
-        /// <returns>The converted expression, or a <see cref="ParseErrorExpression"/> if the expression could not be converted.</returns>
+        /// <returns>The converted expression, or a <see cref="ErrorExpression"/> if the expression could not be converted.</returns>
         public static ExpressionBase ConvertFrom(ExpressionBase expression)
         {
             FloatConstantExpression floatExpression;
@@ -71,7 +71,7 @@ namespace RATools.Parser.Internal
                     break;
 
                 default:
-                    return new ParseErrorExpression("Cannot convert to float", expression);
+                    return new ErrorExpression("Cannot convert to float", expression);
             }
 
             expression.CopyLocation(floatExpression);

--- a/Source/Parser/Internal/ForExpression.cs
+++ b/Source/Parser/Internal/ForExpression.cs
@@ -69,7 +69,7 @@ namespace RATools.Parser.Internal
             var keywordIn = new KeywordExpression("in", line, column);
 
             var range = ExpressionBase.Parse(tokenizer);
-            if (range.Type == ExpressionType.ParseError)
+            if (range.Type == ExpressionType.Error)
                 return range;
 
             var loop = new ForExpression(iterator, range);

--- a/Source/Parser/Internal/FunctionDefinitionExpression.cs
+++ b/Source/Parser/Internal/FunctionDefinitionExpression.cs
@@ -79,7 +79,7 @@ namespace RATools.Parser.Internal
         /// </summary>
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
-        /// <returns><c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result"/> will likely be a <see cref="ParseErrorExpression"/>.</returns>
+        /// <returns><c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result"/> will likely be a <see cref="ErrorExpression"/>.</returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
             // FunctionDefinition.ReplaceVariables is called when evaluating a function for an assignment.
@@ -99,7 +99,7 @@ namespace RATools.Parser.Internal
                 var parameter = scope.GetVariable(parameterName.Name);
                 if (parameter == null)
                 {
-                    result = new ParseErrorExpression("No value provided for " + parameterName.Name + " parameter", parameterName);
+                    result = new ErrorExpression("No value provided for " + parameterName.Name + " parameter", parameterName);
                     return false;
                 }
 
@@ -117,7 +117,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values and function parameters.</param>
         /// <param name="result">[out] The new expression containing the function result.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ErrorExpression" />.
         /// </returns>
         public virtual bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
@@ -146,7 +146,7 @@ namespace RATools.Parser.Internal
             var parameter = scope.GetVariable(name);
             if (parameter == null)
             {
-                parseError = new ParseErrorExpression("No value provided for " + name + " parameter");
+                parseError = new ErrorExpression("No value provided for " + name + " parameter");
                 return null;
             }
 
@@ -197,7 +197,7 @@ namespace RATools.Parser.Internal
                 if (originalParameter != null)
                     parameter = originalParameter;
 
-                parseError = new ParseErrorExpression(name + " is not an integer", parameter);
+                parseError = new ErrorExpression(name + " is not an integer", parameter);
                 return null;
             }
 
@@ -225,7 +225,7 @@ namespace RATools.Parser.Internal
                 if (originalParameter != null)
                     parameter = originalParameter;
 
-                parseError = new ParseErrorExpression(name + " is not a string", parameter);
+                parseError = new ErrorExpression(name + " is not a string", parameter);
                 return null;
             }
 
@@ -253,7 +253,7 @@ namespace RATools.Parser.Internal
                 if (originalParameter != null)
                     parameter = originalParameter;
 
-                parseError = new ParseErrorExpression(name + " is not a boolean", parameter);
+                parseError = new ErrorExpression(name + " is not a boolean", parameter);
                 return null;
             }
 
@@ -281,7 +281,7 @@ namespace RATools.Parser.Internal
                 if (originalParameter != null)
                     parameter = originalParameter;
 
-                parseError = new ParseErrorExpression(name + " is not a dictionary", parameter);
+                parseError = new ErrorExpression(name + " is not a dictionary", parameter);
                 return null;
             }
 
@@ -301,7 +301,7 @@ namespace RATools.Parser.Internal
             var parameter = scope.GetVariable(name);
             if (parameter == null)
             {
-                parseError = new ParseErrorExpression("No value provided for " + name + " parameter");
+                parseError = new ErrorExpression("No value provided for " + name + " parameter");
                 return null;
             }
 
@@ -312,7 +312,7 @@ namespace RATools.Parser.Internal
                 if (originalParameter != null)
                     parameter = originalParameter;
 
-                parseError = new ParseErrorExpression(name + " is not a reference", parameter);
+                parseError = new ErrorExpression(name + " is not a reference", parameter);
                 return null;
             }
 
@@ -325,7 +325,7 @@ namespace RATools.Parser.Internal
             var parameter = scope.GetVariable(name);
             if (parameter == null)
             {
-                parseError = new ParseErrorExpression("No value provided for " + name + " parameter");
+                parseError = new ErrorExpression("No value provided for " + name + " parameter");
                 return null;
             }
 
@@ -335,14 +335,14 @@ namespace RATools.Parser.Internal
                 var functionReference = parameter as FunctionReferenceExpression;
                 if (functionReference == null)
                 {
-                    parseError = new ParseErrorExpression(name + " must be a function reference");
+                    parseError = new ErrorExpression(name + " must be a function reference");
                     return null;
                 }
 
                 functionDefinition = scope.GetFunction(functionReference.Name);
                 if (functionDefinition == null)
                 {
-                    parseError = new ParseErrorExpression("Undefined function: " + functionReference.Name);
+                    parseError = new ErrorExpression("Undefined function: " + functionReference.Name);
                     return null;
                 }
             }
@@ -503,7 +503,7 @@ namespace RATools.Parser.Internal
                         ExpressionBase.SkipWhitespace(tokenizer);
 
                         var value = ExpressionBase.Parse(tokenizer);
-                        if (value.Type == ExpressionType.ParseError)
+                        if (value.Type == ExpressionType.Error)
                             return ExpressionBase.ParseError(tokenizer, "Invalid default value for " + parameter.ToString(), value);
 
                         var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
@@ -550,7 +550,7 @@ namespace RATools.Parser.Internal
             while (tokenizer.NextChar != '}')
             {
                 expression = ExpressionBase.Parse(tokenizer);
-                if (expression.Type == ExpressionType.ParseError)
+                if (expression.Type == ExpressionType.Error)
                 {
                     // the ExpressionTokenizer will capture the error, we should still return the incomplete FunctionDefinition
                     if (tokenizer is ExpressionTokenizer)
@@ -580,7 +580,7 @@ namespace RATools.Parser.Internal
             ExpressionBase.SkipWhitespace(tokenizer);
 
             var expression = ExpressionBase.Parse(tokenizer);
-            if (expression.Type == ExpressionType.ParseError)
+            if (expression.Type == ExpressionType.Error)
                 return expression;
 
             switch (expression.Type)
@@ -607,7 +607,7 @@ namespace RATools.Parser.Internal
         /// </summary>
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
-        /// <returns><c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result"/> will likely be a <see cref="ParseErrorExpression"/>.</returns>
+        /// <returns><c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result"/> will likely be a <see cref="ErrorExpression"/>.</returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
             // user-defined functions should be evaluated (expanded) immediately.
@@ -618,9 +618,9 @@ namespace RATools.Parser.Internal
             {
                 var functionCall = scope.GetContext<FunctionCallExpression>();
                 if (functionCall != null)
-                    result = new ParseErrorExpression(Name.Name + " did not return a value", functionCall.FunctionName);
+                    result = new ErrorExpression(Name.Name + " did not return a value", functionCall.FunctionName);
                 else
-                    result = new ParseErrorExpression(Name.Name + " did not return a value");
+                    result = new ErrorExpression(Name.Name + " did not return a value");
 
                 return false;
             }
@@ -703,7 +703,7 @@ namespace RATools.Parser.Internal
         {
             var variable = parameter as VariableExpression;
             if (variable == null)
-                return new ParseErrorExpression("Cannot create anonymous function from " + parameter.Type);
+                return new ErrorExpression("Cannot create anonymous function from " + parameter.Type);
 
             var name = CreateAnonymousFunctionName(parameter.Location.Start.Line, parameter.Location.Start.Column);
             var function = new AnonymousUserFunctionDefinitionExpression(name);

--- a/Source/Parser/Internal/IfExpression.cs
+++ b/Source/Parser/Internal/IfExpression.cs
@@ -43,7 +43,7 @@ namespace RATools.Parser.Internal
             ExpressionBase.SkipWhitespace(tokenizer);
 
             var condition = ExpressionBase.Parse(tokenizer);
-            if (condition.Type == ExpressionType.ParseError)
+            if (condition.Type == ExpressionType.Error)
                 return condition;
 
             var ifExpression = new IfExpression(condition);

--- a/Source/Parser/Internal/IndexedVariableExpression.cs
+++ b/Source/Parser/Internal/IndexedVariableExpression.cs
@@ -43,7 +43,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ErrorExpression" />.
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
@@ -59,7 +59,7 @@ namespace RATools.Parser.Internal
                         var builder = new StringBuilder();
                         builder.Append("No entry in dictionary for key: ");
                         index.AppendString(builder);
-                        result = new ParseErrorExpression(builder.ToString(), Index);
+                        result = new ErrorExpression(builder.ToString(), Index);
                         return false;
                     }
                     break;
@@ -68,7 +68,7 @@ namespace RATools.Parser.Internal
                     result = ((ArrayExpression)container).Entries[((IntegerConstantExpression)index).Value];
                     break;
 
-                case ExpressionType.ParseError:
+                case ExpressionType.Error:
                     result = container;
                     return false;
 
@@ -80,7 +80,7 @@ namespace RATools.Parser.Internal
                         builder.Append(" (");
                         builder.Append(container.Type);
                         builder.Append(')');
-                        result = new ParseErrorExpression(builder.ToString(), Variable);
+                        result = new ErrorExpression(builder.ToString(), Variable);
                     }
                     return false;
             }
@@ -91,7 +91,7 @@ namespace RATools.Parser.Internal
             return result.ReplaceVariables(scope, out result);
         }
 
-        public ParseErrorExpression Assign(InterpreterScope scope, ExpressionBase newValue)
+        public ErrorExpression Assign(InterpreterScope scope, ExpressionBase newValue)
         {
             ExpressionBase container, index;
             GetContainerIndex(scope, out container, out index);
@@ -106,8 +106,8 @@ namespace RATools.Parser.Internal
                     ((ArrayExpression)container).Entries[((IntegerConstantExpression)index).Value] = newValue;
                     break;
 
-                case ExpressionType.ParseError:
-                    return (ParseErrorExpression)container;
+                case ExpressionType.Error:
+                    return (ErrorExpression)container;
 
                 default:
                     var builder = new StringBuilder();
@@ -116,7 +116,7 @@ namespace RATools.Parser.Internal
                     builder.Append(" (");
                     builder.Append(container.Type);
                     builder.Append(')');
-                    return new ParseErrorExpression(builder.ToString(), Variable);
+                    return new ErrorExpression(builder.ToString(), Variable);
             }
 
             return null;
@@ -162,9 +162,9 @@ namespace RATools.Parser.Internal
             {
                 var intIndex = index as IntegerConstantExpression;
                 if (intIndex == null)
-                    container = new ParseErrorExpression("Index does not evaluate to an integer constant", index);
+                    container = new ErrorExpression("Index does not evaluate to an integer constant", index);
                 else if (intIndex.Value < 0 || intIndex.Value >= array.Entries.Count)
-                    container = new ParseErrorExpression(String.Format("Index {0} not in range 0-{1}", intIndex.Value, array.Entries.Count - 1), index);
+                    container = new ErrorExpression(String.Format("Index {0} not in range 0-{1}", intIndex.Value, array.Entries.Count - 1), index);
             }
         }
 

--- a/Source/Parser/Internal/InterpreterScope.cs
+++ b/Source/Parser/Internal/InterpreterScope.cs
@@ -204,7 +204,7 @@ namespace RATools.Parser.Internal
         /// </summary>
         /// <param name="variable">The variable.</param>
         /// <param name="value">The value.</param>
-        public ParseErrorExpression AssignVariable(VariableExpression variable, ExpressionBase value)
+        public ErrorExpression AssignVariable(VariableExpression variable, ExpressionBase value)
         {
             var indexedVariable = variable as IndexedVariableExpression;
             if (indexedVariable != null)

--- a/Source/Parser/Internal/MathematicExpression.cs
+++ b/Source/Parser/Internal/MathematicExpression.cs
@@ -107,7 +107,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ErrorExpression" />.
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {
@@ -146,7 +146,7 @@ namespace RATools.Parser.Internal
             if (mathematicLeft != null)
             {
                 left = mathematicLeft.MergeOperands();
-                if (left.Type == ExpressionType.ParseError)
+                if (left.Type == ExpressionType.Error)
                     return left;
             }
 
@@ -154,7 +154,7 @@ namespace RATools.Parser.Internal
             if (mathematicRight != null)
             {
                 right = mathematicRight.MergeOperands();
-                if (right.Type == ExpressionType.ParseError)
+                if (right.Type == ExpressionType.Error)
                     return right;
             }
 
@@ -181,7 +181,7 @@ namespace RATools.Parser.Internal
                     if (MergeIdentity(left, operation, right, out result))
                         return true;
 
-                    if (result is ParseErrorExpression)
+                    if (result is ErrorExpression)
                         return false;
                 }
             }
@@ -195,7 +195,7 @@ namespace RATools.Parser.Internal
                         if (MergeIdentity(right, operation, left, out result))
                             return true;
 
-                        if (result is ParseErrorExpression)
+                        if (result is ErrorExpression)
                             return false;
 
                         var temp = left;
@@ -265,7 +265,7 @@ namespace RATools.Parser.Internal
                 return true;
             }
 
-            result = new ParseErrorExpression("Cannot add expressions");
+            result = new ErrorExpression("Cannot add expressions");
             return false;
         }
 
@@ -287,7 +287,7 @@ namespace RATools.Parser.Internal
                 return true;
             }
 
-            result = new ParseErrorExpression("Cannot subtract expressions");
+            result = new ErrorExpression("Cannot subtract expressions");
             return false;
         }
 
@@ -309,7 +309,7 @@ namespace RATools.Parser.Internal
                 return true;
             }
 
-            result = new ParseErrorExpression("Cannot multiply expressions");
+            result = new ErrorExpression("Cannot multiply expressions");
             return false;
         }
 
@@ -323,7 +323,7 @@ namespace RATools.Parser.Internal
 
                 if (((FloatConstantExpression)right).Value == 0.0)
                 {
-                    result = new ParseErrorExpression("Division by zero");
+                    result = new ErrorExpression("Division by zero");
                     return false;
                 }
 
@@ -335,7 +335,7 @@ namespace RATools.Parser.Internal
             {
                 if (((IntegerConstantExpression)right).Value == 0.0)
                 {
-                    result = new ParseErrorExpression("Division by zero");
+                    result = new ErrorExpression("Division by zero");
                     return false;
                 }
 
@@ -343,7 +343,7 @@ namespace RATools.Parser.Internal
                 return true;
             }
 
-            result = new ParseErrorExpression("Cannot divide expressions");
+            result = new ErrorExpression("Cannot divide expressions");
             return false;
         }
 
@@ -357,7 +357,7 @@ namespace RATools.Parser.Internal
 
                 if (((FloatConstantExpression)right).Value == 0.0)
                 {
-                    result = new ParseErrorExpression("Division by zero");
+                    result = new ErrorExpression("Division by zero");
                     return false;
                 }
 
@@ -369,7 +369,7 @@ namespace RATools.Parser.Internal
             {
                 if (((IntegerConstantExpression)right).Value == 0)
                 {
-                    result = new ParseErrorExpression("Division by zero");
+                    result = new ErrorExpression("Division by zero");
                     return false;
                 }
 
@@ -377,7 +377,7 @@ namespace RATools.Parser.Internal
                 return true;
             }
 
-            result = new ParseErrorExpression("Cannot modulus expressions");
+            result = new ErrorExpression("Cannot modulus expressions");
             return false;
         }
 
@@ -389,7 +389,7 @@ namespace RATools.Parser.Internal
                 return true;
             }
 
-            result = new ParseErrorExpression("Cannot bitwise and expressions");
+            result = new ErrorExpression("Cannot bitwise and expressions");
             return false;
         }
 
@@ -498,13 +498,13 @@ namespace RATools.Parser.Internal
                             if (left.Type == ExpressionType.FloatConstant)
                             {
                                 right = FloatConstantExpression.ConvertFrom(right);
-                                if (right.Type == ExpressionType.ParseError)
+                                if (right.Type == ExpressionType.Error)
                                     return false;
                             }
                             else if (right.Type == ExpressionType.FloatConstant)
                             {
                                 left = FloatConstantExpression.ConvertFrom(left);
-                                if (left.Type == ExpressionType.ParseError)
+                                if (left.Type == ExpressionType.Error)
                                     return false;
                             }
                             else
@@ -665,7 +665,7 @@ namespace RATools.Parser.Internal
 
                     case MathematicOperation.Divide:
                     case MathematicOperation.Modulus:
-                        result = new ParseErrorExpression("Division by zero");
+                        result = new ErrorExpression("Division by zero");
                         return false;
                 }
             }

--- a/Source/Parser/Internal/ParseErrorExpression.cs
+++ b/Source/Parser/Internal/ParseErrorExpression.cs
@@ -3,36 +3,36 @@ using System.Text;
 
 namespace RATools.Parser.Internal
 {
-    internal class ParseErrorExpression : ExpressionBase
+    internal class ErrorExpression : ExpressionBase
     {
-        public ParseErrorExpression(string message)
-            : base(ExpressionType.ParseError)
+        public ErrorExpression(string message)
+            : base(ExpressionType.Error)
         {
             Message = message;
         }
 
-        public ParseErrorExpression(string message, int line, int column, int endLine, int endColumn)
+        public ErrorExpression(string message, int line, int column, int endLine, int endColumn)
             : this(message, new TextRange(line, column, endLine, endColumn))
         {
         }
 
-        public ParseErrorExpression(string message, ExpressionBase expression)
+        public ErrorExpression(string message, ExpressionBase expression)
             : this(message, expression.Location)
         {
         }
 
-        public ParseErrorExpression(string message, TextRange location)
+        public ErrorExpression(string message, TextRange location)
             : this(message)
         {
             Location = location;
         }
 
-        public ParseErrorExpression(ExpressionBase error, ExpressionBase expression)
-            : base(ExpressionType.ParseError)
+        public ErrorExpression(ExpressionBase error, ExpressionBase expression)
+            : base(ExpressionType.Error)
         {
             Location = expression.Location;
 
-            var parseError = error as ParseErrorExpression;
+            var parseError = error as ErrorExpression;
             if (parseError != null)
             {
                 Message = parseError.Message;
@@ -49,14 +49,14 @@ namespace RATools.Parser.Internal
             }
         }
 
-        public static ParseErrorExpression WrapError(ParseErrorExpression error, string message, ExpressionBase expression)
+        public static ErrorExpression WrapError(ErrorExpression error, string message, ExpressionBase expression)
         {
             if (error.Location.End == expression.Location.End && error.Location.Start == expression.Location.Start)
             {
                 return error;
             }
 
-            return new ParseErrorExpression(message, expression) { InnerError = error };
+            return new ErrorExpression(message, expression) { InnerError = error };
         }
 
         /// <summary>
@@ -67,12 +67,12 @@ namespace RATools.Parser.Internal
         /// <summary>
         /// Gets a secondary error that caused this error.
         /// </summary>
-        public ParseErrorExpression InnerError { get; internal set; }
+        public ErrorExpression InnerError { get; internal set; }
 
         /// <summary>
         /// Gets the root error that caused this error.
         /// </summary>
-        public ParseErrorExpression InnermostError
+        public ErrorExpression InnermostError
         {
             get
             {
@@ -96,20 +96,20 @@ namespace RATools.Parser.Internal
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="ParseErrorExpression" /> is equal to this instance.
+        /// Determines whether the specified <see cref="ErrorExpression" /> is equal to this instance.
         /// </summary>
-        /// <param name="obj">The <see cref="ParseErrorExpression" /> to compare with this instance.</param>
+        /// <param name="obj">The <see cref="ErrorExpression" /> to compare with this instance.</param>
         /// <returns>
-        ///   <c>true</c> if the specified <see cref="ParseErrorExpression" /> is equal to this instance; otherwise, <c>false</c>.
+        ///   <c>true</c> if the specified <see cref="ErrorExpression" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         protected override bool Equals(ExpressionBase obj)
         {
-            var that = obj as ParseErrorExpression;
+            var that = obj as ErrorExpression;
             return that != null && Message == that.Message;
         }
     }
 
-    internal class UnknownVariableParseErrorExpression : ParseErrorExpression
+    internal class UnknownVariableParseErrorExpression : ErrorExpression
     {
         public UnknownVariableParseErrorExpression(string message, ExpressionBase expression)
             : base(message, expression)

--- a/Source/Parser/Internal/ReturnExpression.cs
+++ b/Source/Parser/Internal/ReturnExpression.cs
@@ -45,7 +45,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ErrorExpression" />.
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {

--- a/Source/Parser/Internal/VariableExpression.cs
+++ b/Source/Parser/Internal/VariableExpression.cs
@@ -63,7 +63,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope object containing variable values.</param>
         /// <param name="result">[out] The new expression containing the replaced variables.</param>
         /// <returns>
-        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ParseErrorExpression" />.
+        ///   <c>true</c> if substitution was successful, <c>false</c> if something went wrong, in which case <paramref name="result" /> will likely be a <see cref="ErrorExpression" />.
         /// </returns>
         public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
         {

--- a/Source/Parser/RichPresenceBuilder.cs
+++ b/Source/Parser/RichPresenceBuilder.cs
@@ -58,18 +58,18 @@ namespace RATools.Parser
             };
         }
 
-        public ParseErrorExpression AddLookupField(ExpressionBase func, string name, DictionaryExpression dict, StringConstantExpression fallback)
+        public ErrorExpression AddLookupField(ExpressionBase func, string name, DictionaryExpression dict, StringConstantExpression fallback)
         {
             var tinyDict = new TinyDictionary<int, string>();
             foreach (var entry in dict.Entries)
             {
                 var key = entry.Key as IntegerConstantExpression;
                 if (key == null)
-                    return new ParseErrorExpression("key is not an integer", entry.Key);
+                    return new ErrorExpression("key is not an integer", entry.Key);
 
                 var value = entry.Value as StringConstantExpression;
                 if (value == null)
-                    return new ParseErrorExpression("value is not a string", entry.Value);
+                    return new ErrorExpression("value is not a string", entry.Value);
 
                 tinyDict[key.Value] = value.Value;
             }
@@ -263,7 +263,7 @@ namespace RATools.Parser
             DisplayString = null;
         }
 
-        public ParseErrorExpression Merge(RichPresenceBuilder from)
+        public ErrorExpression Merge(RichPresenceBuilder from)
         {
             if (!String.IsNullOrEmpty(from.DisplayString))
             {
@@ -279,7 +279,7 @@ namespace RATools.Parser
                 if (!_valueFields.TryGetValue(kvp.Key, out field))
                     _valueFields.Add(kvp);
                 else if (field.Format != kvp.Value.Format)
-                    return new ParseErrorExpression("Multiple rich_presence_value calls with the same name must have the same format", field.Func);
+                    return new ErrorExpression("Multiple rich_presence_value calls with the same name must have the same format", field.Func);
             }
 
             foreach (var kvp in from._lookupFields)
@@ -294,16 +294,16 @@ namespace RATools.Parser
                     var toMerge = kvp.Value;
 
                     if (existing.Fallback != toMerge.Fallback)
-                        return new ParseErrorExpression("Multiple rich_presence_lookup calls with the same name must have the same fallback", toMerge.Fallback ?? existing.Fallback);
+                        return new ErrorExpression("Multiple rich_presence_lookup calls with the same name must have the same fallback", toMerge.Fallback ?? existing.Fallback);
 
                     if (existing.Entries.Count != toMerge.Entries.Count)
-                        return new ParseErrorExpression("Multiple rich_presence_lookup calls with the same name must have the same dictionary", toMerge.Func ?? existing.Func);
+                        return new ErrorExpression("Multiple rich_presence_lookup calls with the same name must have the same dictionary", toMerge.Func ?? existing.Func);
 
                     foreach (var kvp2 in existing.Entries)
                     {
                         string value;
                         if (!toMerge.Entries.TryGetValue(kvp2.Key, out value) || kvp2.Value != value)
-                            return new ParseErrorExpression("Multiple rich_presence_lookup calls with the same name must have the same dictionary", toMerge.Func ?? existing.Func);
+                            return new ErrorExpression("Multiple rich_presence_lookup calls with the same name must have the same dictionary", toMerge.Func ?? existing.Func);
                     }
                 }
             }

--- a/Source/ViewModels/EditorViewModel.cs
+++ b/Source/ViewModels/EditorViewModel.cs
@@ -218,7 +218,7 @@ namespace RATools.ViewModels
                 {
                     var errors = new Stack<CodeReferenceViewModel>();
 
-                    ParseErrorExpression innerError = error;
+                    ErrorExpression innerError = error;
                     while (innerError != null)
                     {
                         errors.Push(new CodeReferenceViewModel
@@ -379,7 +379,7 @@ namespace RATools.ViewModels
                 var expressionStart = (expression.Location.Start.Line == line) ? expression.Location.Start.Column : 1;
                 var expressionEnd = (expression.Location.End.Line == line) ? expression.Location.End.Column : e.Text.Length + 1;
 
-                var parseError = expression as ParseErrorExpression;
+                var parseError = expression as ErrorExpression;
                 if (parseError != null)
                     e.SetError(expressionStart, expressionEnd - expressionStart + 1, parseError.Message);
                 else

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -152,8 +152,8 @@ namespace RATools.Test.Parser
             // inputs /output makes reading the tests and validating the behavior easier for humans.
             var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
             var expression = ExpressionBase.Parse(tokenizer);
-            if (expression is ParseErrorExpression)
-                Assert.Fail(((ParseErrorExpression)expression).Message);
+            if (expression is ErrorExpression)
+                Assert.Fail(((ErrorExpression)expression).Message);
 
             var achievement = new ScriptInterpreterAchievementBuilder();
             var error = achievement.PopulateFromExpression(expression);

--- a/Tests/Parser/Functions/ArrayMapFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayMapFunctionTests.cs
@@ -37,7 +37,7 @@ namespace RATools.Test.Parser.Functions
                 }
             }
 
-            var error = expr as ParseErrorExpression;
+            var error = expr as ErrorExpression;
             if (error != null)
                 return error.InnermostError.Message;
 

--- a/Tests/Parser/Functions/ArrayPopFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayPopFunctionTests.cs
@@ -42,9 +42,9 @@ namespace RATools.Test.Parser.Functions
                 if (error == null)
                     Assert.That(funcDef.Evaluate(parameterScope, out error), Is.False);
 
-                Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
+                Assert.That(error, Is.InstanceOf<ErrorExpression>());
 
-                var parseError = (ParseErrorExpression)error;
+                var parseError = (ErrorExpression)error;
                 while (parseError.InnerError != null)
                     parseError = parseError.InnerError;
                 Assert.That(parseError.Message, Is.EqualTo(expectedError));

--- a/Tests/Parser/Functions/ArrayPushFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayPushFunctionTests.cs
@@ -44,9 +44,9 @@ namespace RATools.Test.Parser.Functions
                 if (error == null)
                     Assert.That(funcDef.Evaluate(parameterScope, out error), Is.False);
 
-                Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
+                Assert.That(error, Is.InstanceOf<ErrorExpression>());
 
-                var parseError = (ParseErrorExpression)error;
+                var parseError = (ErrorExpression)error;
                 while (parseError.InnerError != null)
                     parseError = parseError.InnerError;
                 Assert.That(parseError.Message, Is.EqualTo(expectedError));

--- a/Tests/Parser/Functions/FlagConditionFunctionTests.cs
+++ b/Tests/Parser/Functions/FlagConditionFunctionTests.cs
@@ -136,8 +136,8 @@ namespace RATools.Test.Parser.Functions
             ExpressionBase error;
             var scope = funcCall.GetParameters(funcDef, AchievementScriptInterpreter.GetGlobalScope(), out error);
             Assert.That(funcDef.Evaluate(scope, out error), Is.False);
-            Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)error).Message, Is.EqualTo("never has no meaning outside of a trigger clause"));
+            Assert.That(error, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)error).Message, Is.EqualTo("never has no meaning outside of a trigger clause"));
         }
 
         [Test]

--- a/Tests/Parser/Functions/FormatFunctionTests.cs
+++ b/Tests/Parser/Functions/FormatFunctionTests.cs
@@ -144,8 +144,8 @@ namespace RATools.Test.Parser.Functions
             ExpressionBase result;
             Assert.That(expression.Evaluate(scope, out result), Is.False);
 
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            var parseError = (ParseErrorExpression)result;
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            var parseError = (ErrorExpression)result;
             while (parseError.InnerError != null)
                 parseError = parseError.InnerError;
             return parseError.Message;

--- a/Tests/Parser/Functions/LengthFunctionTests.cs
+++ b/Tests/Parser/Functions/LengthFunctionTests.cs
@@ -44,9 +44,9 @@ namespace RATools.Test.Parser.Functions
                 if (error == null)
                     Assert.That(funcDef.Evaluate(parameterScope, out error), Is.False);
 
-                Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
+                Assert.That(error, Is.InstanceOf<ErrorExpression>());
 
-                var parseError = (ParseErrorExpression)error;
+                var parseError = (ErrorExpression)error;
                 while (parseError.InnerError != null)
                     parseError = parseError.InnerError;
                 Assert.That(parseError.Message, Is.EqualTo(expectedError));

--- a/Tests/Parser/Functions/MemoryAccessorFunctionTests.cs
+++ b/Tests/Parser/Functions/MemoryAccessorFunctionTests.cs
@@ -86,8 +86,8 @@ namespace RATools.Test.Parser.Functions
             ExpressionBase error;
             var scope = funcCall.GetParameters(funcDef, AchievementScriptInterpreter.GetGlobalScope(), out error);
             Assert.That(funcDef.Evaluate(scope, out error), Is.False);
-            Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)error).Message, Is.EqualTo("byte has no meaning outside of a trigger clause"));
+            Assert.That(error, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)error).Message, Is.EqualTo("byte has no meaning outside of a trigger clause"));
         }
 
         [Test]

--- a/Tests/Parser/Functions/OnceFunctionTests.cs
+++ b/Tests/Parser/Functions/OnceFunctionTests.cs
@@ -79,8 +79,8 @@ namespace RATools.Test.Parser.Functions
             ExpressionBase error;
             var scope = funcCall.GetParameters(funcDef, AchievementScriptInterpreter.GetGlobalScope(), out error);
             Assert.That(funcDef.Evaluate(scope, out error), Is.False);
-            Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)error).Message, Is.EqualTo("once has no meaning outside of a trigger clause"));
+            Assert.That(error, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)error).Message, Is.EqualTo("once has no meaning outside of a trigger clause"));
         }
 
         [Test]

--- a/Tests/Parser/Functions/RepeatedFunctionTests.cs
+++ b/Tests/Parser/Functions/RepeatedFunctionTests.cs
@@ -79,8 +79,8 @@ namespace RATools.Test.Parser.Functions
             ExpressionBase error;
             var scope = funcCall.GetParameters(funcDef, AchievementScriptInterpreter.GetGlobalScope(), out error);
             Assert.That(funcDef.Evaluate(scope, out error), Is.False);
-            Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)error).Message, Is.EqualTo("repeated has no meaning outside of a trigger clause"));
+            Assert.That(error, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)error).Message, Is.EqualTo("repeated has no meaning outside of a trigger clause"));
         }
 
         [Test]

--- a/Tests/Parser/Functions/RichPresenceLookupFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceLookupFunctionTests.cs
@@ -36,7 +36,7 @@ namespace RATools.Test.Parser.Functions
                 if (expectedError != null && expectedError.EndsWith(" format"))
                 {
                     Assert.That(funcDef.ReplaceVariables(scope, out evaluated), Is.False);
-                    var parseError = evaluated as ParseErrorExpression;
+                    var parseError = evaluated as ErrorExpression;
                     Assert.That(parseError, Is.Not.Null);
                     Assert.That(parseError.Message, Is.EqualTo(expectedError));
                     return context.RichPresence;
@@ -52,8 +52,8 @@ namespace RATools.Test.Parser.Functions
                 else
                 {
                     Assert.That(funcDef.BuildMacro(context, scope, out result), Is.False);
-                    Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-                    Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo(expectedError));
+                    Assert.That(result, Is.InstanceOf<ErrorExpression>());
+                    Assert.That(((ErrorExpression)result).Message, Is.EqualTo(expectedError));
                 }
 
                 return context.RichPresence;
@@ -111,8 +111,8 @@ namespace RATools.Test.Parser.Functions
             ExpressionBase error;
             var scope = funcCall.GetParameters(funcDef, parentScope, out error);
             Assert.That(funcDef.Evaluate(scope, out error), Is.False);
-            Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)error).Message, Is.EqualTo("rich_presence_lookup has no meaning outside of a rich_presence_display call"));
+            Assert.That(error, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)error).Message, Is.EqualTo("rich_presence_lookup has no meaning outside of a rich_presence_display call"));
         }
 
         [Test]

--- a/Tests/Parser/Functions/RichPresenceMacroFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceMacroFunctionTests.cs
@@ -37,7 +37,7 @@ namespace RATools.Test.Parser.Functions
             if (expectedError != null)
             {
                 Assert.That(funcDef.ReplaceVariables(scope, out evaluated), Is.False);
-                var parseError = evaluated as ParseErrorExpression;
+                var parseError = evaluated as ErrorExpression;
                 Assert.That(parseError, Is.Not.Null);
                 Assert.That(parseError.Message, Is.EqualTo(expectedError));
                 return context.RichPresence;

--- a/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
@@ -40,7 +40,7 @@ namespace RATools.Test.Parser.Functions
             if (expectedError != null && expectedError.EndsWith(" format"))
             {
                 Assert.That(funcDef.ReplaceVariables(scope, out evaluated), Is.False);
-                var parseError = evaluated as ParseErrorExpression;
+                var parseError = evaluated as ErrorExpression;
                 Assert.That(parseError, Is.Not.Null);
                 Assert.That(parseError.Message, Is.EqualTo(expectedError));
                 return context.RichPresence;
@@ -56,8 +56,8 @@ namespace RATools.Test.Parser.Functions
             else
             {
                 Assert.That(funcDef.BuildMacro(context, scope, out result), Is.False);
-                Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-                Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo(expectedError));
+                Assert.That(result, Is.InstanceOf<ErrorExpression>());
+                Assert.That(((ErrorExpression)result).Message, Is.EqualTo(expectedError));
             }
 
             return context.RichPresence;
@@ -84,8 +84,8 @@ namespace RATools.Test.Parser.Functions
             ExpressionBase error;
             var scope = funcCall.GetParameters(funcDef, AchievementScriptInterpreter.GetGlobalScope(), out error);
             Assert.That(funcDef.Evaluate(scope, out error), Is.False);
-            Assert.That(error, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)error).Message, Is.EqualTo("rich_presence_value has no meaning outside of a rich_presence_display call"));
+            Assert.That(error, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)error).Message, Is.EqualTo("rich_presence_value has no meaning outside of a rich_presence_display call"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/AssignmentExpressionTests.cs
+++ b/Tests/Parser/Internal/AssignmentExpressionTests.cs
@@ -52,8 +52,8 @@ namespace RATools.Test.Parser.Internal
             // variable doesn't have a current value, logical comparison not supported
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Unknown variable: variable"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Unknown variable: variable"));
         }
 
         [Test]
@@ -69,8 +69,8 @@ namespace RATools.Test.Parser.Internal
             // variable doesn't have a current value, addition not supported
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Unknown variable: variable"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Unknown variable: variable"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/BooleanConstantExpressionTests.cs
+++ b/Tests/Parser/Internal/BooleanConstantExpressionTests.cs
@@ -31,7 +31,7 @@ namespace RATools.Test.Parser.Internal
         public void TestIsTrueTrue()
         {
             var expr = new BooleanConstantExpression(true);
-            ParseErrorExpression error;
+            ErrorExpression error;
             Assert.That(expr.IsTrue(new InterpreterScope(), out error), Is.True);
             Assert.That(error, Is.Null);
         }
@@ -40,7 +40,7 @@ namespace RATools.Test.Parser.Internal
         public void TestIsTrueFalse()
         {
             var expr = new BooleanConstantExpression(false);
-            ParseErrorExpression error;
+            ErrorExpression error;
             Assert.That(expr.IsTrue(new InterpreterScope(), out error), Is.False);
             Assert.That(error, Is.Null);
         }

--- a/Tests/Parser/Internal/ComparisonExpressionTests.cs
+++ b/Tests/Parser/Internal/ComparisonExpressionTests.cs
@@ -110,7 +110,7 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             if (!expr.ReplaceVariables(scope, out result))
-                Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
+                Assert.That(result, Is.InstanceOf<ErrorExpression>());
 
             var builder = new StringBuilder();
             result.AppendString(builder);
@@ -186,7 +186,7 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             if (!expr.ReplaceVariables(scope, out result))
-                Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
+                Assert.That(result, Is.InstanceOf<ErrorExpression>());
 
             var builder = new StringBuilder();
             result.AppendString(builder);
@@ -378,7 +378,7 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             if (!expr.ReplaceVariables(scope, out result))
-                Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
+                Assert.That(result, Is.InstanceOf<ErrorExpression>());
 
             var builder = new StringBuilder();
             result.AppendString(builder);
@@ -403,8 +403,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Expression can never be true"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Expression can never be true"));
         }
 
         [Test]
@@ -502,7 +502,7 @@ namespace RATools.Test.Parser.Internal
 
             var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
             scope.Context = new RATools.Parser.TriggerBuilderContext();
-            ParseErrorExpression error;
+            ErrorExpression error;
             Assert.That(expr.IsTrue(scope, out error), Is.EqualTo(expected));
             Assert.That(error, Is.Null);
         }

--- a/Tests/Parser/Internal/ConditionalExpressionTests.cs
+++ b/Tests/Parser/Internal/ConditionalExpressionTests.cs
@@ -122,7 +122,7 @@ namespace RATools.Test.Parser.Internal
             var expression = ExpressionBase.Parse(tokenizer);
             Assert.That(expression, Is.InstanceOf<ConditionalExpression>());
 
-            ParseErrorExpression error;
+            ErrorExpression error;
             var scope = AchievementScriptInterpreter.GetGlobalScope();
             var result = expression.IsTrue(scope, out error);
             Assert.That(error, Is.Null);

--- a/Tests/Parser/Internal/DictionaryExpressionTests.cs
+++ b/Tests/Parser/Internal/DictionaryExpressionTests.cs
@@ -150,8 +150,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Dictionary key must evaluate to a constant"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Dictionary key must evaluate to a constant"));
         }
 
         [Test]
@@ -169,8 +169,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            var parseError = (ParseErrorExpression)result;
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            var parseError = (ErrorExpression)result;
             while (parseError.InnerError != null)
                 parseError = parseError.InnerError;
             Assert.That(parseError.Message, Is.EqualTo("func did not return a value"));
@@ -190,8 +190,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("1 already exists in dictionary"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("1 already exists in dictionary"));
         }
 
         [Test]
@@ -212,8 +212,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("1 already exists in dictionary"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("1 already exists in dictionary"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/ExpressionBaseTests.cs
+++ b/Tests/Parser/Internal/ExpressionBaseTests.cs
@@ -93,8 +93,8 @@ namespace RATools.Test.Parser.Internal
 
             tokenizer = CreateTokenizer("4294967296");
             expression = ExpressionBase.Parse(tokenizer);
-            Assert.That(expression, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)expression).Message, Is.EqualTo("Number too large"));
+            Assert.That(expression, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)expression).Message, Is.EqualTo("Number too large"));
         }
 
         [Test]
@@ -107,8 +107,8 @@ namespace RATools.Test.Parser.Internal
 
             tokenizer = CreateTokenizer("0x100000000");
             expression = ExpressionBase.Parse(tokenizer);
-            Assert.That(expression, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)expression).Message, Is.EqualTo("Number too large"));
+            Assert.That(expression, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)expression).Message, Is.EqualTo("Number too large"));
         }
 
         [Test]
@@ -121,8 +121,8 @@ namespace RATools.Test.Parser.Internal
 
             tokenizer = CreateTokenizer("-2147483648");
             expression = ExpressionBase.Parse(tokenizer);
-            Assert.That(expression, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)expression).Message, Is.EqualTo("Number too large"));
+            Assert.That(expression, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)expression).Message, Is.EqualTo("Number too large"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/ExpressionGroupTests.cs
+++ b/Tests/Parser/Internal/ExpressionGroupTests.cs
@@ -49,14 +49,14 @@ namespace RATools.Test.Parser.Internal
             Assert.That(group.ParseErrors, Is.Empty);
             Assert.That(group.IsEmpty);
 
-            var parseError = new ParseErrorExpression("oops");
+            var parseError = new ErrorExpression("oops");
             group.AddParseError(parseError);
             Assert.That(group.ParseErrors.Count(), Is.EqualTo(1));
             Assert.That(group.ParseErrors.Contains(parseError));
             Assert.That(group.Expressions, Is.Empty);
             Assert.That(!group.IsEmpty);
 
-            var parseError2 = new ParseErrorExpression("bad");
+            var parseError2 = new ErrorExpression("bad");
             group.AddParseError(parseError2);
             Assert.That(group.ParseErrors.Count(), Is.EqualTo(2));
             Assert.That(group.ParseErrors.Contains(parseError));
@@ -186,13 +186,13 @@ namespace RATools.Test.Parser.Internal
         public void GetExpressionsForLineParseError()
         {
             var group = Parse("function a()\n{\n  func2()\n}\n").Groups.First();
-            group.AddParseError(new ParseErrorExpression("Oops", 3, 8, 3, 9));
+            group.AddParseError(new ErrorExpression("Oops", 3, 8, 3, 9));
             var lines = new List<ExpressionBase>();
 
             Assert.That(group.GetExpressionsForLine(lines, 3), Is.True);
             Assert.That(lines.Count, Is.EqualTo(2));
             Assert.That(lines[0], Is.InstanceOf<FunctionNameExpression>());
-            Assert.That(lines[1], Is.InstanceOf<ParseErrorExpression>());
+            Assert.That(lines[1], Is.InstanceOf<ErrorExpression>());
 
             lines.Clear();
             Assert.That(group.GetExpressionsForLine(lines, 1), Is.True);

--- a/Tests/Parser/Internal/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Internal/FunctionCallExpressionTests.cs
@@ -111,7 +111,7 @@ namespace RATools.Test.Parser.Internal
             var innerScope = functionCall.GetParameters(functionDefinition, scope, out error);
             Assert.That(innerScope, Is.Null);
             Assert.That(error, Is.Not.Null);
-            var parseError = (ParseErrorExpression)error;
+            var parseError = (ErrorExpression)error;
             Assert.That(parseError.Message, Is.EqualTo("Required parameter 'j' not provided"));
         }
 
@@ -127,7 +127,7 @@ namespace RATools.Test.Parser.Internal
             var innerScope = functionCall.GetParameters(functionDefinition, scope, out error);
             Assert.That(innerScope, Is.Null);
             Assert.That(error, Is.Not.Null);
-            var parseError = (ParseErrorExpression)error;
+            var parseError = (ErrorExpression)error;
             Assert.That(parseError.Message, Is.EqualTo("Too many parameters passed to function"));
         }
 
@@ -143,7 +143,7 @@ namespace RATools.Test.Parser.Internal
             var innerScope = functionCall.GetParameters(functionDefinition, scope, out error);
             Assert.That(innerScope, Is.Not.Null);
             Assert.That(error, Is.Not.Null);
-            var parseError = (ParseErrorExpression)error;
+            var parseError = (ErrorExpression)error;
             Assert.That(parseError.Message, Is.EqualTo("Invalid value for parameter: i"));
             Assert.That(parseError.InnermostError.Message, Is.EqualTo("Unknown variable: var"));
         }
@@ -161,7 +161,7 @@ namespace RATools.Test.Parser.Internal
             var innerScope = functionCall.GetParameters(functionDefinition, scope, out error);
             Assert.That(innerScope, Is.Not.Null);
             Assert.That(error, Is.Not.Null);
-            var parseError = (ParseErrorExpression)error;
+            var parseError = (ErrorExpression)error;
             Assert.That(parseError.Message, Is.EqualTo("Invalid value for parameter: i"));
             Assert.That(parseError.InnermostError.Message, Is.EqualTo("Unknown variable: var"));
         }
@@ -199,7 +199,7 @@ namespace RATools.Test.Parser.Internal
             var innerScope = functionCall.GetParameters(functionDefinition, scope, out error);
             Assert.That(innerScope, Is.Null);
             Assert.That(error, Is.Not.Null);
-            var parseError = (ParseErrorExpression)error;
+            var parseError = (ErrorExpression)error;
             Assert.That(parseError.Message, Is.EqualTo("Required parameter 'i' not provided"));
         }
 
@@ -216,7 +216,7 @@ namespace RATools.Test.Parser.Internal
             var innerScope = functionCall.GetParameters(functionDefinition, scope, out error);
             Assert.That(innerScope, Is.Null);
             Assert.That(error, Is.Not.Null);
-            var parseError = (ParseErrorExpression)error;
+            var parseError = (ErrorExpression)error;
             Assert.That(parseError.Message, Is.EqualTo("'func' does not have a 'k' parameter"));
         }
 
@@ -233,7 +233,7 @@ namespace RATools.Test.Parser.Internal
             var innerScope = functionCall.GetParameters(functionDefinition, scope, out error);
             Assert.That(innerScope, Is.Null);
             Assert.That(error, Is.Not.Null);
-            var parseError = (ParseErrorExpression)error;
+            var parseError = (ErrorExpression)error;
             Assert.That(parseError.Message, Is.EqualTo("'i' already has a value"));
         }
 
@@ -270,7 +270,7 @@ namespace RATools.Test.Parser.Internal
             var innerScope = functionCall.GetParameters(functionDefinition, scope, out error);
             Assert.That(innerScope, Is.Null);
             Assert.That(error, Is.Not.Null);
-            var parseError = (ParseErrorExpression)error;
+            var parseError = (ErrorExpression)error;
             Assert.That(parseError.Message, Is.EqualTo("Non-named parameter following named parameter"));
         }
 
@@ -313,8 +313,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(functionCall.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            var parseError = (ParseErrorExpression)result;
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            var parseError = (ErrorExpression)result;
             Assert.That(parseError.InnermostError.Message, Is.EqualTo("Unknown variable: var"));
         }
 
@@ -329,8 +329,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(functionCall.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            var parseError = (ParseErrorExpression)result;
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            var parseError = (ErrorExpression)result;
             Assert.That(parseError.InnermostError.Message, Is.EqualTo("Unknown variable: var"));
         }
         [Test]
@@ -344,8 +344,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(functionCall.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            var parseError = (ParseErrorExpression)result;
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            var parseError = (ErrorExpression)result;
             Assert.That(parseError.InnermostError.Message, Is.EqualTo("Unknown variable: var"));
         }
 
@@ -361,8 +361,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(functionCall.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            var parseError = (ParseErrorExpression)result;
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            var parseError = (ErrorExpression)result;
             Assert.That(parseError.InnermostError.Message, Is.EqualTo("Unknown variable: var"));
         }
 
@@ -411,8 +411,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(functionCall.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            var parseError = (ParseErrorExpression)result;
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            var parseError = (ErrorExpression)result;
             while (parseError.InnerError != null)
                 parseError = parseError.InnerError;
             Assert.That(parseError.Message, Is.EqualTo("func did not return a value"));
@@ -427,8 +427,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(functionCall.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Unknown function: func"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Unknown function: func"));
         }
 
         [Test]
@@ -516,8 +516,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(functionCall.Evaluate(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Unknown function: func"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Unknown function: func"));
         }
 
         [Test]
@@ -613,7 +613,7 @@ namespace RATools.Test.Parser.Internal
             var expr = AlwaysTrueFunction.CreateAlwaysTrueFunctionCall();
             var scope = AchievementScriptInterpreter.GetGlobalScope();
 
-            ParseErrorExpression error;
+            ErrorExpression error;
             Assert.That(expr.IsTrue(scope, out error), Is.True);
             Assert.That(error, Is.Null);
         }
@@ -624,7 +624,7 @@ namespace RATools.Test.Parser.Internal
             var expr = AlwaysFalseFunction.CreateAlwaysFalseFunctionCall();
             var scope = AchievementScriptInterpreter.GetGlobalScope();
 
-            ParseErrorExpression error;
+            ErrorExpression error;
             Assert.That(expr.IsTrue(scope, out error), Is.False);
             Assert.That(error, Is.Null);
         }
@@ -635,7 +635,7 @@ namespace RATools.Test.Parser.Internal
             var expr = new FunctionCallExpression("byte", new ExpressionBase[] { new IntegerConstantExpression(0x1234) });
             var scope = AchievementScriptInterpreter.GetGlobalScope();
 
-            ParseErrorExpression error;
+            ErrorExpression error;
             Assert.That(expr.IsTrue(scope, out error), Is.Null);
             Assert.That(error, Is.Null);
         }
@@ -648,7 +648,7 @@ namespace RATools.Test.Parser.Internal
             var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
             scope.AddFunction(userFunc);
 
-            ParseErrorExpression error;
+            ErrorExpression error;
             Assert.That(expr.IsTrue(scope, out error), Is.Null);
             Assert.That(error, Is.Null);
         }
@@ -661,7 +661,7 @@ namespace RATools.Test.Parser.Internal
             var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
             scope.AddFunction(userFunc);
 
-            ParseErrorExpression error;
+            ErrorExpression error;
             Assert.That(expr.IsTrue(scope, out error), Is.True);
             Assert.That(error, Is.Null);
         }

--- a/Tests/Parser/Internal/FunctionDefinitionExpressionTests.cs
+++ b/Tests/Parser/Internal/FunctionDefinitionExpressionTests.cs
@@ -42,9 +42,9 @@ namespace RATools.Test.Parser.Internal
 
             if (expectedError != null)
             {
-                Assert.That(expr, Is.InstanceOf<ParseErrorExpression>());
+                Assert.That(expr, Is.InstanceOf<ErrorExpression>());
 
-                var error = (ParseErrorExpression)expr;
+                var error = (ErrorExpression)expr;
                 var formattedErrorMessage = string.Format("{0}:{1} {2}", error.Location.Start.Line, error.Location.Start.Column, error.Message);
                 Assert.That(formattedErrorMessage, Is.EqualTo(expectedError));
                 return null;
@@ -178,8 +178,8 @@ namespace RATools.Test.Parser.Internal
             tokenizer.Match("function");
             var expr = UserFunctionDefinitionExpression.Parse(tokenizer);
 
-            Assert.That(expr, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)expr).Message, Is.EqualTo("Unexpected end of script"));
+            Assert.That(expr, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)expr).Message, Is.EqualTo("Unexpected end of script"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/IndexedVariableExpressionTests.cs
+++ b/Tests/Parser/Internal/IndexedVariableExpressionTests.cs
@@ -106,8 +106,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("No entry in dictionary for key: \"key\""));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("No entry in dictionary for key: \"key\""));
         }
 
         [Test]
@@ -123,8 +123,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Cannot index: variable (IntegerConstant)"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Cannot index: variable (IntegerConstant)"));
         }
 
         [Test]
@@ -207,8 +207,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Index 1 not in range 0-0"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Index 1 not in range 0-0"));
         }
 
         [Test]
@@ -226,8 +226,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Index -1 not in range 0-0"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Index -1 not in range 0-0"));
         }
 
         [Test]
@@ -245,8 +245,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Index does not evaluate to an integer constant"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Index does not evaluate to an integer constant"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/MathematicExpressionTests.cs
+++ b/Tests/Parser/Internal/MathematicExpressionTests.cs
@@ -249,7 +249,7 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Division by zero"));
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Division by zero"));
         }
 
         [Test]
@@ -293,7 +293,7 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(expr.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Division by zero"));
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Division by zero"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/VariableExpressionTests.cs
+++ b/Tests/Parser/Internal/VariableExpressionTests.cs
@@ -56,8 +56,8 @@ namespace RATools.Test.Parser.Internal
 
             ExpressionBase result;
             Assert.That(variable.ReplaceVariables(scope, out result), Is.False);
-            Assert.That(result, Is.InstanceOf<ParseErrorExpression>());
-            Assert.That(((ParseErrorExpression)result).Message, Is.EqualTo("Unknown variable: unknown"));
+            Assert.That(result, Is.InstanceOf<ErrorExpression>());
+            Assert.That(((ErrorExpression)result).Message, Is.EqualTo("Unknown variable: unknown"));
         }
 
         [Test]

--- a/Tests/Parser/RequirementMergerTests.cs
+++ b/Tests/Parser/RequirementMergerTests.cs
@@ -15,8 +15,8 @@ namespace RATools.Test.Parser
             // inputs /output makes reading the tests and validating the behavior easier for humans.
             var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
             var expression = ExpressionBase.Parse(tokenizer);
-            if (expression is ParseErrorExpression)
-                Assert.Fail(((ParseErrorExpression)expression).Message);
+            if (expression is ErrorExpression)
+                Assert.Fail(((ErrorExpression)expression).Message);
 
             var achievement = new ScriptInterpreterAchievementBuilder();
             var error = achievement.PopulateFromExpression(expression);

--- a/Tests/Parser/TriggerBuilderContextTests.cs
+++ b/Tests/Parser/TriggerBuilderContextTests.cs
@@ -34,7 +34,7 @@ namespace RATools.Test.Parser
             var result = TriggerBuilderContext.GetConditionString(processed, scope, out error);
             if (error != null)
             {
-                Assert.That(((ParseErrorExpression)error).InnermostError.Message, Is.EqualTo(expected));
+                Assert.That(((ErrorExpression)error).InnermostError.Message, Is.EqualTo(expected));
             }
             else
             {


### PR DESCRIPTION
Many things currently being returned as ParseErrorExpressions are evaluation errors