### PR TITLE
fix optimization of division by self

### DIFF
--- a/Source/Data/Requirement.cs
+++ b/Source/Data/Requirement.cs
@@ -424,6 +424,11 @@ namespace RATools.Data
                         result = true;
                         break;
 
+                    case RequirementOperator.Multiply:
+                    case RequirementOperator.Divide:
+                    case RequirementOperator.BitwiseAnd:
+                        return null;
+
                     default:
                         result = false;
                         break;

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -405,6 +405,9 @@ namespace RATools.Tests.Parser
         [TestCase("byte(0x001234) < byte(0x001234)", "always_false()")] // never true
         [TestCase("byte(0x001234) >= byte(0x001234)", "always_true()")] // always true
         [TestCase("byte(0x001234) > byte(0x001234)", "always_false()")] // never true
+        [TestCase("byte(0x001234) / byte(0x001234)", "byte(0x001234) / byte(0x001234)")] // indeterminant - 0 or 1
+        [TestCase("byte(0x001234) * byte(0x001234)", "byte(0x001234) * byte(0x001234)")] // cannot be simplified
+        [TestCase("byte(0x001234) & byte(0x001234)", "byte(0x001234) & byte(0x001234)")] // could be simplified to just byte(0x001234)
         [TestCase("once(byte(0x001234) == byte(0x001234))", "always_true()")] // always true
         [TestCase("repeated(3, byte(0x001234) == byte(0x001234))", "repeated(3, always_true())")] // always true, but ignored for two frames
         [TestCase("never(repeated(3, 1 == 1))", "never(repeated(3, always_true()))")] // always true, but ignored for two frames


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/936655398725902356/987365591746744360

```
rich_presence_display("{0}",
    rich_presence_value("Count", sum_of(range(2, 4), f => low4(f)/low4(f)))
)
```

was generating

```
@Count(A:0=0_A:0=0_M:0=1)
```
instead of the expected
```
@Count(A:0xL000002/0xL000002_A:0xL000003/0xL000003_M:0xL000004/0xL000004)
```
