### PR TITLE
fix broken Copy to Clipboard commands

### DIFF
--- a/Source/ViewModels/LeaderboardViewModel.cs
+++ b/Source/ViewModels/LeaderboardViewModel.cs
@@ -13,12 +13,24 @@ namespace RATools.ViewModels
         public LeaderboardViewModel(GameViewModel owner)
             : base(owner)
         {
+            CopyTitleToClipboardCommand = new DelegateCommand(() =>
+            {
+                ServiceRepository.Instance.FindService<IClipboardService>().SetData(Title);
+            });
+
+            CopyDescriptionToClipboardCommand = new DelegateCommand(() =>
+            {
+                ServiceRepository.Instance.FindService<IClipboardService>().SetData(Description);
+            });
         }
 
         public override string ViewerType
         {
             get { return "Leaderboard"; }
         }
+
+        public DelegateCommand CopyTitleToClipboardCommand { get; private set; }
+        public DelegateCommand CopyDescriptionToClipboardCommand { get; private set; }
 
         protected override bool AreAssetSpecificPropertiesModified(AssetSourceViewModel left, AssetSourceViewModel right)
         {

--- a/Source/ViewModels/RichPresenceViewModel.cs
+++ b/Source/ViewModels/RichPresenceViewModel.cs
@@ -1,4 +1,7 @@
 ﻿using Jamiras.Commands;
+using Jamiras.Components;
+using Jamiras.Services;
+using Jamiras.ViewModels;
 using RATools.Data;
 using System;
 using System.Collections.Generic;
@@ -11,6 +14,28 @@ namespace RATools.ViewModels
         public RichPresenceViewModel(GameViewModel owner)
             : base(owner)
         {
+            CopyToClipboardCommand = new DelegateCommand(() =>
+            {
+                var rp = Generated.Asset as RichPresence;
+                if (rp == null)
+                {
+                    rp = Local.Asset as RichPresence;
+                    if (rp == null)
+                    {
+                        rp = Published.Asset as RichPresence;
+                        if (rp == null)
+                            return;
+                    }
+                }
+
+                ServiceRepository.Instance.FindService<IClipboardService>().SetData(rp.Script);
+
+                if (rp.Script.Length > RichPresence.ScriptMaxLength)
+                {
+                    TaskDialogViewModel.ShowWarningMessage("Your Rich Presence may not function as expected.",
+                        "Rich Presence exceeds maximum length of " + RichPresence.ScriptMaxLength + " characters (" + rp.Script.Length + ")");
+                }
+            });
         }
 
         public override string ViewerType


### PR DESCRIPTION
Fixes the "Copy to Clipboard" link for Rich Presence and the "Copy Title to Clipboard" and "Copy Description to Clipboard" links for Leaderboards.