### PR TITLE
allow fetching per-user data when populating user mastery dialog

### DIFF
--- a/Source/ViewModels/GameStatsViewModel.cs
+++ b/Source/ViewModels/GameStatsViewModel.cs
@@ -498,8 +498,7 @@ namespace RATools.ViewModels
             var userStats = new List<UserStats>();
             var achievementStats = new List<AchievementStats>();
 
-            if (!LoadGameFromFile(achievementStats, userStats, false))
-                return;
+            bool updateFile = LoadGameFromFile(achievementStats, userStats, false);
 
             foreach (var user in users)
             {
@@ -516,7 +515,8 @@ namespace RATools.ViewModels
                     user.Achievements[kvp.Key] = kvp.Value;
             }
 
-            WriteGameStats(_gameName, achievementStats, userStats);
+            if (updateFile)
+                WriteGameStats(_gameName, achievementStats, userStats);
         }
 
         private bool MergeUserGameMastery(UserStats stats)

--- a/Source/ViewModels/UserMasteriesViewModel.cs
+++ b/Source/ViewModels/UserMasteriesViewModel.cs
@@ -170,7 +170,7 @@ namespace RATools.ViewModels
                     {
                         result.NumMasters++;
 
-                        if (user.User == UserName)
+                        if (String.Compare(user.User, UserName, StringComparison.InvariantCultureIgnoreCase) == 0)
                         {
                             result.MasteryRank = result.NumMasters;
                             result.MasteryMinutes = (int)user.GameTime.TotalMinutes;


### PR DESCRIPTION
fixes an issue where user master time would be 0 minutes for a game with lots of players