### PR TITLE
Don't optimize measured comparison if it changes the measured target

### DIFF
--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -135,6 +135,8 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new ArrayPushFunction());
                 _globalScope.AddFunction(new ArrayPopFunction());
                 _globalScope.AddFunction(new ArrayMapFunction());
+
+                _globalScope.AddFunction(new RepeatedFunction.OrNextWrapperFunction());
             }
 
             return _globalScope;

--- a/Source/Parser/Expressions/ComparisonExpression.cs
+++ b/Source/Parser/Expressions/ComparisonExpression.cs
@@ -238,9 +238,16 @@ namespace RATools.Parser.Expressions
             // if we are, the right side is the measured target, and we don't want to modify that.
             if (right.Type == ExpressionType.IntegerConstant || right.Type == ExpressionType.FloatConstant)
             {
-                var functionContext = scope.GetContext<FunctionDefinitionExpression>();
-                if (functionContext != null && functionContext is MeasuredFunction)
-                    attemptNormalization = false;
+                var initializationContext = scope.GetContext<ParameterInitializationContext>();
+                if (initializationContext != null)
+                {
+                    var format = initializationContext.GetParameter<StringConstantExpression>(scope, "format");
+                    if (format != null && format.Value == "raw")
+                    {
+                        // capturing raw measured value. don't modify comparison
+                        attemptNormalization = false;
+                    }
+                }
             }
 
             var comparison = new ComparisonExpression(left, Operation, right);

--- a/Source/Parser/Expressions/FunctionCallExpression.cs
+++ b/Source/Parser/Expressions/FunctionCallExpression.cs
@@ -237,7 +237,7 @@ namespace RATools.Parser.Expressions
                 bool isLogicalUnit = value.IsLogicalUnit;
 
                 // not a basic type, evaluate it
-                var assignmentScope = new InterpreterScope(scope) { Context = assignment };
+                var assignmentScope = new InterpreterScope(parameterScope) { Context = assignment };
                 if (!value.ReplaceVariables(assignmentScope, out value))
                 {
                     var error = (ErrorExpression)value;

--- a/Source/Parser/Expressions/FunctionCallExpression.cs
+++ b/Source/Parser/Expressions/FunctionCallExpression.cs
@@ -237,7 +237,7 @@ namespace RATools.Parser.Expressions
                 bool isLogicalUnit = value.IsLogicalUnit;
 
                 // not a basic type, evaluate it
-                var assignmentScope = new InterpreterScope(parameterScope) { Context = assignment };
+                var assignmentScope = new InterpreterScope(scope) { Context = assignment };
                 if (!value.ReplaceVariables(assignmentScope, out value))
                 {
                     var error = (ErrorExpression)value;
@@ -294,6 +294,7 @@ namespace RATools.Parser.Expressions
         public InterpreterScope GetParameters(FunctionDefinitionExpression function, InterpreterScope scope, out ExpressionBase error)
         {
             var parameterScope = function.CreateCaptureScope(scope);
+            var initializationScope = new InterpreterScope(scope) { Context = new ParameterInitializationContext(function, Parameters) };
 
             // optimization for no parameter function
             if (function.Parameters.Count == 0 && Parameters.Count == 0)
@@ -344,7 +345,7 @@ namespace RATools.Parser.Expressions
                         return null;
                     }
 
-                    var value = GetParameter(parameterScope, scope, assignedParameter);
+                    var value = GetParameter(parameterScope, initializationScope, assignedParameter);
                     error = value as ErrorExpression;
                     if (error != null)
                         return null;
@@ -371,7 +372,7 @@ namespace RATools.Parser.Expressions
                     var variableName = index < parameterCount ? function.Parameters.ElementAt(index).Name : "...";
 
                     assignedParameter = new AssignmentExpression(new VariableExpression(variableName), parameter);
-                    var value = GetParameter(parameterScope, scope, assignedParameter);
+                    var value = GetParameter(parameterScope, initializationScope, assignedParameter);
                     error = value as ErrorExpression;
                     if (error != null)
                         return null;
@@ -401,7 +402,7 @@ namespace RATools.Parser.Expressions
                     return null;
                 }
 
-                var assignmentScope = new InterpreterScope(scope) { Context = new AssignmentExpression(new VariableExpression(parameter), value) };
+                var assignmentScope = new InterpreterScope(initializationScope) { Context = new AssignmentExpression(new VariableExpression(parameter), value) };
                 if (!value.ReplaceVariables(assignmentScope, out value))
                 {
                     error = new ErrorExpression(value, this);

--- a/Source/Parser/Expressions/FunctionDefinitionExpression.cs
+++ b/Source/Parser/Expressions/FunctionDefinitionExpression.cs
@@ -1,6 +1,5 @@
 ﻿using Jamiras.Components;
 using RATools.Parser.Internal;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
+++ b/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
@@ -410,6 +410,13 @@ namespace RATools.Parser.Expressions.Trigger
             var modifiedMemoryAccessor = right as ModifiedMemoryAccessorExpression;
             if (modifiedMemoryAccessor != null)
             {
+                if (modifiedMemoryAccessor.ModifyingOperator == ModifyingOperator &&
+                    modifiedMemoryAccessor.Modifier == Modifier)
+                {
+                    // same modifier applied to both sides, eliminate it
+                    return new ComparisonExpression(MemoryAccessor.Clone(), operation, modifiedMemoryAccessor.MemoryAccessor.Clone());
+                }
+
                 var opposingOperator = MathematicExpression.GetOppositeOperation(GetMathematicOperation(modifiedMemoryAccessor.ModifyingOperator));
                 if (opposingOperator != MathematicOperation.Multiply && opposingOperator != MathematicOperation.Divide)
                     return null;

--- a/Source/Parser/Functions/MeasuredFunction.cs
+++ b/Source/Parser/Functions/MeasuredFunction.cs
@@ -69,5 +69,38 @@ namespace RATools.Parser.Functions
 
             return null;
         }
+
+        protected override ErrorExpression ModifyRequirements(AchievementBuilder builder)
+        {
+            bool seenLogicalJoin = false;
+            foreach (var requirement in builder.CoreRequirements)
+            {
+                switch (requirement.Type)
+                {
+                    case RequirementType.AndNext:
+                    case RequirementType.OrNext:
+                        seenLogicalJoin = true;
+                        break;
+
+                    case RequirementType.AddHits:
+                    case RequirementType.SubHits:
+                    case RequirementType.ResetNextIf:
+                        seenLogicalJoin = false;
+                        break;
+
+                    default:
+                        if (seenLogicalJoin && !requirement.IsCombining)
+                        {
+                            if (requirement.HitCount == 0 && requirement == builder.CoreRequirements.Last())
+                                return new ErrorExpression("measured comparison can only have one logical clause");
+                        }
+
+                        seenLogicalJoin = false;
+                        break;
+                }
+            }
+
+            return base.ModifyRequirements(builder);
+        }
     }
 }

--- a/Source/Parser/Functions/MeasuredFunction.cs
+++ b/Source/Parser/Functions/MeasuredFunction.cs
@@ -19,7 +19,8 @@ namespace RATools.Parser.Functions
 
         public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
-            var error = base.BuildTrigger(context, scope, functionCall);
+            var measuredScope = new InterpreterScope(scope) { Context = functionCall };
+            var error = base.BuildTrigger(context, measuredScope, functionCall);
             if (error != null)
                 return error;
 

--- a/Source/Parser/Functions/OnceFunction.cs
+++ b/Source/Parser/Functions/OnceFunction.cs
@@ -14,7 +14,7 @@ namespace RATools.Parser.Functions
         public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
         {
             var comparison = functionCall.Parameters.First();
-            return BuildTriggerConditions(context, scope, comparison, 1);
+            return BuildTriggerConditions(context, scope, comparison, new IntegerConstantExpression(1));
         }
     }
 }

--- a/Source/Parser/Functions/RepeatedFunction.cs
+++ b/Source/Parser/Functions/RepeatedFunction.cs
@@ -3,7 +3,6 @@ using RATools.Parser.Expressions;
 using RATools.Parser.Internal;
 using System.Collections.Generic;
 using System.Linq;
-using static System.Formats.Asn1.AsnWriter;
 
 namespace RATools.Parser.Functions
 {
@@ -180,7 +179,7 @@ namespace RATools.Parser.Functions
             return null;
         }
 
-        protected ErrorExpression EvaluateCondition(TriggerBuilderContext context, InterpreterScope scope, ConditionalExpression condition)
+        protected static ErrorExpression EvaluateCondition(TriggerBuilderContext context, InterpreterScope scope, ConditionalExpression condition)
         {
             ExpressionBase result;
 
@@ -345,6 +344,22 @@ namespace RATools.Parser.Functions
             }
 
             return true;
+        }
+
+        internal class OrNextWrapperFunction : RepeatedFunction
+        {
+            public OrNextWrapperFunction()
+                : base("__ornext")
+            {
+            }
+
+            public override ErrorExpression BuildTrigger(TriggerBuilderContext context, InterpreterScope scope, FunctionCallExpression functionCall)
+            {
+                var comparison = functionCall.Parameters.ElementAt(0);
+
+                // last requirement hit target will implicitly be left at 0
+                return BuildTriggerCondition(context, scope, comparison);
+            }
         }
     }
 }

--- a/Source/Parser/Functions/TallyFunction.cs
+++ b/Source/Parser/Functions/TallyFunction.cs
@@ -137,11 +137,7 @@ namespace RATools.Parser.Functions
 
             // set the target hitcount
             var count = (IntegerConstantExpression)functionCall.Parameters.First();
-            if (count.Value < 0)
-                return new ErrorExpression("count must be greater than or equal to zero", functionCall.Parameters.First());
-            context.LastRequirement.HitCount = (uint)count.Value;
-
-            return null;
+            return AssignHitCount(context, scope, count, Name.Name);
         }
     }
 

--- a/Source/Parser/ParameterInitializationContext.cs
+++ b/Source/Parser/ParameterInitializationContext.cs
@@ -1,0 +1,65 @@
+﻿using RATools.Parser.Expressions;
+using RATools.Parser.Internal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RATools.Parser
+{
+    internal class ParameterInitializationContext
+    {
+        public ParameterInitializationContext(FunctionDefinitionExpression function, IEnumerable<ExpressionBase> parameters)
+        {
+            Function = function;
+            Parameters = parameters;
+        }
+
+        public FunctionDefinitionExpression Function { get; private set; }
+
+        public IEnumerable<ExpressionBase> Parameters { get; private set; }
+
+        public ExpressionBase GetParameter(string name)
+        {
+            var namedParameter = Parameters.OfType<AssignmentExpression>().FirstOrDefault(p => p.Variable.Name == name);
+            if (namedParameter != null)
+                return namedParameter.Value;
+
+            var index = 0;
+            foreach (var parameter in Function.Parameters)
+            {
+                if (parameter.Name == name)
+                {
+                    var value = Parameters.ElementAtOrDefault(index);
+                    if (value != null && value.Type != ExpressionType.Assignment)
+                        return value;
+
+                    if (Function.DefaultParameters.TryGetValue(name, out value))
+                        return value;
+
+                    break;
+                }
+
+                index++;
+            }
+
+            return null;
+        }
+
+        public T GetParameter<T>(InterpreterScope scope, string name)
+            where T : ExpressionBase
+        {
+            var parameter = GetParameter(name);
+            if (parameter == null)
+                return null;
+
+            var parameterT = parameter as T;
+            if (parameterT == null)
+            {
+                ExpressionBase value;
+                if (parameter.ReplaceVariables(scope, out value))
+                    parameterT = value as T;
+            }
+
+            return parameterT;
+        }
+    }
+}

--- a/Source/Parser/ScriptInterpreterAchievementBuilder.cs
+++ b/Source/Parser/ScriptInterpreterAchievementBuilder.cs
@@ -70,7 +70,7 @@ namespace RATools.Parser
 
             // first turn the OR trees into flat lists -- (A || (B || (C || D))) -> A, B, C, D
             var flattenedClauses = new List<List<ExpressionBase>>();
-            var expansionSize = 1;
+            long expansionSize = 1;
             foreach (var clause in orConditions)
             {
                 var flattened = new List<ExpressionBase>();
@@ -197,9 +197,8 @@ namespace RATools.Parser
                     result = new ConditionalExpression(result, ConditionalOperation.Or, condition);
             }
 
-            result = new FunctionCallExpression("repeated", new ExpressionBase[]
+            result = new FunctionCallExpression("__ornext", new ExpressionBase[]
             {
-                new IntegerConstantExpression(0),
                 result
             });
 

--- a/Tests/Parser/Expressions/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Expressions/FunctionCallExpressionTests.cs
@@ -461,6 +461,26 @@ namespace RATools.Tests.Parser.Expressions
         }
 
         [Test]
+        public void TestEvaluateVariableShared()
+        {
+            // func2 should be called with the i value passed into func (6),
+            // not the one queued to be passed into func1 (4)
+            var function1Definition = Parse("function func1(i, j) { return i + j }");
+            var function2Definition = Parse("function func2(i) { return i - 1 }");
+            var functionDefinition = Parse("function func(i) { return func1(4, func2(i)) }");
+            var scope = new InterpreterScope();
+            scope.AddFunction(function1Definition);
+            scope.AddFunction(function2Definition);
+            scope.AddFunction(functionDefinition);
+            var value = new IntegerConstantExpression(6);
+            var functionCall = new FunctionCallExpression("func", new ExpressionBase[] { value });
+
+            ExpressionBase result;
+            Assert.That(functionCall.Evaluate(scope, out result), Is.True);
+            Assert.That(result, Is.EqualTo(new IntegerConstantExpression(9)));
+        }
+
+        [Test]
         public void TestEvaluateMathematical()
         {
             var functionDefinition = Parse("function func(i) { return i * 2 }");

--- a/Tests/Parser/Expressions/Trigger/MemoryAcessorExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/MemoryAcessorExpressionTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using RATools.Parser.Expressions;
 using RATools.Parser.Expressions.Trigger;
 using RATools.Parser.Internal;
 
@@ -134,6 +135,8 @@ namespace RATools.Tests.Parser.Expressions.Trigger
             ExpressionType.Comparison, "byte(0x001234) + 2 > byte(0x002345)")] // constant moved to left side
         [TestCase("byte(0x001234)", ">", "byte(0x002345) + 2",
             ExpressionType.Comparison, "byte(0x002345) + 2 < byte(0x001234)")] // prefer positive modifier, swap sides
+        [TestCase("300 - byte(0x001234)", ">=", "100",
+            ExpressionType.Comparison, "byte(0x001234) <= 200")] // constant moved to right, then whole thing inverted
         public void TestNormalizeComparison(string left, string operation, string right, ExpressionType expectedType, string expected)
         {
             ExpressionTests.AssertNormalizeComparison(left, operation, right, expectedType, expected);

--- a/Tests/Parser/Functions/MeasuredFunctionTests.cs
+++ b/Tests/Parser/Functions/MeasuredFunctionTests.cs
@@ -5,6 +5,7 @@ using RATools.Parser;
 using RATools.Parser.Expressions;
 using RATools.Parser.Functions;
 using RATools.Parser.Internal;
+using RATools.Tests.Parser.Expressions;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -126,6 +127,21 @@ namespace RATools.Tests.Parser.Functions
             Assert.That(requirements[1].Right.ToString(), Is.EqualTo("1"));
             Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.Measured));
             Assert.That(requirements[1].HitCount, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void TestSubtractedTarget()
+        {
+            var requirements = Evaluate("measured(300 - byte(0x1234) >= 100)");
+            Assert.That(requirements.Count, Is.EqualTo(2));
+            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
+            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.None));
+            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.SubSource));
+            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
+            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("300"));
+            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.GreaterThanOrEqual));
+            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("100"));
+            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.Measured));
         }
 
         [Test]

--- a/Tests/Parser/Functions/TallyFunctionTests.cs
+++ b/Tests/Parser/Functions/TallyFunctionTests.cs
@@ -159,19 +159,8 @@ namespace RATools.Tests.Parser.Functions
         [Test]
         public void TestZeroCount()
         {
-            // allow for infinite counting of some set of conditions - mostly for leaderboard values
-            var requirements = Evaluate("tally(0, byte(0x1234) == 56, byte(0x1234) == 67)");
-            Assert.That(requirements.Count, Is.EqualTo(2));
-            Assert.That(requirements[0].Left.ToString(), Is.EqualTo("byte(0x001234)"));
-            Assert.That(requirements[0].Operator, Is.EqualTo(RequirementOperator.Equal));
-            Assert.That(requirements[0].Right.ToString(), Is.EqualTo("56"));
-            Assert.That(requirements[0].Type, Is.EqualTo(RequirementType.AddHits));
-            Assert.That(requirements[0].HitCount, Is.EqualTo(0));
-            Assert.That(requirements[1].Left.ToString(), Is.EqualTo("byte(0x001234)"));
-            Assert.That(requirements[1].Operator, Is.EqualTo(RequirementOperator.Equal));
-            Assert.That(requirements[1].Right.ToString(), Is.EqualTo("67"));
-            Assert.That(requirements[1].Type, Is.EqualTo(RequirementType.None));
-            Assert.That(requirements[1].HitCount, Is.EqualTo(0));
+            Evaluate("tally(0, byte(0x1234) == 56, byte(0x1234) == 67)",
+                "Unbounded count is only supported in measured value expressions");
         }
 
         [Test]

--- a/Tests/Parser/Regression/RegressionTests.cs
+++ b/Tests/Parser/Regression/RegressionTests.cs
@@ -6,7 +6,6 @@ using RATools.Parser;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace RATools.Tests.Parser.Regression
 {
@@ -204,7 +203,18 @@ namespace RATools.Tests.Parser.Regression
                     var outputFileLine = outputFileTokenizer.ReadTo('\n').TrimRight();
 
                     if (expectedFileLine != outputFileLine)
-                        Assert.AreEqual(expectedFileLine.ToString(), outputFileLine.ToString(), "Line " + line);
+                    {
+                        var message = "Line " + line;
+
+                        if (line == 1)
+                        {
+                            // if the first line is not a version, it's an error, dump the entire error
+                            if (outputFileLine.Contains(':'))
+                                message += "\n" + outputFileContents;
+                        }
+
+                        Assert.AreEqual(expectedFileLine.ToString(), outputFileLine.ToString(), message);
+                    }
 
                     expectedFileTokenizer.Advance();
                     outputFileTokenizer.Advance();

--- a/Tests/Parser/TriggerBuilderContextTests.cs
+++ b/Tests/Parser/TriggerBuilderContextTests.cs
@@ -85,7 +85,6 @@ namespace RATools.Tests.Parser
         [TestCase("measured(byte(0x1234 + byte(0x2345)) / 2)", "I:0xH002345_M:0xH001234/2")]
         [TestCase("measured(byte(0x1234) != prev(byte(0x1234)))", "M:0xH001234!=d0xH001234")]
         [TestCase("measured(byte(0x1234) != prev(byte(0x1234))) && never(byte(0x2345) == 1)", "M:0xH001234!=d0xH001234_R:0xH002345=1")]
-        [TestCase("tally(0, byte(0x1234) != prev(byte(0x1234))) && never(byte(0x2345) == 1)", "M:0xH001234!=d0xH001234_R:0xH002345=1")]
         [TestCase("tally(20, byte(0x1234) != prev(byte(0x1234))) && never(byte(0x2345) == 1)", "M:0xH001234!=d0xH001234.20._R:0xH002345=1")]
         [TestCase("byte(byte(0x1234) - 10)", "I:0xH001234_M:0xHfffffff6")]
         [TestCase("measured(repeated(10, byte(0x2345 + word(0x1234) * 4) == 6)))", "I:0x 001234*4_M:0xH002345=6.10.")]


### PR DESCRIPTION
Prevents converting `measured(A + 20 < 80)` to `measured(A < 60)`, which ensures that the reported measured progress in the app still reports "(X/80)". The optimization is still allowed for `measured(A + 20 < 80, format="percent")`. as the value is not being reported directly to the user.

**NOTE:** As part of this change, `repeated(0, X)` and `tally(0, X, Y)` are no longer supported outside of measured value expressions (i.e. leaderboard values or rich presence values). Previously, those constructs could be used to trick the optimizer into ignoring an OrNext/AndNext chain giving the author more control over the resulting syntax. This was not intended. When a script says `trigger = repeated(0, X)`, it's implying that the trigger should only fire if X has never been true. That construct is better represented with `trigger = disable_when(X)`. There should never be a reason to trick the optimizer into ignoring an AndNext chain. If you think of one, let me know. Some people try to trick the optimizer into ignoring an OrNext chain to prevent converting it alt groups. This isn't necessary, and normally isn't desirable. For those people who absolutely must do it, I've added an `__ornext(condition)` undocumented internal function. I plan to revisit the OrNext->alt groups logic some again soon. OrNext has been around long enough that it should no longer be preferential to have alt groups.