### PR TITLE
support for ResetNextIf in tally

### DIFF
--- a/Source/Data/Requirement.cs
+++ b/Source/Data/Requirement.cs
@@ -226,17 +226,28 @@ namespace RATools.Data
         {
             if (HitCount == 0 && addHits == null)
             {
+                bool wrapInParenthesis = false;
+
                 if (!string.IsNullOrEmpty(andNext) && andNext[0] != '(' &&
                     (andNext.Contains(" && ") || andNext.Contains(" || ")))
                 {
+                    wrapInParenthesis = true;
+                }
+
+                if (wrapInParenthesis)
                     builder.Append('(');
-                    AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress);
-                    builder.Append(')');
-                }
-                else
+
+                AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress);
+
+                if (resetNextIf != null)
                 {
-                    AppendCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress);
+                    builder.Append(" && never(");
+                    builder.Append(RemoveOuterParentheses(resetNextIf));
+                    builder.Append(")");
                 }
+
+                if (wrapInParenthesis)
+                    builder.Append(')');
             }
             else
             {

--- a/Source/Parser/Functions/ComparisonModificationFunction.cs
+++ b/Source/Parser/Functions/ComparisonModificationFunction.cs
@@ -18,7 +18,7 @@ namespace RATools.Parser.Functions
             return BuildTriggerCondition(context, scope, comparison);
         }
 
-        protected ErrorExpression BuildTriggerCondition(TriggerBuilderContext context, InterpreterScope scope, ExpressionBase condition)
+        protected ErrorExpression BuildTriggerCondition(TriggerBuilderContext context, InterpreterScope scope, ExpressionBase condition, bool optimize = false)
         { 
             var builder = new ScriptInterpreterAchievementBuilder();
             ExpressionBase result;
@@ -35,6 +35,13 @@ namespace RATools.Parser.Functions
                         // non-allowed construct
                         return new ErrorExpression("comparison did not evaluate to a valid comparison", condition) { InnerError = (ErrorExpression)result };
                 }
+            }
+
+            if (optimize)
+            {
+                var message = builder.OptimizeForSubClause();
+                if (message != null)
+                    return new ErrorExpression(message, condition);
             }
 
             var error = builder.CollapseForSubClause();

--- a/Source/Parser/Functions/TallyFunction.cs
+++ b/Source/Parser/Functions/TallyFunction.cs
@@ -104,7 +104,13 @@ namespace RATools.Parser.Functions
                 }
 
                 if (error == null)
-                    error = BuildTriggerCondition(nestedContext, scope, condition);
+                {
+                    // define a new scope with a nested context to prevent TriggerBuilderContext.ProcessAchievementConditions
+                    // from optimizing out the ResetIf
+                    var innerScope = new InterpreterScope(scope);
+                    innerScope.Context = nestedContext;
+                    error = BuildTriggerCondition(nestedContext, innerScope, condition, true);
+                }
                 if (error != null)
                     return error;
 

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -1180,5 +1180,36 @@ namespace RATools.Tests.Parser
             }
             Assert.That(seen, Is.True);
         }
+
+        [Test]
+        public void TestTallyNeverComplex()
+        {
+            var parser = Parse(
+                "achievement(\"T\", \"D\", 5,\n" +
+                "  tally(8, byte(0x1234) == 1 && never(byte(0x2345) == 2 && byte(0x3456) == 3))\n"+
+                ")");
+
+            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
+
+            var achievement = parser.Achievements.First();
+            Assert.That(GetRequirements(achievement), Is.EqualTo("never((byte(0x002345) == 2 && byte(0x003456) == 3)) && repeated(8, byte(0x001234) == 1)"));
+        }
+
+        [Test]
+        public void TestTallyMultipleNeverComplex()
+        {
+            var parser = Parse(
+                "achievement(\"T\", \"D\", 5,\n" +
+                "  tally(8,\n" +
+                "    byte(0x1234) == 1 && never(byte(0x2345) == 2 && byte(0x3456) == 3),\n" +
+                "    byte(0x1234) == 2 && never(byte(0x2345) == 3 && byte(0x3456) == 4)\n" +
+                "  )\n" +
+                ")");
+
+            Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
+
+            var achievement = parser.Achievements.First();
+            Assert.That(GetRequirements(achievement), Is.EqualTo("tally(8, byte(0x001234) == 1 && never(byte(0x002345) == 2 && byte(0x003456) == 3), byte(0x001234) == 2 && never(byte(0x002345) == 3 && byte(0x003456) == 4))"));
+        }
     }
 }

--- a/Tests/Parser/Functions/LeaderboardFunctionTests.cs
+++ b/Tests/Parser/Functions/LeaderboardFunctionTests.cs
@@ -165,7 +165,7 @@ namespace RATools.Tests.Parser.Functions
             var leaderboard = Evaluate("leaderboard(\"T\", \"D\", " +
                 "byte(0x1234) == 1, byte(0x1234) == 2, byte(0x1234) == 3, " +
                 "measured(byte(0x1234), when=repeated(10, byte(0x2345) == 10) && never(byte(0x2345) == 20)))");
-            Assert.That(leaderboard.Value, Is.EqualTo("M:0xH001234_Q:0xH002345=10.10._R:0xH002345=20"));
+            Assert.That(leaderboard.Value, Is.EqualTo("M:0xH001234_Z:0xH002345=20_Q:0xH002345=10.10."));
 
             // never outside measured
             leaderboard = Evaluate("leaderboard(\"T\", \"D\", " +


### PR DESCRIPTION
Fixes an issue where a `never` within a `tally` would lose the ResetNextIf.

```
tally(8, byte(0x1234) != prev(byte(0x1234)) && never(byte(0x2345) == 2)
```
Would generate
```
AndNext byte 0x2345 != 2
        byte 0x1234 != delta byte 0x1234 (8)
```
Instead of
```
ResetNextIf byte 0x2345 == 2
            byte 0x1234 != delta byte 0x1234 (8)
```

Reported here: https://discord.com/channels/310192285306454017/936655398725902356/1015723213457731704

#204 added ResetNextIf support to `repeated`, but it was never added to `tally`.
