### PR TITLE
add game progression dialog

### DIFF
--- a/Source/RATools.csproj
+++ b/Source/RATools.csproj
@@ -43,4 +43,10 @@
     <Resource Include="Resources\script.png" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Page Update="Views\GameProgressionDialog.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+  </ItemGroup>
+
 </Project>

--- a/Source/ViewModels/GameProgressionViewModel.cs
+++ b/Source/ViewModels/GameProgressionViewModel.cs
@@ -1,0 +1,70 @@
+﻿using Jamiras.Commands;
+using Jamiras.Components;
+using Jamiras.Services;
+using Jamiras.ViewModels;
+using Jamiras.ViewModels.Fields;
+using RATools.Data;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace RATools.ViewModels
+{
+    public class GameProgressionViewModel : DialogViewModelBase
+    {
+        public GameProgressionViewModel(List<AchievementInfo> progressionStats)
+        { 
+            Progress = new ProgressFieldViewModel { Label = String.Empty };
+            DialogTitle = "Game Progression";
+            CanClose = true;
+
+            Achievements = progressionStats;
+
+            ShowAchievementCommand = new DelegateCommand<AchievementInfo>(ShowAchievement);
+        }
+
+        public ProgressFieldViewModel Progress { get; private set; }
+
+        [DebuggerDisplay("{Distance} {Title}")]
+        public class AchievementInfo
+        {
+            public int Id { get; set; }
+            public string Title { get; set; }
+
+            public TimeSpan Distance { get; set; }
+
+            public TimeSpan TotalDistance { get; set; }
+            public int TotalDistanceCount { get; set; }
+
+            public string FormattedDistance
+            {
+                get
+                {
+                    var builder = new StringBuilder();
+
+                    int totalMinutes = (int)Distance.TotalMinutes;
+                    if (totalMinutes < 0)
+                    {
+                        builder.Append('-');
+                        totalMinutes = -totalMinutes;
+                    }
+
+                    builder.AppendFormat("{0}h{1:D2}m", totalMinutes / 60, totalMinutes % 60);
+
+                    return builder.ToString();
+                }
+            }
+        }
+
+        public List<AchievementInfo> Achievements { get; private set; }
+
+        public DelegateCommand<AchievementInfo> ShowAchievementCommand { get; private set; }
+
+        private static void ShowAchievement(AchievementInfo info)
+        {
+            var url = "https://retroachievements.org/achievement/" + info.Id;
+            ServiceRepository.Instance.FindService<IBrowserService>().OpenUrl(url);
+        }
+    }
+}

--- a/Source/ViewModels/UserMasteriesViewModel.cs
+++ b/Source/ViewModels/UserMasteriesViewModel.cs
@@ -193,7 +193,7 @@ namespace RATools.ViewModels
                     {
                         var achievement = gameStats.Achievements.FirstOrDefault(a => a.Id == id);
                         return (achievement != null) ? achievement.Points : 0;
-                    });
+                    }, null);
 
                     if (user.PointsEarned == gameStats.TotalPoints)
                     {

--- a/Source/Views/GameProgressionDialog.xaml
+++ b/Source/Views/GameProgressionDialog.xaml
@@ -1,0 +1,59 @@
+﻿<UserControl x:Class="RATools.Views.GameProgressionDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:jamiras="clr-namespace:Jamiras.Controls;assembly=Jamiras.UI.WPF"
+             mc:Ignorable="d" 
+             Width="416" Height="520">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Jamiras.UI.WPF;component/Controls/Styles/ProgressOverlay.xaml" />
+                <ResourceDictionary Source="/Jamiras.UI.WPF;component/Controls/Styles/FieldStyles.xaml" />
+                <ResourceDictionary Source="/Jamiras.UI.WPF;component/Controls/Styles/SubtleHyperlink.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid Margin="4">
+        <ListView ItemsSource="{Binding Achievements}" jamiras:GridViewSort.IsEnabled="True">
+            <ListView.Resources>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                </Style>
+            </ListView.Resources>
+            <ListView.View>
+                <GridView>
+                    <GridViewColumn Header="User" Width="240">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock>
+                                    <Hyperlink Style="{StaticResource subtleHyperlink}"
+                                               Command="{Binding DataContext.ShowAchievementCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListView}}}" CommandParameter="{Binding}">
+                                        <TextBlock Text="{Binding Title}" />
+                                    </Hyperlink>
+                                </TextBlock>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                    <GridViewColumn Header="Distance" Width="80">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding FormattedDistance}" TextAlignment="Right" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                    <GridViewColumn Header="Count" Width="60">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding TotalDistanceCount}" TextAlignment="Right" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                </GridView>
+            </ListView.View>
+        </ListView>
+
+        <ContentPresenter Grid.RowSpan="3" Grid.ColumnSpan="4" Margin="-4" Content="{Binding Progress}" />
+    </Grid>
+</UserControl>

--- a/Source/Views/GameProgressionDialog.xaml.cs
+++ b/Source/Views/GameProgressionDialog.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Controls;
+
+namespace RATools.Views
+{
+    /// <summary>
+    /// Interaction logic for GameProgressionDialog.xaml
+    /// </summary>
+    public partial class GameProgressionDialog : UserControl
+    {
+        public GameProgressionDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Source/Views/GameStatsDialog.xaml
+++ b/Source/Views/GameStatsDialog.xaml
@@ -71,6 +71,17 @@
             <TextBlock Text="Game ID" />
             <TextBox Text="{Binding GameId}" />
             <Button Command="{Binding SearchCommand}" Content="Search" Margin="64,4,0,4" />
+            <Button Command="{Binding DetailedProgressCommand}" Content="Progression" Margin="64,24,0,4">
+                <Button.Style>
+                    <Style TargetType="{x:Type Button}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding NumberOfPlayers}" Value="0">
+                                <Setter Property="IsEnabled" Value="False" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </Button>
         </StackPanel>
         
         <TextBlock Grid.Row="7" VerticalAlignment="Bottom" Text="Top Hardcore Users" />

--- a/Source/Views/MainWindow.xaml.cs
+++ b/Source/Views/MainWindow.xaml.cs
@@ -56,6 +56,7 @@ namespace RATools.Views
             dialogService.RegisterDialogHandler(typeof(UpdateLocalViewModel), vm => new OkCancelView(new UpdateLocalDialog()));
             dialogService.RegisterDialogHandler(typeof(GameStatsViewModel), vm => new GameStatsDialog());
             dialogService.RegisterDialogHandler(typeof(GameStatsViewModel.UserHistoryViewModel), vm => new UserHistoryDialog());
+            dialogService.RegisterDialogHandler(typeof(GameProgressionViewModel), vm => new GameProgressionDialog());
             dialogService.RegisterDialogHandler(typeof(OpenTicketsViewModel), vm => new OpenTicketsDialog());
             dialogService.RegisterDialogHandler(typeof(AboutDialogViewModel), vm => new OkCancelView(new AboutDialog()));
             dialogService.RegisterDialogHandler(typeof(ConditionsAnalyzerViewModel), vm => new ConditionsAnalyzerDialog());


### PR DESCRIPTION
Provides a breakdown of rough estimates for playtime required to reach each achievement in a set.

![image](https://user-images.githubusercontent.com/32680403/190025428-3f870799-c0f2-4806-ada2-e666ed743be6.png)

Times are estimated for each user using the same logic as mastery calculations (achievements more than four hours apart are considered to be in separate sessions and an adjustment is applied to each session to simulate time spent playing before earning the first achievement in the session or after earning the last). These individual estimates are averaged for each achievement, then the list is sorted by the average.

This functionality leverages the data retrieved for the game mastery times, so it can be accessed as a sub-dialog off the Game Mastery dialog.