### PR TITLE
don't restrict float comparisons to integer ranges

### DIFF
--- a/Source/Parser/AchievementBuilder.cs
+++ b/Source/Parser/AchievementBuilder.cs
@@ -812,6 +812,10 @@ namespace RATools.Parser
                 requirement.Operator = Requirement.GetReversedRequirementOperator(requirement.Operator);
             }
 
+            // comparing float to integer - integer will be cast to float, so don't enforce integer limits
+            if (requirement.Left.IsFloat)
+                return null;
+
             if (requirement.Right.Value == 0)
             {
                 switch (requirement.Operator)

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -437,6 +437,8 @@ namespace RATools.Tests.Parser
         [TestCase("once(byte(0x001234) == 1) && never(once(bit2(0x1234) == 255))", "once(byte(0x001234) == 1)")] // condition becomes always_false(), and never(always_false()) can be eliminated
         [TestCase("byte(0x001234) == 1 && never(byte(0x2345) > 0x2345)", "byte(0x001234) == 1")] // condition becomes always_false(), and never(always_false()) can be eliminated
         [TestCase("byte(0x001234) == 1 && unless(once(byte(0x2345) == 0x2345))", "byte(0x001234) == 1")] // condition becomes always_false(), and unless(always_false()) can be eliminated
+        [TestCase("float(0x001234) < 0.0", "float(0x001234) < 0.0")]
+        [TestCase("float(0x001234) < 0", "float(0x001234) < 0")]
         public void TestOptimizeNormalizeComparisons(string input, string expected)
         {
             var achievement = CreateAchievement(input);

--- a/Tests/Parser/Expressions/Trigger/RequirementClauseExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementClauseExpression_Tests.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using RATools.Parser.Expressions;
 using RATools.Parser.Expressions.Trigger;
 using RATools.Parser.Internal;
 
@@ -32,6 +31,10 @@ namespace RATools.Tests.Parser.Expressions.Trigger
         [TestCase("byte(0x001234) * byte(0x002345) == 3", "A:0xH001234*0xH002345_0=3")]
         [TestCase("byte(0x001234) / byte(0x002345) == 3", "A:0xH001234/0xH002345_0=3")]
         [TestCase("byte(0x001234) & 7 == 3", "A:0xH001234&7_0=3")]
+        [TestCase("float(0x001234) == 3.14", "fF001234=f3.14")]
+        [TestCase("float(0x001234) > 2.0", "fF001234>f2.0")]
+        [TestCase("float(0x001234) != 2", "fF001234!=2")]
+        [TestCase("float(0x001234) < 0", "fF001234<0")]
         public void TestBuildTrigger(string input, string expected)
         {
             var clause = TriggerExpressionTests.Parse<RequirementClauseExpression>(input);


### PR DESCRIPTION
Prevent `float(0x1234) < 0` from being converted to `always_false()`. The optimizer assumed that all memory reads were unsigned. Floating point memory reads may be signed, so the value can logically be less than 0. Using `float(0x1234) < 0.0` is a valid workaround.

https://discord.com/channels/310192285306454017/936655398725902356/1019710133800022066