### PR TITLE
simplify nested AND containing elements in parent AND condition

### DIFF
--- a/Tests/Parser/Expressions/Trigger/MemoryValueExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/MemoryValueExpressionTests.cs
@@ -143,6 +143,8 @@ namespace RATools.Tests.Parser.Expressions.Trigger
             ExpressionType.None, null)] // no change necessary
         [TestCase("0 + byte(0x001234) - 9", "=", "0",
             ExpressionType.Comparison, "byte(0x001234) == 9")]
+        [TestCase("byte(tbyte(0x001234) + 1) + byte(tbyte(0x001234) + 2) - 7", ">=", "byte(tbyte(0x001234) + 3)",
+            ExpressionType.Comparison, "byte(tbyte(0x001234) + 1) + byte(tbyte(0x001234) + 2) - 7 >= byte(tbyte(0x001234) + 3)")]
         public void TestNormalizeComparison(string left, string operation, string right, ExpressionType expectedType, string expected)
         {
             ExpressionTests.AssertNormalizeComparison(left, operation, right, expectedType, expected);


### PR DESCRIPTION
prevents "combination of &&s and ||s is too complex for subclause" error if subclause is redundant with parent.

i.e.

```
once(A && B && (C || (A && B && D) || E))
```
The `A && B` can be removed from `A && B && D`, leaving `once(A && B && (C || D || E))`, which can be properly processed.