### PR TITLE
fix intersection of float comparisons

### DIFF
--- a/Source/Parser/AchievementBuilder.cs
+++ b/Source/Parser/AchievementBuilder.cs
@@ -388,9 +388,9 @@ namespace RATools.Parser
                         break;
 
                     case RequirementType.MeasuredPercent:
-                        // 0.80 TBD
-                        if (minVer < 0.80)
-                            minVer = 0.80;
+                        // 1.0 29 Jan 2022
+                        if (minVer < 1.0)
+                            minVer = 1.0;
                         break;
 
                     default:
@@ -447,9 +447,9 @@ namespace RATools.Parser
                         case FieldSize.BigEndianDWord:
                         case FieldSize.Float:
                         case FieldSize.MBF32:
-                            // 0.80 TBD
-                            if (minVer < 0.80)
-                                minVer = 0.80;
+                            // 1.0 29 Jan 2022
+                            if (minVer < 1.0)
+                                minVer = 1.0;
                             break;
 
                         default:

--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -403,7 +403,7 @@ namespace RATools.Parser
             }
 
             _richPresence.DisableLookupCollapsing = (minimumVersion < 0.79);
-            _richPresence.DisableBuiltInMacros = (minimumVersion < 0.80);
+            _richPresence.DisableBuiltInMacros = (minimumVersion < 1.0);
 
             if (!String.IsNullOrEmpty(_richPresence.DisplayString))
             {

--- a/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
@@ -1,5 +1,7 @@
 ﻿using RATools.Data;
 using RATools.Parser.Internal;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -508,8 +510,21 @@ namespace RATools.Parser.Expressions.Trigger
 
             var leftCondition = ConvertToRequirementOperator(Comparison);
             var rightCondition = ConvertToRequirementOperator(thatCondition.Comparison);
-            var merged = RequirementMerger.MergeComparisons(
-                leftCondition, leftField.Value, rightCondition, rightField.Value, condition);
+
+            KeyValuePair<RequirementOperator, IComparable> merged;
+
+            if (leftField.Type != FieldType.Float && rightField.Type != FieldType.Float)
+            {
+                merged = RequirementMerger.MergeComparisons(
+                    leftCondition, leftField.Value, rightCondition, rightField.Value, condition);
+            }
+            else
+            {
+                var leftFloat = (leftField.Type == FieldType.Float) ? leftField.Float : (float)leftField.Value;
+                var rightFloat = (rightField.Type == FieldType.Float) ? rightField.Float : (float)rightField.Value;
+                merged = RequirementMerger.MergeComparisons(
+                    leftCondition, leftFloat, rightCondition, rightFloat, condition);
+            }
 
             if (merged.Key != RequirementOperator.None)
             {
@@ -528,7 +543,11 @@ namespace RATools.Parser.Expressions.Trigger
                 switch (leftField.Type)
                 {
                     case FieldType.Value:
-                        result.Right = new IntegerConstantExpression((int)merged.Value);
+                        result.Right = new IntegerConstantExpression((int)(uint)merged.Value);
+                        break;
+
+                    case FieldType.Float:
+                        result.Right = new FloatConstantExpression((float)merged.Value);
                         break;
 
                     default:

--- a/Tests/Parser/Expressions/Trigger/RequirementClauseExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementClauseExpression_Tests.cs
@@ -140,6 +140,9 @@ namespace RATools.Tests.Parser.Expressions.Trigger
         [TestCase("A == 1 && B == 1", "A == 1 && C == 1", ConditionalOperation.Or, "A == 1 && (B == 1 || C == 1)")]
         [TestCase("A == 1 && B == 1", "A > 1", ConditionalOperation.Or, null)]
         [TestCase("A > 1", "A == 1 && B == 1", ConditionalOperation.Or, null)]
+        [TestCase("float(0x1234) > 1.0", "float(0x1234) > 2.0", ConditionalOperation.And, "float(0x001234) > 2.0")]
+        [TestCase("float(0x1234) > 1.0", "float(0x1234) < 2.0", ConditionalOperation.And, null)]
+        [TestCase("float(0x1234) > 1.0", "float(0x1234) < -4.0", ConditionalOperation.And, "always_false()")]
         public void TestLogicalIntersect(string left, string right, ConditionalOperation op, string expected)
         {
             TriggerExpressionTests.AssertLogicalIntersect(left, right, op, expected);

--- a/Tests/Parser/Regression/RegressionTests.cs
+++ b/Tests/Parser/Regression/RegressionTests.cs
@@ -174,7 +174,7 @@ namespace RATools.Tests.Parser.Regression
                             fileWriter.WriteLine("=== Rich Presence ===");
 
                             var minimumVersion = Double.Parse(localAchievements.Version, System.Globalization.NumberFormatInfo.InvariantInfo);
-                            if (minimumVersion < 0.80)
+                            if (minimumVersion < 1.0)
                             {
                                 interpreter.RichPresenceBuilder.DisableBuiltInMacros = true;
 


### PR DESCRIPTION
fixes `x > 5.0 && x < 7.2` incorrectly being turned into `always_false()`