### PR TITLE
ensure notes with newlines but no quotes are properly escaped

### DIFF
--- a/Source/Parser/LocalAssets.cs
+++ b/Source/Parser/LocalAssets.cs
@@ -474,7 +474,7 @@ namespace RATools.Parser
 
         private static void WriteEscaped(StreamWriter writer, string str)
         {
-            if (str.IndexOf('"') == -1 && str.IndexOf('\\') == -1)
+            if (str.IndexOfAny(new char[] { '"', '\\', '\n', '\r', '\t' }) == -1)
             {
                 writer.Write(str);
                 return;


### PR DESCRIPTION
prevents "corruption" of notes containing newlines without quotes