### PR TITLE
fix for loop retaining error after correction

### DIFF
--- a/Source/Parser/Expressions/ForExpression.cs
+++ b/Source/Parser/Expressions/ForExpression.cs
@@ -77,7 +77,13 @@ namespace RATools.Parser.Expressions
 
             var error = ParseStatementBlock(tokenizer, loop.Expressions);
             if (error != null)
-                return error;
+            {
+                var expressionTokenizer = tokenizer as ExpressionTokenizer;
+                if (expressionTokenizer == null)
+                    return error;
+
+                expressionTokenizer.AddError((ErrorExpression)error);
+            }
 
             loop._keywordFor = keywordFor;
             loop._keywordIn = keywordIn;

--- a/Source/Parser/Internal/ExpressionTokenizer.cs
+++ b/Source/Parser/Internal/ExpressionTokenizer.cs
@@ -1,6 +1,7 @@
 ﻿using Jamiras.Components;
 using RATools.Parser.Expressions;
 using System.Diagnostics;
+using System.Linq;
 
 namespace RATools.Parser.Internal
 {
@@ -26,7 +27,8 @@ namespace RATools.Parser.Internal
 
         public void AddError(ErrorExpression error)
         {
-            _expressionGroup.AddParseError(error);
+            if (!_expressionGroup.ParseErrors.Contains(error))
+                _expressionGroup.AddParseError(error);
         }
 
         public void AdvanceToLine(int line)


### PR DESCRIPTION
given a script:
```
a = 0
for b in range(0,5) {
    a = a + 1
}
```
if a comma was injected into the middle statement:
```
a = 0
for b in range(0,5) {
    a = a, + 1
}
```
the editor would report several errors:
* unexpected character: ,
* unexpected character: +
* unexpected character: }

When the comma was removed, only the errors on the modified line would be corrected, leaving the third error. Additionally, the `for` line would lose its syntax highlighting.

This fixes both of the above errors by retaining the expressions for the `for` statement through the error state and resolution.