### PR TITLE
add substring() function

### DIFF
--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -133,6 +133,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new RangeFunction());
                 _globalScope.AddFunction(new FormatFunction());
                 _globalScope.AddFunction(new LengthFunction());
+                _globalScope.AddFunction(new SubstringFunction());
                 _globalScope.AddFunction(new ArrayPushFunction());
                 _globalScope.AddFunction(new ArrayPopFunction());
                 _globalScope.AddFunction(new ArrayMapFunction());

--- a/Source/Parser/Functions/SubstringFunction.cs
+++ b/Source/Parser/Functions/SubstringFunction.cs
@@ -1,0 +1,52 @@
+﻿using RATools.Parser.Expressions;
+using RATools.Parser.Internal;
+using System;
+
+namespace RATools.Parser.Functions
+{
+    internal class SubstringFunction : FunctionDefinitionExpression
+    {
+        public SubstringFunction()
+            : base("substring")
+        {
+            Parameters.Add(new VariableDefinitionExpression("string"));
+            Parameters.Add(new VariableDefinitionExpression("offset"));
+            Parameters.Add(new VariableDefinitionExpression("length"));
+
+            DefaultParameters["length"] = new IntegerConstantExpression(int.MaxValue);
+        }
+
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            return Evaluate(scope, out result);
+        }
+
+        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        {
+            var stringExpression = GetStringParameter(scope, "string", out result);
+            if (stringExpression == null)
+                return false;
+
+            var offset = GetIntegerParameter(scope, "offset", out result);
+            if (offset == null)
+                return false;
+
+            var length = GetIntegerParameter(scope, "length", out result);
+            if (length == null)
+                return false;
+
+            var str = stringExpression.Value;
+            var start = (offset.Value < 0) ? str.Length + offset.Value : offset.Value;
+            var end = (length.Value == int.MaxValue) ? str.Length :
+                Math.Min(str.Length, ((length.Value < 0) ? str.Length : start) + length.Value);
+            start = Math.Max(0, start);
+
+            if (start > str.Length || end <= start)
+                result = new StringConstantExpression("");
+            else
+                result = new StringConstantExpression(str.Substring(start, end - start));
+
+            return true;
+        }
+    }
+}

--- a/Tests/Parser/Functions/SubstringFunctionTests.cs
+++ b/Tests/Parser/Functions/SubstringFunctionTests.cs
@@ -1,0 +1,67 @@
+﻿using NUnit.Framework;
+using RATools.Parser.Expressions;
+using RATools.Parser.Functions;
+using RATools.Parser.Internal;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RATools.Tests.Parser.Functions
+{
+    [TestFixture]
+    class SubstringFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new SubstringFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("substring"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(3));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("string"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("offset"));
+            Assert.That(def.Parameters.ElementAt(2).Name, Is.EqualTo("length"));
+
+            Assert.That(def.DefaultParameters.Count, Is.EqualTo(1));
+            Assert.That(def.DefaultParameters.ElementAt(0).Key, Is.EqualTo("length"));
+            Assert.That(def.DefaultParameters.ElementAt(0).Value, Is.InstanceOf<IntegerConstantExpression>());
+            Assert.That(((IntegerConstantExpression)def.DefaultParameters.ElementAt(0).Value).Value, Is.EqualTo(int.MaxValue));
+        }
+
+        [Test]
+        [TestCase("abcdef", 0, 6, "abcdef")]
+        [TestCase("abcdef", 0, 5, "abcde")]
+        [TestCase("abcdef", 0, -1, "abcde")]
+        [TestCase("abcdef", 0, -2, "abcd")]
+        [TestCase("abcdef", 1, 5, "bcdef")]
+        [TestCase("abcdef", 1, -1, "bcde")]
+        [TestCase("abcdef", 1, -2, "bcd")]
+        [TestCase("abcdef", 3, 1, "d")]
+        [TestCase("abcdef", 3, 0, "")]
+        [TestCase("abcdef", 3, -1, "de")] // from fourth character ignoring last character
+        [TestCase("abcdef", 3, -2, "d")]
+        [TestCase("abcdef", 3, -3, "")]
+        [TestCase("abcdef", 3, -4, "")]
+        [TestCase("abcdef", -3, 1, "d")] // one character starting three from the end
+        [TestCase("abcdef", -3, -2, "d")] // from three from the end ignoring the last two
+        [TestCase("abcdef", -8, 4, "ab")] // four characters starting at -2
+        [TestCase("abcdef", -8, 1, "")] // one character starting at -2
+        [TestCase("abcdef", 0, int.MaxValue, "abcdef")] // simulate default parameter
+        [TestCase("abcdef", 3, int.MaxValue, "def")] // simulate default parameter
+        public void TestEvaluate(string input, int offset, int length, string expected)
+        {
+            var parameters = new List<ExpressionBase>();
+            parameters.Add(new StringConstantExpression(input));
+            parameters.Add(new IntegerConstantExpression(offset));
+            parameters.Add(new IntegerConstantExpression(length));
+
+            var expression = new FunctionCallExpression("substring", parameters);
+            var scope = new InterpreterScope();
+            scope.AddFunction(new SubstringFunction());
+
+            ExpressionBase result;
+            Assert.IsTrue(expression.Evaluate(scope, out result));
+
+            Assert.IsTrue(result is StringConstantExpression);
+            Assert.That(((StringConstantExpression)result).Value, Is.EqualTo(expected));
+        }
+    }
+}


### PR DESCRIPTION
as suggested in #345 (under 'splitting' header).

inputs:
* `string` - the string to be split
* `offset` - the 0-based index to start copying from
* `length` - the number of characters to capture (optional - if not specified, the remaining portion of the string will be captured)

`offset` may be a negative number, in which case copying will start from that many characters from the end of the string.
`length` may be a negative number, in which case copying will stop that many characters from the end of the string.

if any combination of `offset` and `length` creates an invalid selection, an empty string will be returned.

examples:
`substring("abcdef", 3)` => `"def"`
`substring("abcdef", 0, 3)` => `"abc"`
`substring("abcdef", 2, 2)` => `"cd"`
`substring("abcdef", 2, -1)` => `"cde"`
`substring("abcdef", -2, 1)` => `"e"`
