### PR TITLE
add ascii_string_equals() and unicode_string_equals() functions

### DIFF
--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -134,6 +134,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new FormatFunction());
                 _globalScope.AddFunction(new LengthFunction());
                 _globalScope.AddFunction(new SubstringFunction());
+                _globalScope.AddFunction(new AsciiStringEqualsFunction());
                 _globalScope.AddFunction(new ArrayPushFunction());
                 _globalScope.AddFunction(new ArrayPopFunction());
                 _globalScope.AddFunction(new ArrayMapFunction());

--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -135,6 +135,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new LengthFunction());
                 _globalScope.AddFunction(new SubstringFunction());
                 _globalScope.AddFunction(new AsciiStringEqualsFunction());
+                _globalScope.AddFunction(new UnicodeStringEqualsFunction());
                 _globalScope.AddFunction(new ArrayPushFunction());
                 _globalScope.AddFunction(new ArrayPopFunction());
                 _globalScope.AddFunction(new ArrayMapFunction());

--- a/Source/Parser/Functions/AsciiStringEqualsFunction.cs
+++ b/Source/Parser/Functions/AsciiStringEqualsFunction.cs
@@ -1,0 +1,125 @@
+﻿using RATools.Data;
+using RATools.Parser.Expressions;
+using RATools.Parser.Expressions.Trigger;
+using RATools.Parser.Internal;
+using System;
+
+namespace RATools.Parser.Functions
+{
+    internal class AsciiStringEqualsFunction : FunctionDefinitionExpression
+    {
+        public AsciiStringEqualsFunction()
+            : base("ascii_string_equals")
+        {
+            Parameters.Add(new VariableDefinitionExpression("address"));
+            Parameters.Add(new VariableDefinitionExpression("string"));
+            Parameters.Add(new VariableDefinitionExpression("length"));
+
+            DefaultParameters["length"] = new IntegerConstantExpression(int.MaxValue);
+        }
+
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            return Evaluate(scope, out result);
+        }
+
+        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        {
+            var address = GetMemoryAddressParameter(scope, "address", out result);
+            if (address == null)
+                return false;
+
+            var stringExpression = GetStringParameter(scope, "string", out result);
+            if (stringExpression == null)
+                return false;
+
+            var length = GetIntegerParameter(scope, "length", out result);
+            if (length == null)
+                return false;
+
+            if (length.Value <= 0)
+            {
+                result = new ErrorExpression("length must be greater than 0", length);
+                return false;
+            }
+
+            var str = stringExpression.Value;
+            var remaining = (length.Value == int.MaxValue) ? str.Length : length.Value;
+            var offset = 0;
+
+            var clause = new RequirementClauseExpression() { Operation = ConditionalOperation.And };
+            while (remaining > 0)
+            {
+                var value = 0;
+                switch (remaining)
+                {
+                    default:
+                        var c4 = (offset + 3 < str.Length) ? str[offset + 3] : 0;
+                        if (c4 > 127)
+                        {
+                            result = new ErrorExpression(String.Format("Character {0} of string ({1}) cannot be converted to ASCII", offset + 3, (char)c4), stringExpression);
+                            return false;
+                        }
+                        value |= (c4 << 24);
+                        goto case 3;
+
+                    case 3:
+                        var c3 = (offset + 2 < str.Length) ? str[offset + 2] : 0;
+                        if (c3 > 127)
+                        {
+                            result = new ErrorExpression(String.Format("Character {0} of string ({1}) cannot be converted to ASCII", offset + 2, (char)c3), stringExpression);
+                            return false;
+                        }
+                        value |= (c3 << 16);
+                        goto case 2;
+
+                    case 2:
+                        var c2 = (offset + 1 < str.Length) ? str[offset + 1] : 0;
+                        if (c2 > 127)
+                        {
+                            result = new ErrorExpression(String.Format("Character {0} of string ({1}) cannot be converted to ASCII", offset + 1, (char)c2), stringExpression);
+                            return false;
+                        }
+                        value |= (c2 << 8);
+                        goto case 1;
+
+                    case 1:
+                        var c1 = offset < str.Length ? str[offset] : 0;
+                        if (c1 > 127)
+                        {
+                            result = new ErrorExpression(String.Format("Character {0} of string ({1}) cannot be converted to ASCII", offset, (char)c1), stringExpression);
+                            return false;
+                        }
+                        value |= c1;
+                        break;
+                }
+
+                FieldSize size;
+                switch (remaining)
+                {
+                    case 1: size = FieldSize.Byte; break;
+                    case 2: size = FieldSize.Word; break;
+                    case 3: size = FieldSize.TByte; break;
+                    default: size = FieldSize.DWord; break;
+                }
+
+                var scan = address.Clone();
+                scan.Field = new Field { Type = address.Field.Type, Size = size, Value = address.Field.Value + (uint)offset };
+
+                var condition = new RequirementConditionExpression()
+                {
+                    Left = scan,
+                    Comparison = ComparisonOperation.Equal,
+                    Right = new IntegerConstantExpression(value),
+                };
+                clause.AddCondition(condition);
+
+                offset += 4;
+                remaining -= 4;
+            }
+
+            result = clause;
+            return true;
+        }
+    }
+}

--- a/Source/Parser/Functions/UnicodeStringEqualsFunction.cs
+++ b/Source/Parser/Functions/UnicodeStringEqualsFunction.cs
@@ -1,0 +1,82 @@
+﻿using RATools.Data;
+using RATools.Parser.Expressions;
+using RATools.Parser.Expressions.Trigger;
+using RATools.Parser.Internal;
+
+namespace RATools.Parser.Functions
+{
+    internal class UnicodeStringEqualsFunction : FunctionDefinitionExpression
+    {
+        public UnicodeStringEqualsFunction()
+            : base("unicode_string_equals")
+        {
+            Parameters.Add(new VariableDefinitionExpression("address"));
+            Parameters.Add(new VariableDefinitionExpression("string"));
+            Parameters.Add(new VariableDefinitionExpression("length"));
+
+            DefaultParameters["length"] = new IntegerConstantExpression(int.MaxValue);
+        }
+
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            return Evaluate(scope, out result);
+        }
+
+        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        {
+            var address = GetMemoryAddressParameter(scope, "address", out result);
+            if (address == null)
+                return false;
+
+            var stringExpression = GetStringParameter(scope, "string", out result);
+            if (stringExpression == null)
+                return false;
+
+            var length = GetIntegerParameter(scope, "length", out result);
+            if (length == null)
+                return false;
+
+            if (length.Value <= 0)
+            {
+                result = new ErrorExpression("length must be greater than 0", length);
+                return false;
+            }
+
+            var str = stringExpression.Value;
+            var remaining = (length.Value == int.MaxValue) ? str.Length : length.Value;
+            var offset = 0;
+
+            var clause = new RequirementClauseExpression() { Operation = ConditionalOperation.And };
+            while (remaining > 0)
+            {
+                var size = FieldSize.Word;
+                var c1 = offset < str.Length ? str[offset] : 0;
+                var value = c1;
+
+                if (remaining > 1)
+                {
+                    size = FieldSize.DWord;
+                    var c2 = (offset + 1 < str.Length) ? str[offset + 1] : 0;
+                    value |= (c2 << 16);
+                }
+
+                var scan = address.Clone();
+                scan.Field = new Field { Type = address.Field.Type, Size = size, Value = address.Field.Value + (uint)offset * 2 };
+
+                var condition = new RequirementConditionExpression()
+                {
+                    Left = scan,
+                    Comparison = ComparisonOperation.Equal,
+                    Right = new IntegerConstantExpression(value),
+                };
+                clause.AddCondition(condition);
+
+                offset += 2;
+                remaining -= 2;
+            }
+
+            result = clause;
+            return true;
+        }
+    }
+}

--- a/Tests/Parser/Functions/AsciiStringEqualsFunctionTests.cs
+++ b/Tests/Parser/Functions/AsciiStringEqualsFunctionTests.cs
@@ -1,0 +1,103 @@
+﻿using NUnit.Framework;
+using RATools.Parser.Expressions;
+using RATools.Parser.Expressions.Trigger;
+using RATools.Parser.Functions;
+using RATools.Parser.Internal;
+using RATools.Tests.Parser.Expressions;
+using RATools.Tests.Parser.Expressions.Trigger;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RATools.Tests.Parser.Functions
+{
+    [TestFixture]
+    class AsciiStringEqualsFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new AsciiStringEqualsFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("ascii_string_equals"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(3));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("address"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("string"));
+            Assert.That(def.Parameters.ElementAt(2).Name, Is.EqualTo("length"));
+
+            Assert.That(def.DefaultParameters.Count, Is.EqualTo(1));
+            Assert.That(def.DefaultParameters.ElementAt(0).Key, Is.EqualTo("length"));
+            Assert.That(def.DefaultParameters.ElementAt(0).Value, Is.InstanceOf<IntegerConstantExpression>());
+            Assert.That(((IntegerConstantExpression)def.DefaultParameters.ElementAt(0).Value).Value, Is.EqualTo(int.MaxValue));
+        }
+
+        [Test]
+        [TestCase("0x1234", "test", 4, "0xX001234=1953719668")] // 0x74736574
+        [TestCase("0x1234", "test", 3, "0xW001234=7562612")] // 0x736574
+        [TestCase("0x1234", "test", 5, "0xX001234=1953719668_0xH001238=0")] // 0x74736574 00
+        [TestCase("0x1234", "test1", 6, "0xX001234=1953719668_0x 001238=49")] // 0x74736574 3100
+        [TestCase("0x1234", "Testing1234", 11, "0xX001234=1953719636_0xX001238=828862057_0xW00123c=3420978")] // 0x74736554 31676E69 343332
+        [TestCase("0x1234", "", 1, "0xH001234=0")] // 0x00
+        [TestCase("0x1234", "test1", Int32.MaxValue, "0xX001234=1953719668_0xH001238=49")] // 0x74736574 31
+        [TestCase("dword(0x1234)", "test1", 6,
+            "I:0xX001234_0xX000000=1953719668_I:0xX001234_0x 000004=49")] // 0x74736574 3100
+        [TestCase("dword(0x1234) + 32", "Testing1234", 11,
+            "I:0xX001234_0xX000020=1953719636_I:0xX001234_0xX000024=828862057_I:0xX001234_0xW000028=3420978")] // 0x74736554 31676E69 343332
+        [TestCase("dword(dword(0x1234) + 8) + 0x2c", "test1", 6,
+            "I:0xX001234_I:0xX000008_0xX00002c=1953719668_I:0xX001234_I:0xX000008_0x 000030=49")] // 0x74736574 3100
+        public void TestEvaluate(string address, string input, int length, string expected)
+        {
+            var parameters = new List<ExpressionBase>();
+            parameters.Add(ExpressionTests.Parse(address));
+            parameters.Add(new StringConstantExpression(input));
+            parameters.Add(new IntegerConstantExpression(length));
+
+            var expression = new FunctionCallExpression("ascii_string_equals", parameters);
+            var scope = new InterpreterScope();
+            scope.AddFunction(new AsciiStringEqualsFunction());
+
+            ExpressionBase result;
+            Assert.IsTrue(expression.Evaluate(scope, out result));
+
+            Assert.That(result, Is.InstanceOf<RequirementClauseExpression>());
+            TriggerExpressionTests.AssertSerialize((RequirementClauseExpression)result, expected);
+        }
+
+        [Test]
+        public void TestNot()
+        {
+            var clause = TriggerExpressionTests.Parse<RequirementClauseExpression>("!ascii_string_equals(0x1234, \"Testing1234\")");
+            TriggerExpressionTests.AssertSerialize(clause, "O:0xX001234!=1953719636_O:0xX001238!=828862057_0xW00123c!=3420978");
+        }
+
+        [Test]
+        [TestCase(0, "âeiou")]
+        [TestCase(1, "aëiou")]
+        [TestCase(2, "aeìou")]
+        [TestCase(3, "aeiôu")]
+        [TestCase(4, "aeioú")]
+        public void TestInvalidCharacter(int errorOffset, string input)
+        {
+            var parameters = new List<ExpressionBase>();
+            parameters.Add(new IntegerConstantExpression(0x1234));
+            parameters.Add(new StringConstantExpression(input));
+            parameters.Add(new IntegerConstantExpression(Int32.MaxValue));
+
+            var expression = new FunctionCallExpression("ascii_string_equals", parameters);
+            var scope = new InterpreterScope();
+            scope.AddFunction(new AsciiStringEqualsFunction());
+
+            ExpressionBase result;
+            Assert.IsFalse(expression.Evaluate(scope, out result));
+
+            var expectedError = String.Format("Character {0} of string ({1}) cannot be converted to ASCII", errorOffset, input[errorOffset]);
+            ExpressionTests.AssertError(result, expectedError);
+        }
+
+        [Test]
+        public void TestLengthZero()
+        {
+            TriggerExpressionTests.AssertParseError("ascii_string_equals(0x1234, \"Test\", 0)",
+                "length must be greater than 0");
+        }
+    }
+}

--- a/Tests/Parser/Functions/UnicodeStringEqualsFunctionTests.cs
+++ b/Tests/Parser/Functions/UnicodeStringEqualsFunctionTests.cs
@@ -1,0 +1,74 @@
+﻿using NUnit.Framework;
+using RATools.Parser.Expressions;
+using RATools.Parser.Expressions.Trigger;
+using RATools.Parser.Functions;
+using RATools.Parser.Internal;
+using RATools.Tests.Parser.Expressions;
+using RATools.Tests.Parser.Expressions.Trigger;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RATools.Tests.Parser.Functions
+{
+    [TestFixture]
+    class UnicodeStringEqualsFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new UnicodeStringEqualsFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("unicode_string_equals"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(3));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("address"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("string"));
+            Assert.That(def.Parameters.ElementAt(2).Name, Is.EqualTo("length"));
+
+            Assert.That(def.DefaultParameters.Count, Is.EqualTo(1));
+            Assert.That(def.DefaultParameters.ElementAt(0).Key, Is.EqualTo("length"));
+            Assert.That(def.DefaultParameters.ElementAt(0).Value, Is.InstanceOf<IntegerConstantExpression>());
+            Assert.That(((IntegerConstantExpression)def.DefaultParameters.ElementAt(0).Value).Value, Is.EqualTo(int.MaxValue));
+        }
+
+        [Test]
+        [TestCase("0x1234", "me", 2, "0xX001234=6619245")] // 0x0065006D
+        [TestCase("0x1234", "test", 3, "0xX001234=6619252_0x 001238=115")] // 0x00650074 0073
+        [TestCase("0x1234", "test", 5, "0xX001234=6619252_0xX001238=7602291_0x 00123c=0")] // 0x00650074 00740073 0000
+        [TestCase("0x1234", "tęst", Int32.MaxValue, "0xX001234=18415732_0xX001238=7602291")] // 0x01190074 00740073
+        [TestCase("dword(0x1234)", "test1", 6, // 0x00650074 00740073 00000031
+            "I:0xX001234_0xX000000=6619252_I:0xX001234_0xX000004=7602291_I:0xX001234_0xX000008=49")]
+        [TestCase("dword(dword(0x1234) + 8) + 0x2c", "test1", 6, // 0x00650074 00740073 00000031
+            "I:0xX001234_I:0xX000008_0xX00002c=6619252_I:0xX001234_I:0xX000008_0xX000030=7602291_I:0xX001234_I:0xX000008_0xX000034=49")]
+        public void TestEvaluate(string address, string input, int length, string expected)
+        {
+            var parameters = new List<ExpressionBase>();
+            parameters.Add(ExpressionTests.Parse(address));
+            parameters.Add(new StringConstantExpression(input));
+            parameters.Add(new IntegerConstantExpression(length));
+
+            var expression = new FunctionCallExpression("unicode_string_equals", parameters);
+            var scope = new InterpreterScope();
+            scope.AddFunction(new UnicodeStringEqualsFunction());
+
+            ExpressionBase result;
+            Assert.IsTrue(expression.Evaluate(scope, out result));
+
+            Assert.That(result, Is.InstanceOf<RequirementClauseExpression>());
+            TriggerExpressionTests.AssertSerialize((RequirementClauseExpression)result, expected);
+        }
+
+        [Test]
+        public void TestNot()
+        {
+            var clause = TriggerExpressionTests.Parse<RequirementClauseExpression>("!unicode_string_equals(0x1234, \"Test\")");
+            TriggerExpressionTests.AssertSerialize(clause, "O:0xX001234!=6619220_0xX001238!=7602291");
+        }
+
+        [Test]
+        public void TestLengthZero()
+        {
+            TriggerExpressionTests.AssertParseError("unicode_string_equals(0x1234, \"Test\", 0)",
+                "length must be greater than 0");
+        }
+    }
+}


### PR DESCRIPTION
As suggested in #345 (under 'matching strings in memory' header). 

I believe this addresses the underlying desires posited in #141.

inputs:
* `address` - the address to match against the first byte of the string
* `string` - the string to match
* `length` - the number of characters to match. if longer than the string, null padding will be validated. if omitted, the length of the string will be used.

examples:
`ascii_string_equals(0x1234, "test")`
 => `dword(0x1234) == 0x74736574`

`ascii_string_equals(dword(0x1234) + 0x20, "Hello!", 7)`
 => `dword(dword(0x1234) + 0x20) == 0x6C6C6548 && tbyte(dword(0x1234) + 0x24) == 0x00216F`

`unicode_string_equals(0x1234, "test")`
 => `dword(0x1234) == 0x00650074 && dword(0x1238) == 0x00740073`
