### PR TITLE
add parenthesis when dumping masked pointers

### DIFF
--- a/Source/Data/Field.cs
+++ b/Source/Data/Field.cs
@@ -160,7 +160,27 @@ namespace RATools.Data
             builder.Append('(');
 
             if (!string.IsNullOrEmpty(addAddress))
-                builder.Append(addAddress);
+            {
+                if (address == 0)
+                {
+                    builder.Append(addAddress);
+                    builder.Length -= 3;
+                    builder.Append(')');
+                    return;
+                }
+
+                if (addAddress.Contains(" & 0x"))
+                {
+                    builder.Append('(');
+                    builder.Append(addAddress);
+                    builder.Length -= 3;
+                    builder.Append(") + ");
+                }
+                else
+                {
+                    builder.Append(addAddress);
+                }
+            }
 
             builder.Append("0x");
             builder.AppendFormat("{0:X6}", address);

--- a/Source/Data/RequirementEx.cs
+++ b/Source/Data/RequirementEx.cs
@@ -96,7 +96,7 @@ namespace RATools.Data
 
                 case RequirementOperator.BitwiseAnd:
                     builder.Append(" & ");
-                    requirement.Right.AppendString(builder, numberFormat);
+                    requirement.Right.AppendString(builder, NumberFormat.Hexadecimal);
                     break;
             }
         }

--- a/Source/Parser/Expressions/Trigger/MemoryAccessorExpressionBase.cs
+++ b/Source/Parser/Expressions/Trigger/MemoryAccessorExpressionBase.cs
@@ -1,10 +1,5 @@
 ﻿using RATools.Data;
 using RATools.Parser.Internal;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RATools.Parser.Expressions.Trigger
 {

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -184,7 +184,7 @@ namespace RATools.Tests.Parser
         [TestCase("A:0xN20770f=0_0xO20770f=0", "(bit1(0x20770F) + bit2(0x20770F)) == 0")]
         [TestCase("A:0xN20770f*6_0xO20770f=0", "(bit1(0x20770F) * 6 + bit2(0x20770F)) == 0")]
         [TestCase("A:0xN20770f/6_0xO20770f=0", "(bit1(0x20770F) / 6 + bit2(0x20770F)) == 0")]
-        [TestCase("A:0xN20770f&6_0xO20770f=0", "(bit1(0x20770F) & 6 + bit2(0x20770F)) == 0")]
+        [TestCase("A:0xN20770f&6_0xO20770f=0", "(bit1(0x20770F) & 0x06 + bit2(0x20770F)) == 0")]
         [TestCase("B:0xN20770f=0_0xO20770f=0", "(bit2(0x20770F) - bit1(0x20770F)) == 0")]
         [TestCase("C:0xN20770f=0_0xO20770f=0.4.", "tally(4, bit1(0x20770F) == 0, bit2(0x20770F) == 0)")]
         [TestCase("O:0xN20770f=0_0xO20770f=0.4.", "repeated(4, bit1(0x20770F) == 0 || bit2(0x20770F) == 0)")]

--- a/Tests/Parser/Expressions/Trigger/MemoryAcessorExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/MemoryAcessorExpressionTests.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using RATools.Parser.Expressions;
 using RATools.Parser.Expressions.Trigger;
 using RATools.Parser.Internal;
 
@@ -76,6 +75,34 @@ namespace RATools.Tests.Parser.Expressions.Trigger
             ExpressionType.Error, "Cannot perform bitwise operations on floating point values")]
         [TestCase("byte(0x001234)", "^", "float(0x002345)",
             ExpressionType.Error, "Cannot perform bitwise operations on floating point values")]
+        [TestCase("dword(0x001234)", "&", "0xFFFFFFFF",
+            ExpressionType.MemoryAccessor, "dword(0x001234)")]
+        [TestCase("dword(0x001234)", "&", "0x7FFFFFFF",
+            ExpressionType.MemoryAccessor, "dword(0x001234) & 0x7FFFFFFF")]
+        [TestCase("dword(0x001234)", "&", "0x00FFFFFF",
+            ExpressionType.MemoryAccessor, "tbyte(0x001234)")]
+        [TestCase("dword(0x001234)", "&", "0x000FFFFF",
+            ExpressionType.MemoryAccessor, "tbyte(0x001234) & 0x000FFFFF")]
+        [TestCase("dword(0x001234)", "&", "0x0000FFFF",
+            ExpressionType.MemoryAccessor, "word(0x001234)")]
+        [TestCase("dword(0x001234)", "&", "0x00000FFF",
+            ExpressionType.MemoryAccessor, "word(0x001234) & 0x00000FFF")]
+        [TestCase("dword(0x001234)", "&", "0x000000FF",
+            ExpressionType.MemoryAccessor, "byte(0x001234)")]
+        [TestCase("dword(0x001234)", "&", "0x0000000F",
+            ExpressionType.MemoryAccessor, "low4(0x001234)")]
+        [TestCase("dword(0x001234)", "&", "0x00000001",
+            ExpressionType.MemoryAccessor, "bit0(0x001234)")]
+        [TestCase("byte(0x001234)", "&", "0x0000FFFF",
+            ExpressionType.MemoryAccessor, "byte(0x001234)")]
+        [TestCase("byte(0x001234)", "&", "0x000001FF",
+            ExpressionType.MemoryAccessor, "byte(0x001234)")]
+        [TestCase("byte(0x001234)", "&", "0x000000FF",
+            ExpressionType.MemoryAccessor, "byte(0x001234)")]
+        [TestCase("byte(0x001234)", "&", "0x000000F7",
+            ExpressionType.MemoryAccessor, "byte(0x001234) & 0x000000F7")]
+        [TestCase("byte(0x001234)", "&", "0x0000007F",
+            ExpressionType.MemoryAccessor, "byte(0x001234) & 0x0000007F")]
         public void TestCombine(string left, string operation, string right, ExpressionType expectedType, string expected)
         {
             // MemoryAccessorExpression.Combine just converts to a ModifiedMemoryAccessor and

--- a/Tests/Parser/Functions/MemoryAccessorFunctionTests.cs
+++ b/Tests/Parser/Functions/MemoryAccessorFunctionTests.cs
@@ -161,19 +161,19 @@ namespace RATools.Tests.Parser.Functions
         }
 
         [Test]
-        [TestCase("byte(word(0x1234))", "byte(word(0x001234) + 0x000000)")] // direct pointer
+        [TestCase("byte(word(0x1234))", "byte(word(0x001234))")] // direct pointer
         [TestCase("byte(word(0x1234) + 10)", "byte(word(0x001234) + 0x00000A)")] // indirect pointer
         [TestCase("byte(10 + word(0x1234))", "byte(word(0x001234) + 0x00000A)")] // indirect pointer
         [TestCase("byte(0x1234 + word(0x2345))", "byte(word(0x002345) + 0x001234)")] // array index
-        [TestCase("byte(word(word(0x1234)))", "byte(word(word(0x001234) + 0x000000) + 0x000000)")] // double direct pointer
+        [TestCase("byte(word(word(0x1234)))", "byte(word(word(0x001234)))")] // double direct pointer
         [TestCase("byte(0x1234 + word(word(0x2345) + 10))", "byte(word(word(0x002345) + 0x00000A) + 0x001234)")] // double indirect pointer
-        [TestCase("byte(prev(word(0x1234)))", "byte(prev(word(0x001234)) + 0x000000)")] // direct pointer using prev data
-        [TestCase("byte(word(0x1234) * 2)", "byte(word(0x001234) * 0x00000002 + 0x000000)")] // scaled direct pointer [unexpected]
+        [TestCase("byte(prev(word(0x1234)))", "byte(prev(word(0x001234)))")] // direct pointer using prev data
+        [TestCase("byte(word(0x1234) * 2)", "byte(word(0x001234) * 0x00000002)")] // scaled direct pointer [unexpected]
         [TestCase("byte(word(0x2345) * 2 + 0x1234)", "byte(word(0x002345) * 0x00000002 + 0x001234)")] // scaled array index
         [TestCase("byte(0x1234 + word(0x2345) * 2)", "byte(word(0x002345) * 0x00000002 + 0x001234)")] // scaled array index
         [TestCase("byte(word(word(0x2345) * 2 + 0x1234) * 4 + 0x3456)",
                   "byte(word(word(0x002345) * 0x00000002 + 0x001234) * 0x00000004 + 0x003456)")] // double scaled array index
-        [TestCase("bit(3, word(0x1234))", "bit3(word(0x001234) + 0x000000)")] // direct pointer
+        [TestCase("bit(3, word(0x1234))", "bit3(word(0x001234))")] // direct pointer
         [TestCase("bit(18, word(0x1234))", "bit2(word(0x001234) + 0x000002)")] // direct pointer
         [TestCase("bit(3, word(0x1234) + 10)", "bit3(word(0x001234) + 0x00000A)")] // indirect pointer
         [TestCase("bit(18, word(0x1234) + 10)", "bit2(word(0x001234) + 0x00000C)")] // indirect pointer
@@ -181,9 +181,9 @@ namespace RATools.Tests.Parser.Functions
         [TestCase("bit(18, prev(word(0x1234)))", "bit2(prev(word(0x001234)) + 0x000002)")] // direct pointer using prev data
         [TestCase("bit(18, 0x1234 + word(0x2345) * 2)", "bit2(word(0x002345) * 0x00000002 + 0x001236)")] // scaled array index
         [TestCase("byte(word(0x1234) - 10)", "byte(word(0x001234) + 0xFFFFFFF6)")]
-        [TestCase("byte(word(0x1234) / 2)", "byte(word(0x001234) / 0x00000002 + 0x000000)")]
-        [TestCase("byte(word(0x1234) & 7)", "byte(word(0x001234) & 0x00000007 + 0x000000)")]
-        [TestCase("byte((word(0x1234) & 7) + 99)", "byte(word(0x001234) & 0x00000007 + 0x000063)")]
+        [TestCase("byte(word(0x1234) / 2)", "byte(word(0x001234) / 0x00000002)")]
+        [TestCase("byte(word(0x1234) & 0x1FF)", "byte(word(0x001234) & 0x000001FF)")]
+        [TestCase("byte((word(0x1234) & 0x1FF) + 99)", "byte((word(0x001234) & 0x000001FF) + 0x000063)")]
         public void TestAddAddress(string input, string expected)
         {
             var requirements = Evaluate(input);


### PR DESCRIPTION
bitwise and has a lower precedence than arithmetic, so the `byte(dword(0x1234) & 0x1FFFFFF + 0x30)` being dumped would get treated as `byte(dword(0x1234) & (0x1FFFFFF + 0x30))`. This update the dumper to put explicit parenthesis around the bitmask so it can be interpreted correctly as `byte((dword(0x1234) & 0x1FFFFFF) + 0x30)`.

Also adds logic to use smaller memory reads when masking (i.e. `dword(0x1234) & 0xFFFF` => `word(0x1234)`)