### PR TITLE
more informative error when function call in trigger cannot be evaluated

### DIFF
--- a/Source/Parser/AchievementBuilder.cs
+++ b/Source/Parser/AchievementBuilder.cs
@@ -1300,11 +1300,11 @@ namespace RATools.Parser
 
                                 foreach (var requirement in requirementEx.Requirements)
                                 {
-                                    subclause.Requirements.Add(requirement);
-
                                     if (requirement.Type == RequirementType.OrNext)
                                     {
-                                        requirement.Type = orNextGroupType;
+                                        var newRequirement = requirement.Clone();
+                                        newRequirement.Type = orNextGroupType;
+                                        subclause.Requirements.Add(newRequirement);
 
                                         subclause = new RequirementEx();
 
@@ -1312,6 +1312,10 @@ namespace RATools.Parser
                                             groups.Add(new List<RequirementEx>() { subclause });
                                         else
                                             group.Insert(++i, subclause);
+                                    }
+                                    else
+                                    {
+                                        subclause.Requirements.Add(requirement);
                                     }
                                 }
                             }

--- a/Tests/Parser/Functions/AchievementFunctionTests.cs
+++ b/Tests/Parser/Functions/AchievementFunctionTests.cs
@@ -106,5 +106,35 @@ namespace RATools.Tests.Parser.Functions
             var builder = new AchievementBuilder(achievement);
             Assert.That(builder.SerializeRequirements(), Is.EqualTo(expected.ToString()));
         }
+
+        [Test]
+        public void TestInvalidComparisonInTrigger()
+        {
+            var input = "function a() => byte(0x1234)\n" +
+                        "achievement(\"T\", \"D\", 5, a == 1)";
+
+            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
+            var parser = new AchievementScriptInterpreter();
+            Assert.That(parser.Run(tokenizer), Is.False);
+            Assert.That(parser.ErrorMessage, Is.EqualTo(
+                "2:1 achievement call failed\r\n" +
+                "- 2:26 trigger is not a requirement"));
+        }
+
+        [Test]
+        public void TestInvalidComparisonInHelperFunction()
+        {
+            var input = "function a() => byte(0x1234)\n" +
+                        "function b() => a == 1\n" +
+                        "achievement(\"T\", \"D\", 5, b())";
+
+            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
+            var parser = new AchievementScriptInterpreter();
+            Assert.That(parser.Run(tokenizer), Is.False);
+            Assert.That(parser.ErrorMessage, Is.EqualTo(
+                "3:1 achievement call failed\r\n" +
+                "- 3:26 trigger is not a requirement\r\n" +
+                "- 2:17 Cannot convert comparison to requirement"));
+        }
     }
 }


### PR DESCRIPTION
instead of just saying "trigger is not a requirement", attempt to highlight the nested condition leading to the error.