### PR TITLE
only show first line of note in requirements view

### DIFF
--- a/Source/ViewModels/RequirementViewModel.cs
+++ b/Source/ViewModels/RequirementViewModel.cs
@@ -74,7 +74,31 @@ namespace RATools.ViewModels
             private set { SetValue(DefinitionProperty, value); }
         }
 
-        public string Notes { get; private set; }
+        public string Notes
+        {
+            get { return _notes; }
+            private set
+            {
+                _notes = value;
+
+                var index = value.IndexOf('\n');
+                if (index != -1)
+                {
+                    NotesShort = value.Substring(0, index).TrimEnd();
+                    IsNoteShortened = true;
+                }
+                else
+                {
+                    NotesShort = value;
+                    IsNoteShortened = false;
+                }
+            }
+        }
+        private string _notes;
+
+        public string NotesShort { get; private set; }
+
+        public bool IsNoteShortened { get; private set; }
 
         internal virtual void OnShowHexValuesChanged(ModelPropertyChangedEventArgs e)
         {

--- a/Source/Views/AssetViewer.xaml
+++ b/Source/Views/AssetViewer.xaml
@@ -106,6 +106,25 @@
         </Style.Triggers>
     </Style>
 
+    <DataTemplate x:Key="codeNotesStackPanelTemplate">
+        <StackPanel Orientation="Horizontal">
+            <TextBlock Text="{Binding NotesShort}" Style="{StaticResource themedTextBlock}" TextWrapping="Wrap" FontStyle="Italic" />
+            <Border BorderBrush="{Binding DataContext.Resources.ScrollBarForegroundBrush, ElementName=gameGrid}"
+                    BorderThickness="2" CornerRadius="4" Margin="6,0,0,0">
+                <Border.Style>
+                    <Style TargetType="{x:Type Border}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsNoteShortened}" Value="False">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <TextBlock Text="..." ToolTip="{Binding Notes}" Style="{StaticResource themedTextBlock}" Margin="2,-6,2,0" />
+            </Border>
+        </StackPanel>
+    </DataTemplate>
+
     <DataTemplate x:Key="assetBodyTemplate">
         <Grid Grid.IsSharedSizeScope="True">
             <Grid.Resources>
@@ -138,7 +157,8 @@
                                 </Style>
                             </TextBlock.Style>
                         </TextBlock>
-                        <TextBlock Grid.Column="2" Text="{Binding Notes}" TextWrapping="Wrap" FontStyle="Italic" Style="{StaticResource themedTextBlock}" />
+                        <ContentControl Grid.Column="2" Content="{Binding}"
+                                        ContentTemplate="{StaticResource codeNotesStackPanelTemplate}" />
                     </Grid>
                 </DataTemplate>
 
@@ -149,7 +169,8 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <TextBlock Text="{Binding Definition}" Margin="0,0,8,0" Style="{StaticResource themedTextBlock}" />
-                        <TextBlock Grid.Column="1" Text="{Binding Notes}" Style="{StaticResource notesTextBlock}" />
+                        <ContentControl Grid.Column="1" Content="{Binding}"
+                                        ContentTemplate="{StaticResource codeNotesStackPanelTemplate}" />
                     </Grid>
                 </DataTemplate>
             </Grid.Resources>

--- a/Source/Views/Common.xaml
+++ b/Source/Views/Common.xaml
@@ -22,11 +22,6 @@
         <Setter Property="VerticalAlignment" Value="Top" />
     </Style>
 
-    <Style TargetType="{x:Type TextBlock}" x:Key="notesTextBlock" BasedOn="{StaticResource themedTextBlock}">
-        <Setter Property="FontStyle" Value="Italic" />
-        <Setter Property="TextWrapping" Value="Wrap" />
-    </Style>
-
     <!-- http://msdn2.microsoft.com/en-us/library/ms742173(VS.85).aspx -->
     <Style x:Key="themedScrollBarLineButton" TargetType="{x:Type RepeatButton}">
         <Setter Property="SnapsToDevicePixels" Value="true" />

--- a/Tests/ViewModels/RequirementViewModelTests.cs
+++ b/Tests/ViewModels/RequirementViewModelTests.cs
@@ -59,5 +59,27 @@ namespace RATools.Tests.ViewModels
 
             Assert.That(vmRequirement.Notes, Is.EqualTo(expected));
         }
+
+        [TestCase("0xH1111=7", "")]
+        [TestCase("0xH1234=7", "Addr1")]
+        [TestCase("0xH2345=7", "Addr2")]
+        public void TestNoteShortening(string serialized, string expected)
+        {
+            var notes = new Dictionary<int, string>();
+            notes[0x1234] = "Addr1";
+            notes[0x2345] = "Addr2\r\n0=True\r\n1=False";
+
+            var builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer(serialized));
+            var requirement = builder.ToAchievement().CoreRequirements.First();
+            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes);
+
+            Assert.That(vmRequirement.NotesShort, Is.EqualTo(expected));
+
+            if (expected == vmRequirement.Notes)
+                Assert.IsFalse(vmRequirement.IsNoteShortened);
+            else
+                Assert.IsTrue(vmRequirement.IsNoteShortened);
+        }
     }
 }


### PR DESCRIPTION
Implements #386 

If a code note has more than one line, only the first line is shown, and a ellipsis "button" is displayed that has a tooltip with the entire code note.

![image](https://user-images.githubusercontent.com/32680403/229927700-7258d504-ca6d-4c33-a480-bdc251161e0d.png)

I'm not going to include an option to toggle the behavior at this time. I feel that as long as the important information is in the first line of the code note, hiding the rest of the information when viewing an overview of the "compiled" code is cleaner.