### PR TITLE
add Achievement List dialog

### DIFF
--- a/Source/ViewModels/AchievementViewModel.cs
+++ b/Source/ViewModels/AchievementViewModel.cs
@@ -53,5 +53,51 @@ namespace RATools.ViewModels
         {
             _owner.UpdateLocal((Achievement)asset, (Achievement)localAsset, warning, validateAll);
         }
+
+        public string MeasuredTarget
+        {
+            get
+            {
+                var asset = Generated.Asset ?? Local.Asset ?? Published.Asset;
+                var achievement = asset as Achievement;
+                if (achievement != null)
+                {
+                    var measuredTarget = GetMeasuredTarget(achievement.CoreRequirements);
+                    if (measuredTarget != null)
+                        return measuredTarget;
+
+                    foreach (var alt in achievement.AlternateRequirements)
+                    {
+                        measuredTarget = GetMeasuredTarget(alt);
+                        if (measuredTarget != null)
+                            return measuredTarget;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        private static string GetMeasuredTarget(IEnumerable<Requirement> requirements)
+        {
+            foreach (var requirement in requirements)
+            {
+                if (requirement.Type == RequirementType.MeasuredPercent)
+                    return "100%";
+
+                if (requirement.Type == RequirementType.Measured)
+                {
+                    if (requirement.Right.IsMemoryReference)
+                        return "?";
+
+                    if (requirement.Right.IsFloat)
+                        return requirement.Right.Float.ToString();
+
+                    return requirement.Right.Value.ToString();
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/Source/ViewModels/MainWindowViewModel.cs
+++ b/Source/ViewModels/MainWindowViewModel.cs
@@ -28,6 +28,7 @@ namespace RATools.ViewModels
 
             DragDropScriptCommand = new DelegateCommand<string[]>(DragDropFile, CanDragDropFile);
             UpdateLocalCommand = DisabledCommand.Instance;
+            ViewAchievementsCommand = DisabledCommand.Instance;
 
             GameStatsCommand = new DelegateCommand(GameStats);
             OpenTicketsCommand = new DelegateCommand(OpenTickets);
@@ -151,10 +152,12 @@ namespace RATools.ViewModels
                 vm.SaveScriptAsCommand = new DelegateCommand(() => vm.SaveScriptAs());
                 vm.RefreshScriptCommand = new DelegateCommand(vm.RefreshScript);
                 vm.UpdateLocalCommand = new DelegateCommand(vm.UpdateLocal);
+                vm.ViewAchievementsCommand = new DelegateCommand(vm.ViewAchievements);
                 vm.OnPropertyChanged(() => vm.SaveScriptCommand);
                 vm.OnPropertyChanged(() => vm.SaveScriptAsCommand);
                 vm.OnPropertyChanged(() => vm.RefreshScriptCommand);
                 vm.OnPropertyChanged(() => vm.UpdateLocalCommand);
+                vm.OnPropertyChanged(() => vm.ViewAchievementsCommand);
             }
         }
 
@@ -474,6 +477,20 @@ namespace RATools.ViewModels
             }
 
             var dialog = new UpdateLocalViewModel(game);
+            dialog.ShowDialog();
+        }
+
+        public CommandBase ViewAchievementsCommand { get; private set; }
+        private void ViewAchievements()
+        {
+            var game = Game;
+            if (game == null)
+            {
+                TaskDialogViewModel.ShowErrorMessage("No game loaded", "Cannot view achievements if game not loaded.");
+                return;
+            }
+
+            var dialog = new ViewAchievementsViewModel(game);
             dialog.ShowDialog();
         }
 

--- a/Source/ViewModels/ViewAchievementsViewModel.cs
+++ b/Source/ViewModels/ViewAchievementsViewModel.cs
@@ -1,0 +1,62 @@
+﻿using Jamiras.Commands;
+using Jamiras.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata.Ecma335;
+
+namespace RATools.ViewModels
+{
+    public class ViewAchievementsViewModel : DialogViewModelBase
+    {
+        public ViewAchievementsViewModel(GameViewModel game)
+        {
+            _game = game;
+
+            DialogTitle = "View Achievements - " + game.Title;
+            CanClose = true;
+            CancelButtonText = null;
+            ExtraButtonCommand = new DelegateCommand(Export);
+
+            Achievements = game.Editors.OfType<AchievementViewModel>().ToArray();
+        }
+
+        private readonly GameViewModel _game;
+
+        /// <summary>
+        /// Gets the list of achievements.
+        /// </summary>
+        public IEnumerable<AchievementViewModel> Achievements { get; private set; }
+
+        public string ExtraButtonText {  get { return "Export"; } }
+        public CommandBase ExtraButtonCommand { get; private set; }
+
+        private void Export()
+        {
+            var filename = Path.GetFileNameWithoutExtension(_game.Script.Filename) ?? "achievements";
+
+            var vm = new FileDialogViewModel();
+            vm.DialogTitle = "Export achievement information";
+            vm.Filters["CSV file"] = "*.csv";
+            vm.FileNames = new[] { filename + ".csv" };
+            vm.OverwritePrompt = true;
+
+            if (vm.ShowSaveFileDialog() == DialogResult.Ok)
+            {
+                using (var file = File.CreateText(vm.FileNames[0]))
+                {
+                    file.WriteLine("Id,Title,Description,Points");
+
+                    foreach (var achievement in Achievements)
+                    {
+                        file.Write("{0},\"{1}\",", achievement.Id, achievement.Title.Replace("\"", "\\\""));
+                        file.Write("\"{0}\",", achievement.Description.Replace("\"", "\\\""));
+                        file.Write("{0}", achievement.Points);
+                        file.WriteLine();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/ViewModels/ViewAchievementsViewModel.cs
+++ b/Source/ViewModels/ViewAchievementsViewModel.cs
@@ -1,10 +1,8 @@
 ﻿using Jamiras.Commands;
 using Jamiras.ViewModels;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 
 namespace RATools.ViewModels
 {
@@ -14,7 +12,7 @@ namespace RATools.ViewModels
         {
             _game = game;
 
-            DialogTitle = "View Achievements - " + game.Title;
+            DialogTitle = "Achievements - " + game.Title;
             CanClose = true;
             CancelButtonText = null;
             ExtraButtonCommand = new DelegateCommand(Export);

--- a/Source/Views/MainWindow.xaml
+++ b/Source/Views/MainWindow.xaml
@@ -54,6 +54,8 @@
                 <MenuItem Header="Update _Local" Command="{Binding UpdateLocalCommand}" controls:CommandBinding.InputGesture="Ctrl+L" />
             </MenuItem>
             <MenuItem Header="_View">
+                <MenuItem Header="_Achievement List" Command="{Binding ViewAchievementsCommand}" />
+                <Separator />
                 <MenuItem Header="_Hexadecimal Values" IsCheckable="True" IsChecked="{Binding ShowHexValues}" />
                 <Separator />
                 <MenuItem Header="_Error List" IsCheckable="True" IsChecked="{Binding Game.SelectedEditor.Editor.ErrorsToolWindow.IsVisible, FallbackValue=False}" InputGestureText="Ctrl+E" />

--- a/Source/Views/MainWindow.xaml.cs
+++ b/Source/Views/MainWindow.xaml.cs
@@ -54,6 +54,7 @@ namespace RATools.Views
             dialogService.RegisterDialogHandler(typeof(NewScriptDialogViewModel), vm => new NewScriptDialog());
             dialogService.RegisterDialogHandler(typeof(OptionsDialogViewModel), vm => new OkCancelView(new OptionsDialog()));
             dialogService.RegisterDialogHandler(typeof(UpdateLocalViewModel), vm => new OkCancelView(new UpdateLocalDialog()));
+            dialogService.RegisterDialogHandler(typeof(ViewAchievementsViewModel), vm => new OkCancelView(new ViewAchievementsDialog()));
             dialogService.RegisterDialogHandler(typeof(GameStatsViewModel), vm => new GameStatsDialog());
             dialogService.RegisterDialogHandler(typeof(GameStatsViewModel.UserHistoryViewModel), vm => new UserHistoryDialog());
             dialogService.RegisterDialogHandler(typeof(GameProgressionViewModel), vm => new GameProgressionDialog());

--- a/Source/Views/ViewAchievementsDialog.xaml
+++ b/Source/Views/ViewAchievementsDialog.xaml
@@ -30,7 +30,7 @@
                   ScrollViewer.HorizontalScrollBarVisibility="Hidden">
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <Grid Margin="0,2,0,2">
+                    <Grid Margin="0,2,0,2" Height="64">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
@@ -59,13 +59,13 @@
                             </Grid.RowDefinitions>
 
                             <TextBlock FontSize="26" FontWeight="Medium"
-                                       Foreground="#828194" Margin="0,-2,0,-2">
+                                       Foreground="#828194" Margin="0,-4,0,-4">
                                 <TextBlock Text="{Binding Title}" /><Run Text=" (" /><TextBlock Text="{Binding Points}" /><Run Text=" points)" />
                             </TextBlock>
                             <TextBlock Grid.Row="1" FontSize="18" FontWeight="Medium"
                                        Foreground="#706A69" Text="{Binding Description}" />
 
-                            <Grid Grid.Row="2">
+                            <Grid Grid.Row="2" Margin="0,-2,0,0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="600" />
                                     <ColumnDefinition Width="*" />
@@ -79,7 +79,7 @@
                                         </Style.Triggers>
                                     </Style>
                                 </Grid.Style>
-                                <Border BorderBrush="#3C3D3E" Background="#B2B1AF" BorderThickness="2" Height="6" HorizontalAlignment="Stretch" />
+                                <Border BorderBrush="#3C3D3E" Background="#B2B1AF" BorderThickness="2" Height="8" HorizontalAlignment="Stretch" />
                                 <TextBlock Grid.Column="1" Margin="4,-2,0,0" Foreground="#5B5757" Text="{Binding MeasuredTarget}" />
                             </Grid>
                             

--- a/Source/Views/ViewAchievementsDialog.xaml
+++ b/Source/Views/ViewAchievementsDialog.xaml
@@ -24,8 +24,9 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
-        <ListView ItemsSource="{Binding Achievements}" Background="#090F1A"
-                  Margin="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+        <ListView Margin="2" ItemsSource="{Binding Achievements}" Background="#090F1A"         
+                  HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                  HorizontalContentAlignment="Stretch"
                   ScrollViewer.HorizontalScrollBarVisibility="Hidden">
             <ListView.ItemTemplate>
                 <DataTemplate>
@@ -49,12 +50,40 @@
                             </Image.Style>
                         </Image>
 
-                        <StackPanel Grid.Column="1" Margin="8,0,0,0" VerticalAlignment="Top">
-                            <TextBlock FontSize="26" FontWeight="Medium" Foreground="#828194" Margin="0,-2,0,-2">
+                        <Grid Grid.Column="1" Margin="8,0,0,0"
+                              VerticalAlignment="Top" HorizontalAlignment="Stretch">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+
+                            <TextBlock FontSize="26" FontWeight="Medium"
+                                       Foreground="#828194" Margin="0,-2,0,-2">
                                 <TextBlock Text="{Binding Title}" /><Run Text=" (" /><TextBlock Text="{Binding Points}" /><Run Text=" points)" />
                             </TextBlock>
-                            <TextBlock FontSize="18" FontWeight="Medium" Foreground="#706A69" Text="{Binding Description}" />
-                        </StackPanel>
+                            <TextBlock Grid.Row="1" FontSize="18" FontWeight="Medium"
+                                       Foreground="#706A69" Text="{Binding Description}" />
+
+                            <Grid Grid.Row="2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="600" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.Style>
+                                    <Style TargetType="{x:Type Grid}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding MeasuredTarget}" Value="{x:Null}">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Grid.Style>
+                                <Border BorderBrush="#3C3D3E" Background="#B2B1AF" BorderThickness="2" Height="6" HorizontalAlignment="Stretch" />
+                                <TextBlock Grid.Column="1" Margin="4,-2,0,0" Foreground="#5B5757" Text="{Binding MeasuredTarget}" />
+                            </Grid>
+                            
+                        </Grid>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/Source/Views/ViewAchievementsDialog.xaml
+++ b/Source/Views/ViewAchievementsDialog.xaml
@@ -1,0 +1,63 @@
+﻿<UserControl x:Class="RATools.Views.ViewAchievementsDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             SnapsToDevicePixels="True"
+             UseLayoutRounding="True"
+             RenderOptions.BitmapScalingMode="HighQuality"
+             Width="820" Height="592"
+             mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="AssetViewer.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid Margin="4">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <ListView ItemsSource="{Binding Achievements}" Background="#090F1A"
+                  Margin="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                  ScrollViewer.HorizontalScrollBarVisibility="Hidden">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <Grid Margin="0,2,0,2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <Image Source="{Binding Badge}" Width="64" Height="64" />
+                        <Image Width="56" Height="56" Source="{Binding ViewerImage}">
+                            <Image.Style>
+                                <Style TargetType="{x:Type Image}">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Badge}" Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Image.Style>
+                        </Image>
+
+                        <StackPanel Grid.Column="1" Margin="8,0,0,0" VerticalAlignment="Top">
+                            <TextBlock FontSize="26" FontWeight="Medium" Foreground="#828194" Margin="0,-2,0,-2">
+                                <TextBlock Text="{Binding Title}" /><Run Text=" (" /><TextBlock Text="{Binding Points}" /><Run Text=" points)" />
+                            </TextBlock>
+                            <TextBlock FontSize="18" FontWeight="Medium" Foreground="#706A69" Text="{Binding Description}" />
+                        </StackPanel>
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </Grid>
+</UserControl>

--- a/Source/Views/ViewAchievementsDialog.xaml.cs
+++ b/Source/Views/ViewAchievementsDialog.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Controls;
+
+namespace RATools.Views
+{
+    /// <summary>
+    /// Interaction logic for ViewAchievementsDialog.xaml
+    /// </summary>
+    public partial class ViewAchievementsDialog : UserControl
+    {
+        public ViewAchievementsDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Adds a new item to the View menu that shows the list of achievements as they would appear in the overlay.

![image](https://user-images.githubusercontent.com/32680403/232889435-8e3bd488-7057-4976-a32f-30c4cee7a8a4.png)

Includes an "Export" button in the lower left that generates a CSV of the ID, title, description, and points for all achievements (#369)