### PR TITLE
report trailing comma error when parameter list ends in ',)'

### DIFF
--- a/Source/Parser/Internal/ExpressionBase.cs
+++ b/Source/Parser/Internal/ExpressionBase.cs
@@ -686,8 +686,18 @@ namespace RATools.Parser.Internal
                     if (tokenizer.NextChar != ',')
                         break;
 
+                    var commaLocation = tokenizer.Location;
                     tokenizer.Advance();
                     SkipWhitespace(tokenizer);
+
+                    if (tokenizer.NextChar == ')')
+                    {
+                        tokenizer.Advance(); // skip parenthesis at end of list
+                        var error = ParseError(tokenizer, "Trailing comma in parameter list");
+                        error.Location = new TextRange(commaLocation,
+                            new TextLocation(commaLocation.Line, commaLocation.Column + 1));
+                        return error;
+                    }
                 } while (true);
             }
 

--- a/Tests/Parser/Expressions/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Expressions/FunctionCallExpressionTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using Jamiras.Components;
+using NUnit.Framework;
 using RATools.Parser;
 using RATools.Parser.Expressions;
 using RATools.Parser.Functions;
@@ -75,7 +76,22 @@ namespace RATools.Tests.Parser.Expressions
             Assert.That(innerScope.VariableCount, Is.EqualTo(0));
         }
 
-        private FunctionDefinitionExpression Parse(string input)
+        [Test]
+        public void TestParseTrailingComma()
+        {
+            var group = new ExpressionGroup();
+            var tokenizer = new ExpressionTokenizer(Tokenizer.CreateTokenizer("func(i,)"), group);
+            var functionCall = ExpressionBase.Parse(tokenizer);
+
+            // function call is still returned for parsing completeness
+            Assert.That(functionCall, Is.InstanceOf<FunctionCallExpression>());
+
+            var parseError = group.ParseErrors.First();
+            Assert.That(parseError.Message, Is.EqualTo("Trailing comma in parameter list"));
+            Assert.That(parseError.Location, Is.EqualTo(new TextRange(1, 7, 1, 8)));
+        }
+
+        private static FunctionDefinitionExpression Parse(string input)
         {
             var def = UserFunctionDefinitionExpression.ParseForTest(input);
             Assert.That(def, Is.Not.Null);
@@ -334,6 +350,7 @@ namespace RATools.Tests.Parser.Expressions
             var parseError = (ErrorExpression)result;
             Assert.That(parseError.InnermostError.Message, Is.EqualTo("Unknown variable: var"));
         }
+
         [Test]
         public void TestReplaceVariablesUnknownParameter()
         {


### PR DESCRIPTION
instead of the more generic "unexpected character )" and "invalid expression" errors.

https://discord.com/channels/310192285306454017/936655398725902356/1107470058663444521