### PR TITLE
allow 'constants' to be used as values in default parameters

### DIFF
--- a/Source/Parser/Internal/ExpressionBase.cs
+++ b/Source/Parser/Internal/ExpressionBase.cs
@@ -55,7 +55,7 @@ namespace RATools.Parser.Internal
         /// </summary>
         internal void CopyLocation(ExpressionBase target)
         {
-            if (!Location.IsEmpty && !target.IsReadOnly)
+            if (Location.End.Line != 0 && !target.IsReadOnly)
                 target.Location = Location;
         }
 


### PR DESCRIPTION
Fixes #395

Because the error is being generated when parsing, there's no context to know whether or not the variable is actually defined, or what its value is. To work around that, I've opted to allow variables to be assigned to default parameters, but not variable expressions (i.e. "param3=a" is okay, but "param3=a+1" is not.)

As a result, the default parameter becomes a variable reference, which is evaluated when the function is called. Assuming this functionality is only used with "constant" variables, the user won't notice.