### PR TITLE
fix dumping measured(tally(0, X && Y))

### DIFF
--- a/Source/Data/Requirement.cs
+++ b/Source/Data/Requirement.cs
@@ -190,7 +190,23 @@ namespace RATools.Data
                 case RequirementType.Measured:
                 case RequirementType.MeasuredPercent:
                     builder.Append("measured(");
-                    AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress, resetNextIf);
+
+                    // if there's no HitTarget and there's an AndNext or OrNext clause, assume we're counting
+                    // complex conditions for a Value clause and wrap it in a "tally(0, ...)"
+                    if (HitCount == 0 && !String.IsNullOrEmpty(andNext))
+                    {
+                        var measuredClause = new StringBuilder();
+                        AppendRepeatedCondition(measuredClause, numberFormat, addSources, subSources, addHits, andNext, addAddress, resetNextIf);
+
+                        builder.Append("tally(0, ");
+                        builder.Append(RemoveOuterParentheses(measuredClause.ToString()));
+                        builder.Append(')');
+                    }
+                    else
+                    {
+                        AppendRepeatedCondition(builder, numberFormat, addSources, subSources, addHits, andNext, addAddress, resetNextIf);
+                    }
+
                     if (measuredIf != null)
                     {
                         builder.Append(", when=");

--- a/Tests/Data/RequirementExTests.cs
+++ b/Tests/Data/RequirementExTests.cs
@@ -58,6 +58,12 @@ namespace RATools.Tests.Data
                   "repeated(10, byte(0x002345) == 1 && byte(0x003456) == 2 && never(byte(0x001234) < 5 || byte(0x001234) > 8))")]
         [TestCase("Z:0xH004567=4_O:0xH001234=1_0xH002345=2.1.",
                   "once((byte(0x001234) == 1 || byte(0x002345) == 2) && never(byte(0x004567) == 4))")]
+        [TestCase("N:0xH001234=1_M:0xH002345=2.100.",
+                  "measured(repeated(100, byte(0x001234) == 1 && byte(0x002345) == 2))")]
+        [TestCase("N:0xH001234=1_M:0xH002345=2",
+                  "measured(tally(0, byte(0x001234) == 1 && byte(0x002345) == 2))")]
+        [TestCase("O:0xH001234=1_M:0xH002345=2",
+                  "measured(tally(0, byte(0x001234) == 1 || byte(0x002345) == 2))")]
         public void TestAppendString(string input, string expected)
         {
             var achievement = new AchievementBuilder();

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Regressions\**" />
+    <EmbeddedResource Remove="Regressions\**" />
+    <None Remove="Regressions\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />


### PR DESCRIPTION
fixes dumping syntax related to https://github.com/Jamiras/RATools/issues/396#issuecomment-1573783500