### PR TITLE
don't change ResetNextIf to ResetIf when attached to a Trigger condition

### DIFF
--- a/Source/Parser/AchievementBuilder.cs
+++ b/Source/Parser/AchievementBuilder.cs
@@ -1802,6 +1802,15 @@ namespace RATools.Parser
                             continue;
                         }
 
+                        if (lastRequirement.Type == RequirementType.Trigger)
+                        {
+                            // if the ResetNextIf is attached to a Trigger clause, assume there are other conditions
+                            // that would also be reset if the ResetNextIf were changed to a ResetIf and that would
+                            // cause the challenge indicator to be hidden.
+                            canExtract = false;
+                            continue;
+                        }
+
                         resetNextIfClauses.Add(requirementEx);
 
                         resetNextIsForPause |= (lastRequirement.Type == RequirementType.PauseIf);

--- a/Tests/Parser/AchievementBuilderTests.cs
+++ b/Tests/Parser/AchievementBuilderTests.cs
@@ -432,6 +432,10 @@ namespace RATools.Tests.Parser
         [TestCase("never(byte(0x001234) != 5) && (byte(0x002345) == 6 || once(byte(0x002345) == 7))", "never(byte(0x001234) != 5) && (byte(0x002345) == 6 || once(byte(0x002345) == 7))")] // if there's a HitCount anywhere, leave the ResetIf alone
         [TestCase("(measured(byte(0x1234) < 100) && unless(byte(0x1235) == 1)) || (measured(byte(0x1236) < 100) && unless(byte(0x1235) == 2))",
                   "(measured(byte(0x001234) < 100) && unless(byte(0x001235) == 1)) || (measured(byte(0x001236) < 100) && unless(byte(0x001235) == 2))")] // measured should prevent unless from being inverted
+        [TestCase("trigger_when(repeated(3, byte(0x1234) == 1) && never(byte(0x2345) == 2)", // don't convert ResetNextIf to ResetIf when attached to a challenge indicator
+                  "trigger_when(repeated(3, byte(0x001234) == 1 && never(byte(0x002345) == 2)))")]
+        [TestCase("trigger_when(repeated(3, byte(0x1234) == 1) && never(byte(0x2345) == 2)) && byte(0x3456) == 3", // don't convert ResetNextIf to ResetIf when attached to a challenge indicator
+                  "trigger_when(repeated(3, byte(0x001234) == 1 && never(byte(0x002345) == 2))) && byte(0x003456) == 3")]
         public void TestOptimizeNormalizeResetIfsAndPauseIfs(string input, string expected)
         {
             var achievement = CreateAchievement(input);


### PR DESCRIPTION
Closes #404 

While logically correct, converting a ResetNextIf attached to a Trigger condition into a ResetIf causes the challenge indicator to disappear when the ResetIf is true. Clearing the hits on the Trigger should not cause the challenge indicator to be hidden as long as the non-Trigger conditions remain true.