### PR TITLE
don't try to underflow comparisons to very large numbers

### DIFF
--- a/Source/Parser/Expressions/IntegerConstantExpression.cs
+++ b/Source/Parser/Expressions/IntegerConstantExpression.cs
@@ -44,7 +44,7 @@ namespace RATools.Parser.Expressions
         /// <summary>
         /// Returns <c>true</c> if the constant is numerically negative
         /// </summary>
-        public bool IsNegative
+        public virtual bool IsNegative
         {
             get { return Value < 0; }
         }
@@ -52,7 +52,7 @@ namespace RATools.Parser.Expressions
         /// <summary>
         /// Returns <c>true</c> if the constant is numerically positive
         /// </summary>
-        public bool IsPositive
+        public virtual bool IsPositive
         {
             get { return Value > 0; }
         }
@@ -91,36 +91,52 @@ namespace RATools.Parser.Expressions
             var integerExpression = right as IntegerConstantExpression;
             if (integerExpression != null)
             {
+                var newValue = 0;
                 switch (operation)
                 {
                     case MathematicOperation.Add:
-                        return new IntegerConstantExpression(Value + integerExpression.Value);
+                        newValue = Value + integerExpression.Value;
+                        break;
 
                     case MathematicOperation.Subtract:
-                        return new IntegerConstantExpression(Value - integerExpression.Value);
+                        newValue = Value - integerExpression.Value;
+                        break;
 
                     case MathematicOperation.Multiply:
-                        return new IntegerConstantExpression(Value * integerExpression.Value);
+                        newValue = Value * integerExpression.Value;
+                        break;
 
                     case MathematicOperation.Divide:
                         if (integerExpression.Value == 0)
                             return new ErrorExpression("Division by zero");
-                        return new IntegerConstantExpression(Value / integerExpression.Value);
+                        newValue = Value / integerExpression.Value;
+                        break;
 
                     case MathematicOperation.Modulus:
                         if (integerExpression.Value == 0)
                             return new ErrorExpression("Division by zero");
-                        return new IntegerConstantExpression(Value % integerExpression.Value);
+                        newValue = Value % integerExpression.Value;
+                        break;
 
                     case MathematicOperation.BitwiseAnd:
-                        return new IntegerConstantExpression(Value & integerExpression.Value);
+                        newValue = Value & integerExpression.Value;
+                        break;
 
                     case MathematicOperation.BitwiseXor:
-                        return new IntegerConstantExpression(Value ^ integerExpression.Value);
+                        newValue = Value ^ integerExpression.Value;
+                        break;
 
                     default:
                         break;
                 }
+
+                if (right is UnsignedIntegerConstantExpression ||
+                    this is UnsignedIntegerConstantExpression)
+                {
+                    return new UnsignedIntegerConstantExpression((uint)newValue);
+                }
+
+                return new IntegerConstantExpression(newValue);
             }
 
             if (right is FloatConstantExpression)
@@ -180,6 +196,39 @@ namespace RATools.Parser.Expressions
                 return new ComparisonExpression(right, ComparisonExpression.ReverseComparisonOperation(operation), this);
 
             return null;
+        }
+    }
+
+    internal class UnsignedIntegerConstantExpression : IntegerConstantExpression
+    {
+        public UnsignedIntegerConstantExpression(uint value)
+            : base((int)value)
+        {
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the constant is numerically negative
+        /// </summary>
+        public override bool IsNegative
+        {
+            get { return false; }
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the constant is numerically positive
+        /// </summary>
+        public override bool IsPositive
+        {
+            get { return Value != 0; }
+        }
+
+        /// <summary>
+        /// Appends the textual representation of this expression to <paramref name="builder" />.
+        /// </summary>
+        internal override void AppendString(StringBuilder builder)
+        {
+            builder.Append((uint)Value);
+            builder.Append('U');
         }
     }
 }

--- a/Source/Parser/Internal/ExpressionBase.cs
+++ b/Source/Parser/Internal/ExpressionBase.cs
@@ -480,8 +480,15 @@ namespace RATools.Parser.Internal
                     return new ErrorExpression("Number too large");
             }
 
-            if (value > Int32.MaxValue && !isUnsigned)
-                return new ErrorExpression("Number too large");
+            if (value > Int32.MaxValue)
+            { 
+                if (!isUnsigned)
+                    return new ErrorExpression("Number too large");
+
+                var unsignedIntegerExpression = new UnsignedIntegerConstantExpression(value);
+                unsignedIntegerExpression.Location = new TextRange(line, column, endLine, endColumn);
+                return unsignedIntegerExpression;
+            }
 
             var integerExpression = new IntegerConstantExpression((int)value);
             integerExpression.Location = new TextRange(line, column, endLine, endColumn);

--- a/Tests/Parser/Expressions/Trigger/ModifiedMemoryAcessorExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/ModifiedMemoryAcessorExpressionTests.cs
@@ -152,8 +152,6 @@ namespace RATools.Tests.Parser.Expressions.Trigger
             ExpressionType.Comparison, "float(0x001234) != 3.363636")]
         [TestCase("byte(0x001234) * 10", "=", "byte(0x002345) * 5",
             ExpressionType.Comparison, "byte(0x001234) * 2 == byte(0x002345)")]
-        [TestCase("byte(0x001234) * 10", "=", "byte(0x002345) * 3",
-            ExpressionType.Error, "Result can never be true using integer math")]
         [TestCase("byte(0x001234) * 10", "=", "byte(0x002345) / 3",
             ExpressionType.Comparison, "byte(0x001234) * 30 == byte(0x002345)")]
         [TestCase("byte(0x001234) / 10", "=", "byte(0x002345) * 3",
@@ -178,6 +176,18 @@ namespace RATools.Tests.Parser.Expressions.Trigger
             ExpressionType.None, null)] // division cannot be moved; multiplication cannot be extracted
         [TestCase("byte(0x001234) / byte(0x002345) * 10", ">", "80",
             ExpressionType.Comparison, "byte(0x001234) / byte(0x002345) > 8")]
+        [TestCase("byte(0x001234) * 10", "=", "byte(0x002345) * 8",
+            ExpressionType.Comparison, "byte(0x001234) * 10 - byte(0x002345) * 8 == 0U")] // comparison of two modified memory accesors results in subsource chain
+        [TestCase("byte(0x001234) * 10", "!=", "byte(0x002345) * 8",
+            ExpressionType.Comparison, "byte(0x001234) * 10 - byte(0x002345) * 8 != 0U")] // comparison of two modified memory accesors results in subsource chain
+        [TestCase("byte(0x001234) * 10", "<", "byte(0x002345) * 8",
+            ExpressionType.Comparison, "byte(0x001234) * 10 - byte(0x002345) * 8 >= 2147483648U")] // comparison of two modified memory accesors results in subsource chain
+        [TestCase("byte(0x001234) * 10", "<=", "byte(0x002345) * 8",
+            ExpressionType.Requirement, "byte(0x001234) * 10 - byte(0x002345) * 8 >= 2147483648U || byte(0x001234) * 10 - byte(0x002345) * 8 == 0U")] // comparison of two modified memory accesors results in subsource chain
+        [TestCase("byte(0x001234) * 10", ">", "byte(0x002345) * 8",
+            ExpressionType.Requirement, "byte(0x001234) * 10 - byte(0x002345) * 8 < 2147483648U && byte(0x001234) * 10 - byte(0x002345) * 8 != 0U")] // comparison of two modified memory accesors results in subsource chain
+        [TestCase("byte(0x001234) * 10", ">=", "byte(0x002345) * 8",
+            ExpressionType.Comparison, "byte(0x001234) * 10 - byte(0x002345) * 8 < 2147483648U")] // comparison of two modified memory accesors results in subsource chain
         public void TestNormalizeComparison(string left, string operation, string right, ExpressionType expectedType, string expected)
         {
             ExpressionTests.AssertNormalizeComparison(left, operation, right, expectedType, expected);

--- a/Tests/Parser/Expressions/Trigger/RequirementClauseExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementClauseExpression_Tests.cs
@@ -1,11 +1,9 @@
 using Jamiras.Components;
 using NUnit.Framework;
-using RATools.Data;
 using RATools.Parser;
 using RATools.Parser.Expressions;
 using RATools.Parser.Expressions.Trigger;
 using RATools.Parser.Internal;
-using System.Collections.Generic;
 
 namespace RATools.Tests.Parser.Expressions.Trigger
 {

--- a/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
@@ -54,6 +54,11 @@ namespace RATools.Tests.Parser.Expressions.Trigger
         [TestCase("low4(0x001234) * 10000000 + byte(0x1235) != prev(low4(0x002345)) * 10000000 + prev(byte(0x2346))", "A:0xL001234*10000000_B:d0xL002345*10000000_0xH001235!=d0xH002346")] // don't need underflow adjustment for inequality
         [TestCase("dword(dword(0x001234) + 8) - dword(dword(0x001234) + 12) > 100000", "A:100000_I:0xX001234_0xX00000c<0xX000008")] // AddAddress can be shared
         [TestCase("dword(dword(0x001234) + 8) - dword(dword(0x001234) + 12) * 4 > 100000", "I:0xX001234_B:0xX00000c*4_I:0xX001234_0xX000008>100000")] // AddAddress cannot be shared
+        [TestCase("word(0x18294A) * 10 - word(0x182946) * 8 < 0x80000000", "A:0x 18294a*10_B:0x 182946*8_0<2147483648")]
+        [TestCase("byte(0x1234) - byte(0x2345) == 1", "B:0xH002345=0_0xH001234=1")]
+        [TestCase("byte(0x1234) - byte(0x2345) == -1", "B:0xH001234=0_0xH002345=1")] // invert to eliminate negative value
+        [TestCase("byte(0x1234) - byte(0x2345) == 4294967295", "B:0xH002345=0_0xH001234=4294967295")] // don't invert very high positive value
+        [TestCase("byte(0x1234) - byte(0x2345) <= -1", "A:1=0_0xH001234<=0xH002345")]
         public void TestBuildTrigger(string input, string expected)
         {
             var clause = TriggerExpressionTests.Parse<RequirementConditionExpression>(input);
@@ -85,12 +90,12 @@ namespace RATools.Tests.Parser.Expressions.Trigger
         [TestCase("tbyte(0x001234) <= 16777215", "always_true()")]
         [TestCase("tbyte(0x001234) > 16777215", "always_false()")]
         [TestCase("tbyte(0x001234) >= 16777215", "tbyte(0x001234) == 16777215")]
-        [TestCase("dword(0x001234) == 4294967295", "dword(0x001234) == 4294967295")]
-        [TestCase("dword(0x001234) != 4294967295", "dword(0x001234) != 4294967295")]
-        [TestCase("dword(0x001234) < 4294967295", "dword(0x001234) < 4294967295")]
+        [TestCase("dword(0x001234) == 4294967295", "dword(0x001234) == 4294967295U")]
+        [TestCase("dword(0x001234) != 4294967295", "dword(0x001234) != 4294967295U")]
+        [TestCase("dword(0x001234) < 4294967295", "dword(0x001234) < 4294967295U")]
         [TestCase("dword(0x001234) <= 4294967295", "always_true()")]
         [TestCase("dword(0x001234) > 4294967295", "always_false()")]
-        [TestCase("dword(0x001234) >= 4294967295", "dword(0x001234) == 4294967295")]
+        [TestCase("dword(0x001234) >= 4294967295", "dword(0x001234) == 4294967295U")]
         [TestCase("bit3(0x001234) == 0", "bit3(0x001234) == 0")]
         [TestCase("bit3(0x001234) != 0", "bit3(0x001234) == 1")]
         [TestCase("bit3(0x001234) < 0", "always_false()")]


### PR DESCRIPTION
prevents infinite loop trying to process
```
(word(0x18294A) * 10 - word(0x182946) * 8) < 0x80000000
```
               