### PR TITLE
fix modification detection of AddSource constant

### DIFF
--- a/Source/Data/Requirement.cs
+++ b/Source/Data/Requirement.cs
@@ -651,14 +651,14 @@ namespace RATools.Data
                         result = true;
                         break;
 
-                    case RequirementOperator.Multiply:
-                    case RequirementOperator.Divide:
-                    case RequirementOperator.BitwiseAnd:
-                        return null;
-
-                    default:
+                    case RequirementOperator.NotEqual:
+                    case RequirementOperator.LessThan:
+                    case RequirementOperator.GreaterThan:
                         result = false;
                         break;
+
+                    default:
+                        return null;
                 }
             }
             else if (Left.Type == FieldType.Float || Right.Type == FieldType.Float)
@@ -688,8 +688,7 @@ namespace RATools.Data
                         result = (leftFloat >= rightFloat);
                         break;
                     default:
-                        result = false;
-                        break;
+                        return null;
                 }
             }
             else
@@ -716,8 +715,7 @@ namespace RATools.Data
                         result = (Left.Value >= Right.Value);
                         break;
                     default:
-                        result = false;
-                        break;
+                        return null;
                 }
             }
 

--- a/Tests/Data/RequirementTests.cs
+++ b/Tests/Data/RequirementTests.cs
@@ -14,6 +14,7 @@ namespace RATools.Tests.Data
             Byte2345,
             Word2345,
             Value99,
+            Value66,
         }
 
         private Field GetField(TestField field)
@@ -28,6 +29,8 @@ namespace RATools.Tests.Data
                     return new Field { Size = FieldSize.Word, Type = FieldType.MemoryAddress, Value = 0x2345 };
                 case TestField.Value99:
                     return new Field { Size = FieldSize.Byte, Type = FieldType.Value, Value = 99 };
+                case TestField.Value66:
+                    return new Field { Size = FieldSize.Byte, Type = FieldType.Value, Value = 66 };
                 default:
                     return new Field();
             }
@@ -99,6 +102,69 @@ namespace RATools.Tests.Data
         {
             var field = new Requirement();
             Assert.That(field.ToString(), Is.EqualTo("none"));
+        }
+
+        [Test]
+        [TestCase(TestField.Byte1234, RequirementOperator.Equal, TestField.Value99, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.NotEqual, TestField.Value99, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.LessThan, TestField.Value99, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.LessThanOrEqual, TestField.Value99, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.GreaterThan, TestField.Value99, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.GreaterThanOrEqual, TestField.Value99, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.Equal, TestField.Byte2345, null)]
+        [TestCase(TestField.Byte2345, RequirementOperator.Equal, TestField.Word2345, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.Equal, TestField.Byte1234, true)]
+        [TestCase(TestField.Byte1234, RequirementOperator.NotEqual, TestField.Byte2345, null)]
+        [TestCase(TestField.Byte2345, RequirementOperator.NotEqual, TestField.Word2345, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.NotEqual, TestField.Byte1234, false)]
+        [TestCase(TestField.Byte1234, RequirementOperator.NotEqual, TestField.Byte1234, false)]
+        [TestCase(TestField.Byte1234, RequirementOperator.LessThan, TestField.Byte1234, false)]
+        [TestCase(TestField.Byte1234, RequirementOperator.LessThanOrEqual, TestField.Byte1234, true)]
+        [TestCase(TestField.Byte1234, RequirementOperator.GreaterThan, TestField.Byte1234, false)]
+        [TestCase(TestField.Byte1234, RequirementOperator.GreaterThanOrEqual, TestField.Byte1234, true)]
+        [TestCase(TestField.Value66, RequirementOperator.Equal, TestField.Value99, false)]
+        [TestCase(TestField.Value66, RequirementOperator.NotEqual, TestField.Value99, true)]
+        [TestCase(TestField.Value66, RequirementOperator.LessThan, TestField.Value99, true)]
+        [TestCase(TestField.Value66, RequirementOperator.LessThanOrEqual, TestField.Value99, true)]
+        [TestCase(TestField.Value66, RequirementOperator.GreaterThan, TestField.Value99, false)]
+        [TestCase(TestField.Value66, RequirementOperator.GreaterThanOrEqual, TestField.Value99, false)]
+        [TestCase(TestField.Value66, RequirementOperator.Equal, TestField.Value66, true)]
+        [TestCase(TestField.Value66, RequirementOperator.NotEqual, TestField.Value66, false)]
+        [TestCase(TestField.Byte1234, RequirementOperator.Multiply, TestField.Value99, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.Multiply, TestField.Byte1234, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.Divide, TestField.Value99, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.BitwiseAnd, TestField.Value99, null)]
+        [TestCase(TestField.Value99, RequirementOperator.None, TestField.None, null)]
+        public void TestEvaluate(TestField left, RequirementOperator requirementOperator, TestField right, bool? expected)
+        {
+            var requirement = new Requirement
+            {
+                Left = GetField(left),
+                Operator = requirementOperator,
+                Right = GetField(right),
+            };
+
+            Assert.That(requirement.Evaluate(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase(TestField.Byte1234, RequirementOperator.Equal, TestField.Byte1234, 0, true)]
+        [TestCase(TestField.Byte1234, RequirementOperator.Equal, TestField.Byte1234, 1, true)]
+        [TestCase(TestField.Byte1234, RequirementOperator.Equal, TestField.Byte1234, 2, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.NotEqual, TestField.Byte1234, 0, false)]
+        [TestCase(TestField.Byte1234, RequirementOperator.NotEqual, TestField.Byte1234, 1, false)]
+        [TestCase(TestField.Byte1234, RequirementOperator.NotEqual, TestField.Byte1234, 2, false)]
+        public void TestEvaluateHitCount(TestField left, RequirementOperator requirementOperator, TestField right, int hitTarget, bool? expected)
+        {
+            var requirement = new Requirement
+            {
+                Left = GetField(left),
+                Operator = requirementOperator,
+                Right = GetField(right),
+                HitCount = (uint)hitTarget,
+            };
+
+            Assert.That(requirement.Evaluate(), Is.EqualTo(expected));
         }
 
         [Test]

--- a/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
@@ -59,6 +59,7 @@ namespace RATools.Tests.Parser.Expressions.Trigger
         [TestCase("byte(0x1234) - byte(0x2345) == -1", "B:0xH001234=0_0xH002345=1")] // invert to eliminate negative value
         [TestCase("byte(0x1234) - byte(0x2345) == 4294967295", "B:0xH002345=0_0xH001234=4294967295")] // don't invert very high positive value
         [TestCase("byte(0x1234) - byte(0x2345) <= -1", "A:1=0_0xH001234<=0xH002345")]
+        [TestCase("dword(0x1234) - prev(dword(0x1234)) >= 0x1000", "A:4096=0_d0xX001234<=0xX001234")]
         public void TestBuildTrigger(string input, string expected)
         {
             var clause = TriggerExpressionTests.Parse<RequirementConditionExpression>(input);


### PR DESCRIPTION
Fixes an issue where a modification to an AddSource constant would not be flagged as a modification.

Expected:
![image](https://github.com/Jamiras/RATools/assets/32680403/fbf86cd6-3e6f-4721-8f54-d70696ef2311)

Actual:
![image](https://github.com/Jamiras/RATools/assets/32680403/d22cbdd1-c243-4919-99ab-e481a37ae176)
