### PR TITLE
Add transform parameter to ascii_string_equals and unicode_string_equals

### DIFF
--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -101,6 +101,8 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new PrevPriorFunction("prior", FieldType.PriorValue));
                 _globalScope.AddFunction(new PrevPriorFunction("bcd", FieldType.BinaryCodedDecimal));
 
+                _globalScope.AddFunction(new IdentityTransformFunction());
+
                 _globalScope.AddFunction(new OnceFunction());
                 _globalScope.AddFunction(new RepeatedFunction());
                 _globalScope.AddFunction(new TallyFunction());

--- a/Source/Parser/Functions/IdentityTransformFunction.cs
+++ b/Source/Parser/Functions/IdentityTransformFunction.cs
@@ -1,0 +1,32 @@
+﻿using RATools.Parser.Expressions;
+using RATools.Parser.Internal;
+
+namespace RATools.Parser.Functions
+{
+    internal class IdentityTransformFunction : FunctionDefinitionExpression
+    {
+        public IdentityTransformFunction()
+            : base("identity_transform")
+        {
+            Parameters.Add(new VariableDefinitionExpression("accessor"));
+        }
+
+        public override bool ReplaceVariables(InterpreterScope scope, out ExpressionBase result)
+        {
+            return Evaluate(scope, out result);
+        }
+
+        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        {
+            var parameter = GetParameter(scope, "accessor", out result);
+            if (parameter == null)
+                return false;
+
+            if (!parameter.ReplaceVariables(scope, out result))
+                return false;
+
+            CopyLocation(result);
+            return true;
+        }
+    }
+}

--- a/Tests/Parser/Functions/UnicodeStringEqualsFunctionTests.cs
+++ b/Tests/Parser/Functions/UnicodeStringEqualsFunctionTests.cs
@@ -19,15 +19,19 @@ namespace RATools.Tests.Parser.Functions
         {
             var def = new UnicodeStringEqualsFunction();
             Assert.That(def.Name.Name, Is.EqualTo("unicode_string_equals"));
-            Assert.That(def.Parameters.Count, Is.EqualTo(3));
+            Assert.That(def.Parameters.Count, Is.EqualTo(4));
             Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("address"));
             Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("string"));
             Assert.That(def.Parameters.ElementAt(2).Name, Is.EqualTo("length"));
+            Assert.That(def.Parameters.ElementAt(3).Name, Is.EqualTo("transform"));
 
-            Assert.That(def.DefaultParameters.Count, Is.EqualTo(1));
+            Assert.That(def.DefaultParameters.Count, Is.EqualTo(2));
             Assert.That(def.DefaultParameters.ElementAt(0).Key, Is.EqualTo("length"));
             Assert.That(def.DefaultParameters.ElementAt(0).Value, Is.InstanceOf<IntegerConstantExpression>());
             Assert.That(((IntegerConstantExpression)def.DefaultParameters.ElementAt(0).Value).Value, Is.EqualTo(int.MaxValue));
+            Assert.That(def.DefaultParameters.ElementAt(1).Key, Is.EqualTo("transform"));
+            Assert.That(def.DefaultParameters.ElementAt(1).Value, Is.InstanceOf<FunctionReferenceExpression>());
+            Assert.That(((FunctionReferenceExpression)def.DefaultParameters.ElementAt(1).Value).Name, Is.EqualTo("identity_transform"));
         }
 
         [Test]
@@ -49,6 +53,37 @@ namespace RATools.Tests.Parser.Functions
             var expression = new FunctionCallExpression("unicode_string_equals", parameters);
             var scope = new InterpreterScope();
             scope.AddFunction(new UnicodeStringEqualsFunction());
+            scope.AddFunction(new IdentityTransformFunction());
+
+            ExpressionBase result;
+            Assert.IsTrue(expression.Evaluate(scope, out result));
+
+            Assert.That(result, Is.InstanceOf<RequirementClauseExpression>());
+            TriggerExpressionTests.AssertSerialize((RequirementClauseExpression)result, expected);
+        }
+
+        [Test]
+        [TestCase("0x1234", "me", 2, "d0xX001234=6619245")] // 0x0065006D
+        [TestCase("0x1234", "test", 3, "d0xX001234=6619252_d0x 001238=115")] // 0x00650074 0073
+        [TestCase("0x1234", "test", 5, "d0xX001234=6619252_d0xX001238=7602291_d0x 00123c=0")] // 0x00650074 00740073 0000
+        [TestCase("0x1234", "tęst", Int32.MaxValue, "d0xX001234=18415732_d0xX001238=7602291")] // 0x01190074 00740073
+        [TestCase("dword(0x1234)", "test1", 6, // 0x00650074 00740073 00000031
+            "I:0xX001234_d0xX000000=6619252_I:0xX001234_d0xX000004=7602291_I:0xX001234_d0xX000008=49")]
+        [TestCase("dword(dword(0x1234) + 8) + 0x2c", "test1", 6, // 0x00650074 00740073 00000031
+            "I:0xX001234_I:0xX000008_d0xX00002c=6619252_I:0xX001234_I:0xX000008_d0xX000030=7602291_I:0xX001234_I:0xX000008_d0xX000034=49")]
+        public void TestEvaluatePrev(string address, string input, int length, string expected)
+        {
+            var parameters = new List<ExpressionBase>();
+            parameters.Add(ExpressionTests.Parse(address));
+            parameters.Add(new StringConstantExpression(input));
+            parameters.Add(new IntegerConstantExpression(length));
+            parameters.Add(new FunctionReferenceExpression("prev"));
+
+            var expression = new FunctionCallExpression("unicode_string_equals", parameters);
+            var scope = new InterpreterScope();
+            scope.AddFunction(new UnicodeStringEqualsFunction());
+            scope.AddFunction(new IdentityTransformFunction());
+            scope.AddFunction(new PrevPriorFunction("prev", RATools.Data.FieldType.PreviousValue));
 
             ExpressionBase result;
             Assert.IsTrue(expression.Evaluate(scope, out result));


### PR DESCRIPTION
Allows passing `prev`, `prior`, or even a custom function to modify each chunk of the generated comparison.

https://discord.com/channels/310192285306454017/936655398725902356/1124756200001634387

```
ascii_string_equals(0x1234, "banana", transform = a => prev(a))    
```

becomes
```
d0xX001234=1634623842_d0x 001238=24942
```

and because `prev` is already a function that accepts a single accessor parameter an returns an accessor, it can be used directly:
```
ascii_string_equals(0x1234, "banana", transform = prev)    
```