### PR TITLE
fix issue parsing code note containing bitflags string and array size notation

### DIFF
--- a/Source/Data/CodeNote.cs
+++ b/Source/Data/CodeNote.cs
@@ -77,6 +77,7 @@ namespace RATools.Data
                         if (Char.IsLetter(c) && c != 's' && c != 'S')
                         {
                             bitIndex = token.IndexOf("bit", StringComparison.OrdinalIgnoreCase);
+                            byteIndex = token.IndexOf("byte", StringComparison.OrdinalIgnoreCase);
                             continue;
                         }
                     }

--- a/Tests/Data/CodeNoteTests.cs
+++ b/Tests/Data/CodeNoteTests.cs
@@ -98,6 +98,8 @@ namespace RATools.Data.Tests
 
         [TestCase("100 32-bit pointers [400 bytes]", 400, FieldSize.DWord)]
         [TestCase("[400 bytes] 100 32-bit pointers", 400, FieldSize.None)]
+
+        [TestCase("Bitflags (array of ~40 bytes)", 40, FieldSize.None)]
         public void TestGetSizeFromNote(string note, int expectedLength, FieldSize expectedFieldSize)
         {
             var n = new CodeNote(1, note);


### PR DESCRIPTION
fixes #428 

It's choking on the code note:
```
Bitflags for Sea chart (possible array of ~40 bytes)
```

It sees both "bit" and "byte" in the same string. After it discards the "bit" portion because it's not explicitly "bit" or "bits", the offset it found for "byte" is no longer correct and results in a read past the end of the string.