### PR TITLE
fix anonymous function error using boolean variable directly in if statement

### DIFF
--- a/Source/Parser/Expressions/VariableExpression.cs
+++ b/Source/Parser/Expressions/VariableExpression.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using RATools.Data;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -84,6 +85,24 @@ namespace RATools.Parser.Expressions
             }
 
             return value.ReplaceVariables(scope, out result);
+        }
+
+        /// <summary>
+        /// Determines whether the expression evaluates to true for the provided <paramref name="scope"/>
+        /// </summary>
+        /// <param name="scope">The scope object containing variable values.</param>
+        /// <param name="error">[out] The error that prevented evaluation (or null if successful).</param>
+        /// <returns>The result of evaluating the expression</returns>
+        public override bool? IsTrue(InterpreterScope scope, out ErrorExpression error)
+        {
+            ExpressionBase value;
+            if (!ReplaceVariables(scope, out value))
+            {
+                error = value as ErrorExpression;
+                return null;
+            }
+
+            return value.IsTrue(scope, out error);
         }
 
         IEnumerable<ExpressionBase> INestedExpressions.NestedExpressions

--- a/Tests/Parser/Expressions/IfExpressionTests.cs
+++ b/Tests/Parser/Expressions/IfExpressionTests.cs
@@ -122,6 +122,22 @@ namespace RATools.Parser.Tests.Expressions
         }
 
         [Test]
+        public void TestParseBooleanVariable()
+        {
+            var expr = Parse("if (someBoolean) { j = i }");
+
+            Assert.That(expr.Condition, Is.InstanceOf<VariableExpression>());
+            Assert.That(((VariableExpression)expr.Condition).Name, Is.EqualTo("someBoolean"));
+
+            Assert.That(expr.Expressions.Count, Is.EqualTo(1));
+            Assert.That(expr.ElseExpressions.Count, Is.EqualTo(0));
+
+            var builder = new StringBuilder();
+            expr.Expressions.First().AppendString(builder);
+            Assert.That(builder.ToString(), Is.EqualTo("j = i"));
+        }
+
+        [Test]
         public void TestNestedExpressions()
         {
             var expr = Parse("if (a == 3) { b = c + 4 } else { d = e }");

--- a/Tests/Parser/Expressions/VariableExpressionTests.cs
+++ b/Tests/Parser/Expressions/VariableExpressionTests.cs
@@ -77,6 +77,55 @@ namespace RATools.Parser.Tests.Expressions
         }
 
         [Test]
+        public void TestIsTrueBooleanTrue()
+        {
+            var variable = new VariableExpression("variable");
+            var value = new BooleanConstantExpression(true);
+
+            var scope = new InterpreterScope();
+            scope.AssignVariable(variable, value);
+
+            ErrorExpression error;
+            Assert.That(variable.IsTrue(scope, out error), Is.True);
+        }
+
+        [Test]
+        public void TestIsTrueBooleanFalse()
+        {
+            var variable = new VariableExpression("variable");
+            var value = new BooleanConstantExpression(false);
+
+            var scope = new InterpreterScope();
+            scope.AssignVariable(variable, value);
+
+            ErrorExpression error;
+            Assert.That(variable.IsTrue(scope, out error), Is.False);
+        }
+
+        [Test]
+        public void TestIsTrueInteger()
+        {
+            var variable = new VariableExpression("variable");
+            var value = new IntegerConstantExpression(0);
+
+            var scope = new InterpreterScope();
+            scope.AssignVariable(variable, value);
+
+            ErrorExpression error;
+            Assert.That(variable.IsTrue(scope, out error), Is.Null);
+        }
+
+        [Test]
+        public void TestIsTrueUndefined()
+        {
+            var variable = new VariableExpression("variable");
+            var scope = new InterpreterScope();
+
+            ErrorExpression error;
+            Assert.That(variable.IsTrue(scope, out error), Is.Null);
+        }
+
+        [Test]
         public void TestNestedExpressions()
         {
             var expr = new VariableExpression("variable1");


### PR DESCRIPTION
Fixes https://discord.com/channels/310192285306454017/533411674162593812/1201574594327347281

```
if (someBoolean)
{
    do_something()
}
```

was being parsed incorrectly. The `(someBoolean) { do_something() }` was being seen as an anonymous function definition. Then, when the `if` was evaluated, the anonymous function definition was not convertible to a boolean and an error was generated.

Solution: don't greedily assume anonymous function definition following an `if` keyword.
