### PR TITLE
add rascript-cli command line interpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .vs
 lib
 /Tests/Regressions
+**/launchSettings.json

--- a/RATools.sln
+++ b/RATools.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RATools.Parser", "Source\Pa
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RATools.Parser.Tests", "Tests\Parser\RATools.Parser.Tests.csproj", "{38F7E1F1-D759-4E0A-81B7-BF1EC773D9D2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "rascript-cli", "Source\rascript-cli\rascript-cli.csproj", "{6679BB28-DE37-4586-A4D6-0DA196C28380}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,18 @@ Global
 		{38F7E1F1-D759-4E0A-81B7-BF1EC773D9D2}.Release|x64.Build.0 = Release|Any CPU
 		{38F7E1F1-D759-4E0A-81B7-BF1EC773D9D2}.Release|x86.ActiveCfg = Release|Any CPU
 		{38F7E1F1-D759-4E0A-81B7-BF1EC773D9D2}.Release|x86.Build.0 = Release|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Debug|x64.Build.0 = Debug|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Debug|x86.Build.0 = Debug|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Release|x64.ActiveCfg = Release|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Release|x64.Build.0 = Release|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Release|x86.ActiveCfg = Release|Any CPU
+		{6679BB28-DE37-4586-A4D6-0DA196C28380}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Data/Achievement.cs
+++ b/Source/Data/Achievement.cs
@@ -96,17 +96,17 @@ namespace RATools.Data
             if (achievement.Id != 0)
             {
                 match = achievements.FirstOrDefault(a => a.Id == achievement.Id);
-                if (match != null)
+                if (match != null) // exact ID match, don't check anything else
                     return match;
-
-                if (achievement.Id < FirstLocalId) // explicit non-local ID can only match a non-local ID
-                    return null;
             }
+
+            // ignore achievements with non-local IDs. they're only eligible for matching by ID.
+            var localAchievements = achievements.Where(a => a.Id == 0 || a.Id >= FirstLocalId);
 
             // second pass - look for title match
             if (!String.IsNullOrEmpty(achievement.Title))
             {
-                match = achievements.FirstOrDefault(a => String.Compare(a.Title, achievement.Title, StringComparison.InvariantCultureIgnoreCase) == 0);
+                match = localAchievements.FirstOrDefault(a => String.Compare(a.Title, achievement.Title, StringComparison.InvariantCultureIgnoreCase) == 0);
                 if (match != null)
                     return match;
             }
@@ -114,7 +114,7 @@ namespace RATools.Data
             // third pass - look for description match
             if (!String.IsNullOrEmpty(achievement.Description))
             {
-                match = achievements.FirstOrDefault(a => String.Compare(a.Description, achievement.Description, StringComparison.InvariantCultureIgnoreCase) == 0);
+                match = localAchievements.FirstOrDefault(a => String.Compare(a.Description, achievement.Description, StringComparison.InvariantCultureIgnoreCase) == 0);
                 if (match != null)
                     return match;
             }

--- a/Source/Data/Achievement.cs
+++ b/Source/Data/Achievement.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace RATools.Data
 {
@@ -84,6 +86,42 @@ namespace RATools.Data
                 foreach (var alt in Trigger.Alts)
                     yield return alt.Requirements;
             }
+        }
+
+        public static Achievement FindMergeAchievement(IEnumerable<Achievement> achievements, Achievement achievement)
+        {
+            Achievement match;
+
+            // first pass - look for ID match
+            if (achievement.Id != 0)
+            {
+                match = achievements.FirstOrDefault(a => a.Id == achievement.Id);
+                if (match != null)
+                    return match;
+
+                if (achievement.Id < FirstLocalId) // explicit non-local ID can only match a non-local ID
+                    return null;
+            }
+
+            // second pass - look for title match
+            if (!String.IsNullOrEmpty(achievement.Title))
+            {
+                match = achievements.FirstOrDefault(a => String.Compare(a.Title, achievement.Title, StringComparison.InvariantCultureIgnoreCase) == 0);
+                if (match != null)
+                    return match;
+            }
+
+            // third pass - look for description match
+            if (!String.IsNullOrEmpty(achievement.Description))
+            {
+                match = achievements.FirstOrDefault(a => String.Compare(a.Description, achievement.Description, StringComparison.InvariantCultureIgnoreCase) == 0);
+                if (match != null)
+                    return match;
+            }
+
+            // TODO: attempt to match requirements
+
+            return null;
         }
     }
 

--- a/Source/Data/AssetBase.cs
+++ b/Source/Data/AssetBase.cs
@@ -51,5 +51,10 @@ namespace RATools.Data
         {
             get { return false; }
         }
+
+        /// <summary>
+        /// Gets the first unique identifier reserved for locally generated assets.
+        /// </summary>
+        public static readonly int FirstLocalId = 111000001;
     }
 }

--- a/Source/Data/Leaderboard.cs
+++ b/Source/Data/Leaderboard.cs
@@ -1,4 +1,8 @@
-﻿namespace RATools.Data
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RATools.Data
 {
     /// <summary>
     /// Defines a leaderboard.
@@ -145,6 +149,42 @@
                 default:
                     return "UNKNOWN";
             }
+        }
+
+        public static Leaderboard FindMergeLeaderboard(IEnumerable<Leaderboard> leaderboards, Leaderboard leaderboard)
+        {
+            Leaderboard match;
+
+            // first pass - look for ID match
+            if (leaderboard.Id != 0)
+            {
+                match = leaderboards.FirstOrDefault(l => l.Id == leaderboard.Id);
+                if (match != null)
+                    return match;
+
+                if (leaderboard.Id < FirstLocalId) // explicit non-local ID can only match a non-local ID
+                    return null;
+            }
+
+            // second pass - look for title match
+            if (!String.IsNullOrEmpty(leaderboard.Title))
+            {
+                match = leaderboards.FirstOrDefault(l => String.Compare(l.Title, leaderboard.Title, StringComparison.InvariantCultureIgnoreCase) == 0);
+                if (match != null)
+                    return match;
+            }
+
+            // third pass - look for description match
+            if (!String.IsNullOrEmpty(leaderboard.Description))
+            {
+                match = leaderboards.FirstOrDefault(l => String.Compare(l.Description, leaderboard.Description, StringComparison.InvariantCultureIgnoreCase) == 0);
+                if (match != null)
+                    return match;
+            }
+
+            // TODO: attempt to match requirements
+
+            return null;
         }
     }
 

--- a/Source/Data/Leaderboard.cs
+++ b/Source/Data/Leaderboard.cs
@@ -159,17 +159,17 @@ namespace RATools.Data
             if (leaderboard.Id != 0)
             {
                 match = leaderboards.FirstOrDefault(l => l.Id == leaderboard.Id);
-                if (match != null)
+                if (match != null) // exact ID match, don't check anything else
                     return match;
-
-                if (leaderboard.Id < FirstLocalId) // explicit non-local ID can only match a non-local ID
-                    return null;
             }
+
+            // ignore leaderboards with non-local IDs. they're only eligible for matching by ID.
+            var localLeaderboards = leaderboards.Where(a => a.Id == 0 || a.Id >= FirstLocalId);
 
             // second pass - look for title match
             if (!String.IsNullOrEmpty(leaderboard.Title))
             {
-                match = leaderboards.FirstOrDefault(l => String.Compare(l.Title, leaderboard.Title, StringComparison.InvariantCultureIgnoreCase) == 0);
+                match = localLeaderboards.FirstOrDefault(l => String.Compare(l.Title, leaderboard.Title, StringComparison.InvariantCultureIgnoreCase) == 0);
                 if (match != null)
                     return match;
             }
@@ -177,7 +177,7 @@ namespace RATools.Data
             // third pass - look for description match
             if (!String.IsNullOrEmpty(leaderboard.Description))
             {
-                match = leaderboards.FirstOrDefault(l => String.Compare(l.Description, leaderboard.Description, StringComparison.InvariantCultureIgnoreCase) == 0);
+                match = localLeaderboards.FirstOrDefault(l => String.Compare(l.Description, leaderboard.Description, StringComparison.InvariantCultureIgnoreCase) == 0);
                 if (match != null)
                     return match;
             }

--- a/Source/Data/RATools.Data.csproj
+++ b/Source/Data/RATools.Data.csproj
@@ -5,9 +5,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Platforms>AnyCPU</Platforms>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>disable</Nullable>
-    <UseWPF>true</UseWPF>
     <BaseOutputPath>..\..\bin\</BaseOutputPath>
   </PropertyGroup>
 

--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -210,26 +210,12 @@ namespace RATools.Parser
         internal ErrorExpression Error { get; private set; }
 
         /// <summary>
-        /// Processes the provided script.
+        /// Converts the provided script to a collection of expressions.
         /// </summary>
-        /// <returns>
-        /// <c>true</c> if the script was successfully processed, 
-        /// <c>false</c> if not - in which case <see cref="ErrorMessage"/> will indicate why.
-        /// </returns>
-        public bool Run(Tokenizer input)
+        public ExpressionGroupCollection Parse(Tokenizer input)
         {
             var expressionGroups = new AssetExpressionGroupCollection();
             expressionGroups.Parse(input);
-
-            if (Error == null)
-            {
-                foreach (var group in expressionGroups.Groups)
-                {
-                    Error = group.ParseErrors.FirstOrDefault();
-                    if (Error != null)
-                        return false;
-                }
-            }
 
             GameTitle = null;
             foreach (var comment in expressionGroups.Groups.First().Expressions.OfType<CommentExpression>())
@@ -242,6 +228,30 @@ namespace RATools.Parser
                 else if (GameTitle == null)
                 {
                     GameTitle = comment.Value.Substring(2).Trim();
+                }
+            }
+
+            return expressionGroups;
+        }
+
+        /// <summary>
+        /// Processes the provided script.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if the script was successfully processed, 
+        /// <c>false</c> if not - in which case <see cref="ErrorMessage"/> will indicate why.
+        /// </returns>
+        public bool Run(Tokenizer input)
+        {
+            var expressionGroups = Parse(input);
+
+            if (Error == null)
+            {
+                foreach (var group in expressionGroups.Groups)
+                {
+                    Error = group.ParseErrors.FirstOrDefault();
+                    if (Error != null)
+                        return false;
                 }
             }
 

--- a/Source/Parser/RATools.Parser.csproj
+++ b/Source/Parser/RATools.Parser.csproj
@@ -5,9 +5,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Platforms>AnyCPU</Platforms>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>disable</Nullable>
-    <UseWPF>true</UseWPF>
     <BaseOutputPath>..\..\bin\</BaseOutputPath>
   </PropertyGroup>
 

--- a/Source/RATools.csproj
+++ b/Source/RATools.csproj
@@ -17,12 +17,16 @@
   <ItemGroup>
     <Compile Remove="Data\**" />
     <Compile Remove="Parser\**" />
+    <Compile Remove="rascript-cli\**" />
     <EmbeddedResource Remove="Data\**" />
     <EmbeddedResource Remove="Parser\**" />
+    <EmbeddedResource Remove="rascript-cli\**" />
     <None Remove="Data\**" />
     <None Remove="Parser\**" />
+    <None Remove="rascript-cli\**" />
     <Page Remove="Data\**" />
     <Page Remove="Parser\**" />
+    <Page Remove="rascript-cli\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/ViewModels/AssetViewModelBase.cs
+++ b/Source/ViewModels/AssetViewModelBase.cs
@@ -449,7 +449,7 @@ namespace RATools.ViewModels
 
             if (Generated.Id != 0)
                 Id = Generated.Id;
-            else if (Local.Id > 111000000 && Published.Id != 0)
+            else if (Local.Id >= AssetBase.FirstLocalId && Published.Id != 0)
                 Id = Published.Id;
             else if (Local.Id != 0)
                 Id = Local.Id;

--- a/Source/ViewModels/GameViewModel.cs
+++ b/Source/ViewModels/GameViewModel.cs
@@ -268,7 +268,7 @@ namespace RATools.ViewModels
         private void UpdateTemporaryIds(List<ViewerViewModelBase> editors)
         {
             // find the maximum temporary id already assigned
-            int nextLocalId = 111000001;
+            int nextLocalId = AssetBase.FirstLocalId;
             foreach (var assetViewModel in editors.OfType<AssetViewModelBase>())
             {
                 var id = assetViewModel.Local.Id;
@@ -746,61 +746,69 @@ namespace RATools.ViewModels
             else
                 assetEditors.AddRange(editors.OfType<LeaderboardViewModel>());
 
-            // first pass - look for ID matches
-            for (int i = assetEditors.Count - 1; i >= 0; i--)
+            var achievements = new List<Achievement>();
+            var leaderboards = new List<Leaderboard>();
+            foreach (var editor in assetEditors)
             {
-                AssetBase mergeAsset = null;
-                var assetEditor = assetEditors[i];
-
-                if (assetEditor.Generated.Id > 0)
-                    mergeAsset = mergeAssets.FirstOrDefault(a => a.Id == assetEditor.Generated.Id);
-                if (mergeAsset == null && assetEditor.Published.Id > 0)
-                    mergeAsset = mergeAssets.FirstOrDefault(a => a.Id == assetEditor.Published.Id);
-
-                if (mergeAsset != null)
+                if (editor is AchievementViewModel)
                 {
-                    assign(assetEditor, mergeAsset);
-
-                    mergeAssets.Remove(mergeAsset);
-                    assetEditors.RemoveAt(i);
+                    var achievement = editor.Published.Asset as Achievement;
+                    if (achievement != null)
+                        achievements.Add(achievement);
+                    achievement = editor.Generated.Asset as Achievement;
+                    if (achievement != null)
+                        achievements.Add(achievement);
+                }
+                else if (editor is LeaderboardViewModel)
+                {
+                    var leaderboard = editor.Published.Asset as Leaderboard;
+                    if (leaderboard != null)
+                        leaderboards.Add(leaderboard);
+                    leaderboard = editor.Generated.Asset as Leaderboard;
+                    if (leaderboard != null)
+                        leaderboards.Add(leaderboard);
                 }
             }
 
-            // second pass - look for title matches
-            for (int i = mergeAssets.Count - 1; i >= 0; i--)
+            int j = 0;
+            while (j < mergeAssets.Count && assetEditors.Count > 0)
             {
-                var mergeAsset = mergeAssets[i];
-                var assetEditor = assetEditors.FirstOrDefault(a =>
-                    (String.Compare(a.Generated.Title.Text, mergeAsset.Title, StringComparison.InvariantCultureIgnoreCase) == 0 ||
-                     String.Compare(a.Published.Title.Text, mergeAsset.Title, StringComparison.InvariantCultureIgnoreCase) == 0)
-                );
+                var mergeAsset = mergeAssets[j];
 
-                if (assetEditor != null)
+                AssetBase match = null;
+                var achievement = mergeAsset as Achievement;
+                if (achievement != null)
+                    match = Achievement.FindMergeAchievement(achievements, achievement);
+
+                var leaderboard = mergeAsset as Leaderboard;
+                if (leaderboard != null)
+                    match = Leaderboard.FindMergeLeaderboard(leaderboards, leaderboard);
+
+                if (match == null)
                 {
-                    assign(assetEditor, mergeAsset);
+                    j++;
+                    continue;
+                }
 
-                    mergeAssets.RemoveAt(i);
-                    assetEditors.Remove(assetEditor);
+                for (int i = assetEditors.Count - 1; i >= 0; i--)
+                {
+                    var assetEditor = assetEditors[i];
+                    if (ReferenceEquals(assetEditor.Published.Asset, match) ||
+                        ReferenceEquals(assetEditor.Generated.Asset, match))
+                    {
+                        assign(assetEditor, mergeAsset);
+
+                        if (achievement != null)
+                            achievements.Remove(achievement);
+                        else if (leaderboard != null)
+                            leaderboards.Remove(leaderboard);
+
+                        mergeAssets.Remove(mergeAsset);
+                        assetEditors.RemoveAt(i);
+                        break;
+                    }
                 }
             }
-
-            // third pass - look for description matches
-            for (int i = mergeAssets.Count - 1; i >= 0; i--)
-            {
-                var mergeAsset = mergeAssets[i];
-                var assetEditor = assetEditors.FirstOrDefault(a =>
-                    String.Compare(a.Generated.Description.Text, mergeAsset.Description, StringComparison.InvariantCultureIgnoreCase) == 0);
-
-                if (assetEditor != null)
-                {
-                    assign(assetEditor, mergeAsset);
-
-                    mergeAssets.RemoveAt(i);
-                    assetEditors.Remove(assetEditor);
-                }
-            }
-
-            // TODO: attempt to match requirements
 
             // create new entries for each remaining unmerged achievement
             foreach (var mergeAsset in mergeAssets)

--- a/Source/ViewModels/GameViewModel.cs
+++ b/Source/ViewModels/GameViewModel.cs
@@ -793,20 +793,31 @@ namespace RATools.ViewModels
                 for (int i = assetEditors.Count - 1; i >= 0; i--)
                 {
                     var assetEditor = assetEditors[i];
-                    if (ReferenceEquals(assetEditor.Published.Asset, match) ||
-                        ReferenceEquals(assetEditor.Generated.Asset, match))
+                    if (ReferenceEquals(assetEditor.Published.Asset, match))
                     {
-                        assign(assetEditor, mergeAsset);
-
-                        if (achievement != null)
-                            achievements.Remove(achievement);
-                        else if (leaderboard != null)
-                            leaderboards.Remove(leaderboard);
-
-                        mergeAssets.Remove(mergeAsset);
-                        assetEditors.RemoveAt(i);
-                        break;
+                        achievement = assetEditor.Published.Asset as Achievement;
+                        leaderboard = assetEditor.Published.Asset as Leaderboard;
                     }
+                    else if (ReferenceEquals(assetEditor.Generated.Asset, match))
+                    {
+                        achievement = assetEditor.Generated.Asset as Achievement;
+                        leaderboard = assetEditor.Generated.Asset as Leaderboard;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+
+                    assign(assetEditor, mergeAsset);
+
+                    if (achievement != null)
+                        achievements.Remove(achievement);
+                    else if (leaderboard != null)
+                        leaderboards.Remove(leaderboard);
+
+                    mergeAssets.Remove(mergeAsset);
+                    assetEditors.RemoveAt(i);
+                    break;
                 }
             }
 

--- a/Source/rascript-cli/Program.cs
+++ b/Source/rascript-cli/Program.cs
@@ -1,0 +1,12 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using RATools;
+
+Jamiras.Services.CoreServices.RegisterServices();
+
+var cli = new RAScriptCLI();
+var result = cli.ProcessArgs(args);
+if (result == ReturnCode.Proceed)
+    result = cli.Run();
+
+return (int)result;

--- a/Source/rascript-cli/RAScriptCLI.cs
+++ b/Source/rascript-cli/RAScriptCLI.cs
@@ -1,0 +1,320 @@
+﻿using Jamiras.Components;
+using Jamiras.Services;
+using RATools.Data;
+using RATools.Parser;
+using RATools.Parser.Expressions;
+using System.Reflection;
+
+namespace RATools
+{
+    public class RAScriptCLI
+    {
+        public RAScriptCLI()
+            : this(ServiceRepository.Instance.FindService<IFileSystemService>())
+        {
+
+        }
+
+        protected RAScriptCLI(IFileSystemService fileSystemService)
+        {
+            _fileSystemService = fileSystemService;
+
+            OutputStream = Console.Out;
+            ErrorStream = Console.Error;
+            InputFile = "";
+            OutputDirectory = ".";
+            Author = "Author";
+        }
+
+        protected TextWriter OutputStream { get; set; }
+        protected TextWriter ErrorStream { get; set; }
+        protected string InputFile { get; set; }
+        protected string OutputDirectory { get; set; }
+        protected string Author { get; set; }
+        protected IFileSystemService _fileSystemService;
+
+        protected string _inputFileName = "";
+        protected bool _verbose = false;
+        protected bool _quiet = false;
+
+        public void Usage()
+        {
+            var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0.0";
+            if (version.EndsWith(".0"))
+                version = version.Substring(0, version.Length - 2);
+
+            OutputStream.WriteLine("rascript-cli " + version);
+            OutputStream.WriteLine("========================");
+            OutputStream.WriteLine("Usage: rascript-cli [-v] [-q] [-i script] [-o outdir] [-a author]");
+            OutputStream.WriteLine();
+            OutputStream.WriteLine("  -v            (optional) enabled verbose messages");
+            OutputStream.WriteLine("  -q            (optional) disable all messages");
+            OutputStream.WriteLine("  -i script     specifies the input file to process");
+            OutputStream.WriteLine("  -o outdir     (optional) specifies the output directory to write to [default: current directory]");
+            OutputStream.WriteLine("                will append RACache\\Data to the specified directory if an RACache\\Data subdirectoy exists");
+            OutputStream.WriteLine("  -a author     (optional) specifies the author to attribute the achievements to [default: Author]");
+        }
+
+        public ReturnCode ProcessArgs(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                Usage();
+                return ReturnCode.Success;
+            }
+
+            if (args.Any(a => a == "-v"))
+                _verbose = true;
+
+            if (args.Any(a => a == "-q"))
+            {
+                _verbose = false;
+                _quiet = true;
+            }
+
+            int i = 0;
+            while (i < args.Length)
+            {
+                if (args[i] == "-v" || args[i] == "-q")
+                {
+                    // verbose and quiet handled above
+                }
+                else if (args[i] == "-i")
+                {
+                    var inputFile = args[++i];
+                    if (!File.Exists(inputFile))
+                    {
+                        ErrorStream.WriteLine("File not found: " + inputFile);
+                        return ReturnCode.InvalidParmeter;
+                    }
+                    InputFile = File.ReadAllText(inputFile);
+                    _inputFileName = Path.GetFileName(inputFile);
+
+                    if (_verbose)
+                        OutputStream.WriteLine("Read {0} bytes from {1}", InputFile.Length, _inputFileName);
+
+                }
+                else if (args[i] == "-o")
+                {
+                    OutputDirectory = args[++i];
+                    if (!Directory.Exists(OutputDirectory))
+                    {
+                        ErrorStream.WriteLine("Directory not found: " + OutputDirectory);
+                        return ReturnCode.InvalidParmeter;
+                    }
+
+                    var subDirectory = Path.Combine(OutputDirectory, "RACache", "Data");
+                    if (Directory.Exists(subDirectory))
+                        OutputDirectory = subDirectory;
+                }
+                else if (args[i] == "-a")
+                {
+                    Author = args[++i];
+                }
+                else
+                {
+                    ErrorStream.WriteLine("Unknown parameters: " + args[i]);
+                    return ReturnCode.InvalidParmeter;
+                }
+
+                ++i;
+            }
+
+            if (_verbose)
+                OutputStream.WriteLine("Output directory set to: " + OutputDirectory);
+
+            return ReturnCode.Proceed;
+        }
+
+        private class ErrorReporter
+        {
+            public ErrorReporter(string input)
+            {
+                _input = input;
+                _tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
+                _currentLineText = "";
+                _currentLine = 0;
+            }
+
+            private readonly string _input;
+            private PositionalTokenizer _tokenizer;
+            private string _currentLineText;
+            private int _currentLine;
+
+            public void PrintError(TextWriter stream, ErrorExpression error)
+            {
+                while (error.InnerError != null)
+                {
+                    stream.Write("{0}:{1}: ", error.Location.Front.Line, error.Location.Front.Column);
+                    stream.WriteLine(error.Message);
+                    error = error.InnerError;
+                }
+
+                if (_currentLine > error.Location.Front.Line)
+                {
+                    _tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(_input));
+                    _currentLine = 0;
+                }
+
+                if (_currentLine < error.Location.Front.Line)
+                {
+                    while (_tokenizer.Line < error.Location.Front.Line && _tokenizer.NextChar != '\0')
+                    {
+                        _tokenizer.ReadTo('\n');
+                        _tokenizer.Advance();
+                    }
+
+                    _currentLine = _tokenizer.Line;
+                    _currentLineText = _tokenizer.ReadTo('\n').TrimRight().ToString();
+                    _tokenizer.Advance();
+                }
+
+                stream.Write("{0}:{1}: ", error.Location.Front.Line, error.Location.Front.Column);
+                Console.ForegroundColor = ConsoleColor.DarkRed;
+                stream.Write("error: ");
+                Console.ResetColor();
+                stream.WriteLine(error.Message);
+
+                stream.WriteLine(_currentLineText);
+                stream.Write(new String(' ', error.Location.Front.Column - 1));
+                Console.ForegroundColor = ConsoleColor.DarkGreen;
+                stream.Write('^');
+                if (error.Location.Front.Line == error.Location.Back.Line)
+                {
+                    var distance = error.Location.Back.Column - error.Location.Front.Column;
+                    if (distance > 0)
+                        stream.Write(new String('~', distance));
+                }
+                Console.ResetColor();
+                stream.WriteLine();
+            }
+        }
+
+        public ReturnCode Run()
+        {
+            if (_inputFileName == "")
+            {
+                ErrorStream.WriteLine("No input file specified");
+                return ReturnCode.InvalidParmeter;
+            }
+
+            var interpreter = new AchievementScriptInterpreter();
+            var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(InputFile));
+            var groups = interpreter.Parse(tokenizer);
+
+            if (_verbose)
+                OutputStream.WriteLine("Read {0} lines from {1}", tokenizer.Line, _inputFileName);
+
+            if (groups.Errors.Any())
+            {
+                if (_verbose)
+                    OutputStream.WriteLine("Found {0} parse errors", groups.Errors.Count());
+
+                var reporter = new ErrorReporter(InputFile);
+
+                foreach (var error in groups.Errors)
+                    reporter.PrintError(ErrorStream, error);
+
+                return ReturnCode.ParseError;
+            }
+
+            interpreter.Run(groups, null);
+
+            if (groups.HasEvaluationErrors)
+            {
+                if (_verbose)
+                    OutputStream.WriteLine("Found {0} evaluation errors", groups.Errors.Count());
+
+                var reporter = new ErrorReporter(InputFile);
+
+                foreach (var error in groups.Errors)
+                    reporter.PrintError(ErrorStream, error);
+
+                return ReturnCode.EvaluationError;
+            }
+
+            var outputFileName = Path.Combine(OutputDirectory, String.Format("{0}-User.txt", interpreter.GameId));
+            var localAchievements = new LocalAssets(outputFileName, _fileSystemService);
+            localAchievements.Title = interpreter.GameTitle ?? Path.GetFileNameWithoutExtension(_inputFileName);
+
+            if (_verbose)
+            {
+                OutputStream.WriteLine("Read {0} achievements and {1} leaderboards from {2}-User.txt",
+                    localAchievements.Achievements.Count(), localAchievements.Leaderboards.Count(), interpreter.GameId);
+            }
+
+            var existingAchievements = new List<Achievement>(localAchievements.Achievements);
+            foreach (var achievement in interpreter.Achievements)
+            {
+                var existingAchievement = Achievement.FindMergeAchievement(existingAchievements, achievement);
+                if (existingAchievement != null)
+                {
+                    existingAchievements.Remove(existingAchievement);
+                    achievement.Id = existingAchievement.Id;
+                }
+                localAchievements.Replace(existingAchievement, achievement);
+            }
+
+            var existingLeaderboards = new List<Leaderboard>(localAchievements.Leaderboards);
+            foreach (var leaderboard in interpreter.Leaderboards)
+            {
+                var existingLeaderboard = Leaderboard.FindMergeLeaderboard(existingLeaderboards, leaderboard);
+                if (existingLeaderboard != null)
+                {
+                    existingLeaderboards.Remove(existingLeaderboard);
+                    leaderboard.Id = existingLeaderboard.Id;
+                }
+                localAchievements.Replace(existingLeaderboard, leaderboard);
+            }
+            localAchievements.Commit(Author, null, null);
+
+            if (!_quiet)
+            {
+                OutputStream.WriteLine("Wrote {0} achievements and {1} leaderboards to {2}-User.txt",
+                    localAchievements.Achievements.Count(), localAchievements.Leaderboards.Count(), interpreter.GameId);
+            }
+
+            if (!String.IsNullOrEmpty(interpreter.RichPresence))
+            {
+                string richPresence;
+                var minimumVersion = Double.Parse(localAchievements.Version, System.Globalization.NumberFormatInfo.InvariantInfo);
+                if (minimumVersion < 1.0)
+                {
+                    interpreter.RichPresenceBuilder.DisableBuiltInMacros = true;
+
+                    if (minimumVersion < 0.79)
+                        interpreter.RichPresenceBuilder.DisableLookupCollapsing = true;
+
+                    richPresence = interpreter.RichPresenceBuilder.ToString();
+                }
+                else
+                {
+                    richPresence = interpreter.RichPresence;
+                }
+
+                outputFileName = Path.Combine(OutputDirectory, String.Format("{0}-Rich.txt", interpreter.GameId));
+                using (var stream = _fileSystemService.CreateFile(outputFileName))
+                {
+                    using (var writer = new StreamWriter(stream))
+                    {
+                        writer.Write(richPresence);
+                    }
+                }
+
+                if (!_quiet)
+                    OutputStream.WriteLine("Wrote {0} bytes to {1}-Rich.txt", richPresence.Length, interpreter.GameId);
+            }
+
+            return ReturnCode.Success;
+        }
+    }
+
+    public enum ReturnCode
+    {
+        Proceed = -1,
+        Success = 0,
+        InvalidParmeter = 1,
+        ParseError = 2,
+        EvaluationError = 3,
+    }
+}

--- a/Source/rascript-cli/rascript-cli.csproj
+++ b/Source/rascript-cli/rascript-cli.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\RATools.properties" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>RATools</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <BaseOutputPath>..\..\bin\</BaseOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Core\Source\Jamiras.Core.csproj" />
+    <ProjectReference Include="..\..\Source\Data\RATools.Data.csproj" />
+    <ProjectReference Include="..\..\Source\Parser\RATools.Parser.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/RATools.Tests.csproj
+++ b/Tests/RATools.Tests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\Core\UI\WPF\Source\Jamiras.UI.WPF.csproj" />
     <ProjectReference Include="..\Source\Data\RATools.Data.csproj" />
     <ProjectReference Include="..\Source\Parser\RATools.Parser.csproj" />
+    <ProjectReference Include="..\Source\rascript-cli\rascript-cli.csproj" />
     <ProjectReference Include="..\Source\RATools.csproj" />
     <ProjectReference Include="Data\RATools.Data.Tests.csproj" />
   </ItemGroup>

--- a/Tests/Regression/RegressionTests.cs
+++ b/Tests/Regression/RegressionTests.cs
@@ -48,9 +48,23 @@ namespace RATools.Tests.Regression
             var expectedFileContents = File.ReadAllText(expectedFileName);
             var outputFileContents = File.ReadAllText(outputFileName);
 
-            // file didn't match, report first difference
+            if (expectedFileContents != outputFileContents) 
+            {
+                AssertContents(outputFileContents, expectedFileContents);
+
+                // failed to find differing line, fallback to nunit assertion
+                FileAssert.AreEqual(expectedFileName, outputFileName);
+            }
+
+            // file matched, delete temporary file
+            File.Delete(outputFileName);
+        }
+
+        public static void AssertContents(string outputFileContents, string expectedFileContents)
+        {
             if (expectedFileContents != outputFileContents)
             {
+                // contents don't match. report first difference
                 var expectedFileTokenizer = Tokenizer.CreateTokenizer(expectedFileContents);
                 var outputFileTokenizer = Tokenizer.CreateTokenizer(outputFileContents);
 
@@ -63,14 +77,6 @@ namespace RATools.Tests.Regression
                     if (expectedFileLine != outputFileLine)
                     {
                         var message = "Line " + line;
-
-                        if (line == 1)
-                        {
-                            // if the first line is not a version, it's an error, dump the entire error
-                            if (outputFileLine.Contains(':'))
-                                message += "\n" + outputFileContents;
-                        }
-
                         Assert.AreEqual(expectedFileLine.ToString(), outputFileLine.ToString(), message);
                     }
 
@@ -79,13 +85,7 @@ namespace RATools.Tests.Regression
 
                     ++line;
                 } while (expectedFileTokenizer.NextChar != '\0' || outputFileTokenizer.NextChar != '\0');
-
-                // failed to find differing line, fallback to nunit assertion
-                FileAssert.AreEqual(expectedFileName, outputFileName);
             }
-
-            // file matched, delete temporary file
-            File.Delete(outputFileName);
         }
     }
 }


### PR DESCRIPTION
Allows rascript files to be processed from the command line for people who prefer to use other editors (like VSCode).

It does not provide the same feature set however. There's no way to see what changes are being applied to individual achievements, and only update specific achievements. The tool effectively does an Update Local with everything in the Update column checked. It will abort if there are _any_ errors.

The tool has one required parameter.
```
rascript-cli 1.13.0
========================
Usage: rascript-cli [-v] [-q] [-i script] [-o outdir] [-a author]

  -v            (optional) enabled verbose messages
  -q            (optional) disable all messages
  -i script     specifies the input file to process
  -o outdir     (optional) specifies the output directory to write to [default: current directory]
                will append RACache\Data to the specified directory if an RACache\Data subdirectoy exists
  -a author     (optional) specifies the author to attribute the achievements to [default: Author]
```

 `-i` specifies the path to the input file.
`-o` specifies the path to the output directory. If not provided, the current directory will be used.
`-a` specifies which author to use in the XXX-User.txt file. If not specified, `Author` will be used. When uploaded to the server, the logged in user will be attributed to the new achievements.
`-q` suppresses all output
`-v` adds additional output

Some examples:
![image](https://github.com/Jamiras/RATools/assets/32680403/b3627278-1735-4fa9-a9b2-a398e3fb2892)

The first run is a successful run. 20 achievements and 1 leaderboard were written to the XXX-User.txt file, and 987 bytes were written to the XXX-Rich.txt file.

The second run illustrates an error, and reflects the same error as would be reported in the UI:
![image](https://github.com/Jamiras/RATools/assets/32680403/f548f370-b890-4551-a25d-932e78b2385a)
