### PR TITLE
allow assigning values to nested dictionaries

### DIFF
--- a/Source/Parser/Expressions/AssignmentExpression.cs
+++ b/Source/Parser/Expressions/AssignmentExpression.cs
@@ -83,8 +83,19 @@ namespace RATools.Parser.Expressions
             }
             else
             {
-                if (!Value.ReplaceVariables(assignmentScope, out result))
-                    return (ErrorExpression)result;
+                var variable = Value as VariableExpression;
+                if (variable != null)
+                {
+                    result = variable.GetValue(assignmentScope);
+                    var error = result as ErrorExpression;
+                    if (error != null)
+                        return error;
+                }
+                else
+                {
+                    if (!Value.ReplaceVariables(assignmentScope, out result))
+                        return (ErrorExpression)result;
+                }
             }
 
             return scope.AssignVariable(Variable, result);

--- a/Source/Parser/Expressions/FunctionCallExpression.cs
+++ b/Source/Parser/Expressions/FunctionCallExpression.cs
@@ -1,5 +1,6 @@
 ﻿using RATools.Parser.Internal;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -201,25 +202,16 @@ namespace RATools.Parser.Expressions
             var variable = value as VariableExpression;
             if (variable != null)
             {
-                value = scope.GetVariable(variable.Name);
+                value = variable.GetValue(scope);
 
-                if (value == null)
-                {
-                    // could not find variable, fallback to VariableExpression.ReplaceVariables generating an error
-                    value = assignment.Value;
-                }
-                else
-                {
-                    // when a parameter is assigned to a variable that is an array or dictionary,
-                    // assume it has already been evaluated and pass it by reference. this is magnitudes
-                    // more performant, and allows the function to modify the data in the container.
-                    if (value.Type == ExpressionType.Dictionary || value.Type == ExpressionType.Array)
-                    {
-                        value = scope.GetVariableReference(variable.Name);
-                        assignment.Value.CopyLocation(value);
-                        return value;
-                    }
-                }
+                var error = value as ErrorExpression;
+                if (error != null)
+                    return new ErrorExpression("Invalid value for parameter: " + assignment.Variable.Name, assignment.Value) { InnerError = error };
+
+                if (value is VariableReferenceExpression)
+                    return value;
+
+                Debug.Assert(value != null);
             }
 
             if (value.IsConstant)

--- a/Tests/Parser/Expressions/DictionaryExpressionTests.cs
+++ b/Tests/Parser/Expressions/DictionaryExpressionTests.cs
@@ -1,10 +1,13 @@
 ﻿using Jamiras.Components;
 using NUnit.Framework;
 using RATools.Parser.Expressions;
+using RATools.Parser.Expressions.Trigger;
 using RATools.Parser.Internal;
+using RATools.Parser.Tests.Expressions.Trigger;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Windows.Input;
 
 namespace RATools.Parser.Tests.Expressions
 {
@@ -349,6 +352,34 @@ namespace RATools.Parser.Tests.Expressions
             ((INestedExpressions)expr).GetModifications(modifications);
 
             Assert.That(modifications.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestAddNestedEntry()
+        {
+            var dict = new DictionaryExpression();
+            var subdict = new DictionaryExpression();
+            var key = new IntegerConstantExpression(1);
+            dict.Add(key, subdict);
+
+            var scope = new InterpreterScope();
+            scope.DefineVariable(new VariableDefinitionExpression("dict"), dict);
+
+            var assignment = ExpressionTests.Parse<AssignmentExpression>("dict[1][2] = 3");
+            Assert.That(assignment.Evaluate(scope), Is.Null);
+
+            Assert.That(subdict.Entries.Count, Is.EqualTo(1));
+            var entry = subdict.Entries.First();
+            Assert.That(entry.Key, Is.EqualTo(new IntegerConstantExpression(2)));
+            Assert.That(entry.Value, Is.EqualTo(new IntegerConstantExpression(3)));
+
+            assignment = ExpressionTests.Parse<AssignmentExpression>("dict[1][2] = 4");
+            Assert.That(assignment.Evaluate(scope), Is.Null);
+
+            Assert.That(subdict.Entries.Count, Is.EqualTo(1));
+            entry = subdict.Entries.First();
+            Assert.That(entry.Key, Is.EqualTo(new IntegerConstantExpression(2)));
+            Assert.That(entry.Value, Is.EqualTo(new IntegerConstantExpression(4)));
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where modifying a nested dictionary did not work:
```
dict = {"a": {"b": 3} }
dict["a"]["b"] = 5
achievement("test", "test", dict["a"]["b"], trigger=...)
```
Would generate an achievement worth 3 points, not 5.

This is a result of the temporary variable used for storing `dict["a"]` evaluating the dictionary instead of referencing it. By evaluating it, a copy was made, and the `["b"] = 5` modification was applied to the copy.

The same problem occurs when using a non-anonymous intermediate variable:
```
dict = {"a": {"b": 3} }
t = dict["a"]
t["b"] = 5
achievement("test", "test", dict["a"]["b"], trigger=...)
```
`t` was a copy of `dict["a"]`, so the modification was applied to the copy.

When dictionaries (or arrays) are passed to a function, they're done so by reference, so the function can modify the dictionary. I've extended that logic to do assignments of dictionaries (and arrays) by reference. As such, both `t` and the temporary variable in the first example are references to the nested dictionary, allowing the modification to go through.

NOTE: This eliminates the ability to copy a dictionary (or array) just through assignment:
```
function MergeArrays(arr1, arr2)
{
    newArr = arr1 // <-- this now creates a reference
    for i in arr2
    {
        array_push(newArr, i) // <-- so i is now actually being pushed onto arr1
    }
    return newArr
}
```

needs to be changed to:
```
function MergeArrays(arr1, arr2)
{
    newArr = []
    for i in arr1
    {
        array_push(newArr, i)
    }
    for i in arr2
    {
        array_push(newArr, i)
    }
    return newArr
}
```

This also provides a performance improvement when working with nested dictionaries as copies of the subdictionaries are no longer made just to pull values from them.