### PR TITLE
Allow params... to be an array in FormatFunctions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,54 @@ After opening the project, open the Test > Windows > Test Explorer tool window a
 
 
 ## A Solid Snack's changes
-- Currently made it available for the format_string(), rich_presence_display() and rich_presence_conditional_display() to accept an array of parameters besides the normal functionality
+The following function can now accept an array of parameters
+
+- [`format(format_string, parameters...)`](https://github.com/Jamiras/RATools/wiki/Rich-Presence-Functions#rich_presence_conditional_displaycondition-format_string-parameters "format function RATools documentation")
+```
+area_names = {
+    1: "Downtown",
+    2: "Roof",
+    3: "Garden"
+}
+function getCurrentAreaNumber() {
+    return byte(0xAF10)
+}
+stringToFormat = "Area {0}: {1} | Heading to Area {2}: {3}"
+
+format(stringToFormat, [
+    getCurrentAreaNumber(), 
+    Area_names[getCurrentAreaNumber()], 
+    getNextAreaNumber(), 
+    stage_names[getNextAreaNumber()]
+])
+```
+> Output example: `Area 1: Downtown | Heading to area 3: Garden`
+
+- [`rich_presence_display(format_string, parameters...)`](https://github.com/Jamiras/RATools/wiki/Rich-Presence-Functions#rich_presence_conditional_displaycondition-format_string-parameters "rich_presence_display function RATools documentation")
+```
+stringToFormat = "Area {0}: {1} | Heading to area {2}: {3} | Time left: {4}"
+displayParameters = [
+    rich_presence_value("currentAreaNr", getCurrentStageNumber()),
+    rich_presence_lookup("currentAreaName", getCurrentStageNumber(), stage_names),
+    rich_presence_value("nextAreaNr", getNextAreaNumber()),
+    rich_presence_lookup("nextAreaName", getNextAreaNumber(), stage_names),
+    rich_presence_macro("Seconds", getTimeLeft()),
+]
+
+rich_presence_display(stringToFormat, displayParameters)
+```
+> Output in rich presence: `Stage 1: Downtown | Heading to 3: Garden | Time left: 02:21`
+- [`rich_presence_conditional_display(condition, format_string, parameters...)`](https://github.com/Jamiras/RATools/wiki/Rich-Presence-Functions#rich_presence_conditional_displaycondition-format_string-parameters "rich_presence_conditional_display function RATools documentation")
+```
+stringToFormat = "Area {0}: {1} | Heading to area {2}: {3} | Time left: {4}"
+function isTravelling() => word(0xACF6) == 0x3
+displayParameters = [
+    rich_presence_value("currentAreaNr", getCurrentStageNumber()),
+    rich_presence_lookup("currentAreaName", getCurrentStageNumber(), stage_names),
+    rich_presence_value("nextAreaNr", getNextAreaNumber()),
+    rich_presence_lookup("nextAreaName", getNextAreaNumber(), stage_names),
+    rich_presence_macro("Seconds", getTimeLeft()),
+]
+
+rich_presence_conditional_display(isTravelling(), stringToFormat, displayParameters)
+```

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Also contains some analysis tools for examining site data
 
 ## Unit Tests
 After opening the project, open the Test > Windows > Test Explorer tool window and press the Run All button. Individual tests (or groups of tests) can be run by right clicking on them and selecting Run Selected Tests.
+
+
+## A Solid Snack's changes
+- Currently made it available for the format_string(), rich_presence_display() and rich_presence_conditional_display() to accept an array of parameters besides the normal functionality

--- a/README.md
+++ b/README.md
@@ -48,18 +48,19 @@ displayParameters = [
 
 rich_presence_display(stringToFormat, displayParameters)
 ```
-> Output in rich presence: `Stage 1: Downtown | Heading to 3: Garden | Time left: 02:21`
+> Output in rich presence: `Stage 1: Downtown | Heading to 3: Garden`
 - [`rich_presence_conditional_display(condition, format_string, parameters...)`](https://github.com/Jamiras/RATools/wiki/Rich-Presence-Functions#rich_presence_conditional_displaycondition-format_string-parameters "rich_presence_conditional_display function RATools documentation")
 ```
-stringToFormat = "Area {0}: {1} | Heading to area {2}: {3} | Time left: {4}"
-function isTravelling() => word(0xACF6) == 0x3
+stringToFormat = "Area {0}: {1} | Heading to area {2}: {3} | Fuel left: {4}"
+function isTravelling() => bit0(0xACF6) == 1
 displayParameters = [
     rich_presence_value("currentAreaNr", getCurrentStageNumber()),
     rich_presence_lookup("currentAreaName", getCurrentStageNumber(), stage_names),
     rich_presence_value("nextAreaNr", getNextAreaNumber()),
     rich_presence_lookup("nextAreaName", getNextAreaNumber(), stage_names),
-    rich_presence_macro("Seconds", getTimeLeft()),
+    rich_presence_macro("Fixed2", getCurrentFuel()),
 ]
 
 rich_presence_conditional_display(isTravelling(), stringToFormat, displayParameters)
 ```
+> Output in rich presence: `Stage 1: Downtown | Heading to 3: Garden | Fuel left: 02:21`

--- a/Source/Parser/Functions/FormatFunction.cs
+++ b/Source/Parser/Functions/FormatFunction.cs
@@ -30,7 +30,7 @@ namespace RATools.Parser.Functions
             if (stringExpression == null)
                 return false;
 
-            var varargs = GetVarArgsParameter(scope, out result, stringExpression);
+            var varargs = GetVarArgsParameter(scope, out result, stringExpression, true);
             if (varargs == null)
                 return false;
 
@@ -66,7 +66,7 @@ namespace RATools.Parser.Functions
 
                 Int32 parameterIndex;
                 if (!Int32.TryParse(index.ToString(), out parameterIndex)
-                    || parameterIndex < 0 || parameterIndex >= varargs.Entries.Count)
+                   || parameterIndex < 0 || parameterIndex >= varargs.Entries.Count)
                 {
                     result = new ErrorExpression("Invalid parameter index: " + index.ToString(),
                                                       stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + positionalTokenColumn,

--- a/Source/Parser/Functions/FormatFunction.cs
+++ b/Source/Parser/Functions/FormatFunction.cs
@@ -66,7 +66,7 @@ namespace RATools.Parser.Functions
 
                 Int32 parameterIndex;
                 if (!Int32.TryParse(index.ToString(), out parameterIndex)
-                   || parameterIndex < 0 || parameterIndex >= varargs.Entries.Count)
+                    || parameterIndex < 0 || parameterIndex >= varargs.Entries.Count)
                 {
                     result = new ErrorExpression("Invalid parameter index: " + index.ToString(),
                                                       stringExpression.Location.Start.Line, stringExpression.Location.Start.Column + positionalTokenColumn,


### PR DESCRIPTION
## A Solid Snack's changes
The following function can now accept an array of parameters

- [`format(format_string, parameters...)`](https://github.com/Jamiras/RATools/wiki/Rich-Presence-Functions#rich_presence_conditional_displaycondition-format_string-parameters "format function RATools documentation")
```
area_names = {
    1: "Downtown",
    2: "Roof",
    3: "Garden"
}
function getCurrentAreaNumber() {
    return byte(0xAF10)
}
stringToFormat = "Area {0}: {1} | Heading to Area {2}: {3}"

format(stringToFormat, [
    getCurrentAreaNumber(), 
    Area_names[getCurrentAreaNumber()], 
    getNextAreaNumber(), 
    stage_names[getNextAreaNumber()]
])
```
> Output example: `Area 1: Downtown | Heading to area 3: Garden`

- [`rich_presence_display(format_string, parameters...)`](https://github.com/Jamiras/RATools/wiki/Rich-Presence-Functions#rich_presence_conditional_displaycondition-format_string-parameters "rich_presence_display function RATools documentation")
```
stringToFormat = "Area {0}: {1} | Heading to area {2}: {3} | Time left: {4}"
displayParameters = [
    rich_presence_value("currentAreaNr", getCurrentStageNumber()),
    rich_presence_lookup("currentAreaName", getCurrentStageNumber(), stage_names),
    rich_presence_value("nextAreaNr", getNextAreaNumber()),
    rich_presence_lookup("nextAreaName", getNextAreaNumber(), stage_names),
    rich_presence_macro("Seconds", getTimeLeft()),
]

rich_presence_display(stringToFormat, displayParameters)
```
> Output in rich presence: `Stage 1: Downtown | Heading to 3: Garden`
- [`rich_presence_conditional_display(condition, format_string, parameters...)`](https://github.com/Jamiras/RATools/wiki/Rich-Presence-Functions#rich_presence_conditional_displaycondition-format_string-parameters "rich_presence_conditional_display function RATools documentation")
```
stringToFormat = "Area {0}: {1} | Heading to area {2}: {3} | Fuel left: {4}"
function isTravelling() => bit0(0xACF6) == 1
displayParameters = [
    rich_presence_value("currentAreaNr", getCurrentStageNumber()),
    rich_presence_lookup("currentAreaName", getCurrentStageNumber(), stage_names),
    rich_presence_value("nextAreaNr", getNextAreaNumber()),
    rich_presence_lookup("nextAreaName", getNextAreaNumber(), stage_names),
    rich_presence_macro("Fixed2", getCurrentFuel()),
]

rich_presence_conditional_display(isTravelling(), stringToFormat, displayParameters)
```
> Output in rich presence: `Stage 1: Downtown | Heading to 3: Garden | Fuel left: 02:21`


It's a very small change in code, but one I actually use. So it would be nice if this could sneak into the master branch. 
There's no need to merge the README, that was something I just wrote down for reference.