### PR TITLE
add SerializationContext

### DIFF
--- a/Source/Data/Field.cs
+++ b/Source/Data/Field.cs
@@ -309,7 +309,7 @@ namespace RATools.Data
         /// <remarks>
         /// This is a custom serialization format.
         /// </remarks>
-        public void Serialize(StringBuilder builder, int addressWidth = 6)
+        public void Serialize(StringBuilder builder, SerializationContext serializationContext)
         {
             switch (Type)
             {
@@ -367,20 +367,8 @@ namespace RATools.Data
                 case FieldSize.BigEndianFloat: builder.Append("fB"); break;
             }
 
-            switch (addressWidth)
-            {
-                case 2:
-                    builder.AppendFormat("{0:x2}", Value);
-                    break;
-                case 4:
-                    builder.AppendFormat("{0:x4}", Value);
-                    break;
-                default:
-                    builder.AppendFormat("{0:x6}", Value);
-                    break;
-            }
+            builder.Append(serializationContext.FormatAddress(Value));
         }
-
 
         /// <summary>
         /// Creates a <see cref="Field"/> from a serialized value.

--- a/Source/Data/Requirement.cs
+++ b/Source/Data/Requirement.cs
@@ -248,6 +248,12 @@ namespace RATools.Data
 
             switch (Type)
             {
+                case RequirementType.ResetIf:
+                case RequirementType.PauseIf:
+                    if (HitCount > 0)
+                        minimumVersion = Version._0_73;
+                    break;
+
                 case RequirementType.AndNext:
                     minimumVersion = Version._0_76;
                     break;

--- a/Source/Data/Requirement.cs
+++ b/Source/Data/Requirement.cs
@@ -176,7 +176,7 @@ namespace RATools.Data
             return builder.ToString();
         }
 
-        public void Serialize(StringBuilder builder, double minimumVersion = 0.0, int addressWidth = 6)
+        public void Serialize(StringBuilder builder, SerializationContext serializationContext)
         {
             switch (Type)
             {
@@ -196,7 +196,7 @@ namespace RATools.Data
                 case RequirementType.Trigger: builder.Append("T:"); break;
             }
 
-            Left.Serialize(builder, addressWidth);
+            Left.Serialize(builder, serializationContext);
 
             if (IsScalable)
             {
@@ -207,12 +207,12 @@ namespace RATools.Data
                     case RequirementOperator.BitwiseAnd: builder.Append('&'); break;
                     case RequirementOperator.BitwiseXor: builder.Append('^'); break;
                     default:
-                        if (minimumVersion < 0.77)
+                        if (serializationContext.MinimumVersion < Version._0_77)
                             builder.Append("=0");
                         return;
                 }
 
-                Right.Serialize(builder, addressWidth);
+                Right.Serialize(builder, serializationContext);
             }
             else
             {
@@ -231,7 +231,7 @@ namespace RATools.Data
                     case RequirementOperator.None: return;
                 }
 
-                Right.Serialize(builder, addressWidth);
+                Right.Serialize(builder, serializationContext);
             }
 
             if (HitCount > 0)
@@ -242,39 +242,34 @@ namespace RATools.Data
             }
         }
 
-        public double MinimumVersion()
+        public SoftwareVersion MinimumVersion()
         {
-            double minVer = 0.30;
+            var minimumVersion = Version.MinimumVersion;
 
             switch (Type)
             {
                 case RequirementType.AndNext:
-                    // 0.76 21 Jun 2019
-                    minVer = 0.76;
+                    minimumVersion = Version._0_76;
                     break;
 
                 case RequirementType.AddAddress:
                 case RequirementType.Measured:
-                    // 0.77 30 Nov 2019
-                    minVer = 0.77;
+                    minimumVersion = Version._0_77;
                     break;
 
                 case RequirementType.MeasuredIf:
                 case RequirementType.OrNext:
-                    // 0.78 18 May 2020
-                    minVer = 0.78;
+                    minimumVersion = Version._0_78;
                     break;
 
                 case RequirementType.ResetNextIf:
                 case RequirementType.Trigger:
                 case RequirementType.SubHits:
-                    // 0.79 22 May 2021
-                    minVer = 0.79;
+                    minimumVersion = Version._0_79;
                     break;
 
                 case RequirementType.MeasuredPercent:
-                    // 1.0 29 Jan 2022
-                    minVer = 1.0;
+                    minimumVersion = Version._1_0;
                     break;
 
                 default:
@@ -286,15 +281,11 @@ namespace RATools.Data
                 case RequirementOperator.Multiply:
                 case RequirementOperator.Divide:
                 case RequirementOperator.BitwiseAnd:
-                    // 0.78 18 May 2020
-                    if (minVer < 0.78)
-                        minVer = 0.78;
+                    minimumVersion = minimumVersion.OrNewer(Version._0_78);
                     break;
 
                 case RequirementOperator.BitwiseXor:
-                    // 1.1 15 Nov 2022
-                    if (minVer < 1.1)
-                        minVer = 1.1;
+                    minimumVersion = minimumVersion.OrNewer(Version._1_1);
                     break;
 
                 default:
@@ -306,9 +297,7 @@ namespace RATools.Data
                 switch (type)
                 {
                     case FieldType.PriorValue:
-                        // 0.76 21 Jun 2019
-                        if (minVer < 0.76)
-                            minVer = 0.76;
+                        minimumVersion = minimumVersion.OrNewer(Version._0_76);
                         break;
 
                     default:
@@ -321,15 +310,11 @@ namespace RATools.Data
                 switch (size)
                 {
                     case FieldSize.TByte:
-                        // 0.77 30 Nov 2019
-                        if (minVer < 0.77)
-                            minVer = 0.77;
+                        minimumVersion = minimumVersion.OrNewer(Version._0_77);
                         break;
 
                     case FieldSize.BitCount:
-                        // 0.78 18 May 2020
-                        if (minVer < 0.78)
-                            minVer = 0.78;
+                        minimumVersion = minimumVersion.OrNewer(Version._0_78);
                         break;
 
                     case FieldSize.BigEndianWord:
@@ -337,21 +322,15 @@ namespace RATools.Data
                     case FieldSize.BigEndianDWord:
                     case FieldSize.Float:
                     case FieldSize.MBF32:
-                        // 1.0 29 Jan 2022
-                        if (minVer < 1.0)
-                            minVer = 1.0;
+                        minimumVersion = minimumVersion.OrNewer(Version._1_0);
                         break;
 
                     case FieldSize.LittleEndianMBF32:
-                        // 1.1 15 Nov 2022
-                        if (minVer < 1.1)
-                            minVer = 1.1;
+                        minimumVersion = minimumVersion.OrNewer(Version._1_1);
                         break;
 
                     case FieldSize.BigEndianFloat:
-                        // 1.3 TBD
-                        if (minVer < 1.3)
-                            minVer = 1.3;
+                        minimumVersion = minimumVersion.OrNewer(Version._1_3);
                         break;
 
                     default:
@@ -359,7 +338,7 @@ namespace RATools.Data
                 }
             }
 
-            return minVer;
+            return minimumVersion;
         }
 
         /// <summary>

--- a/Source/Data/SerializationContext.cs
+++ b/Source/Data/SerializationContext.cs
@@ -1,0 +1,50 @@
+﻿using Jamiras.Components;
+using System;
+using System.Text;
+
+namespace RATools.Data
+{
+    public class SerializationContext
+    {
+        public SerializationContext()
+        {
+            MinimumVersion = Version.Uninitialized;
+            AddressWidth = 6;
+        }
+
+        public SerializationContext WithVersion(SoftwareVersion newVersion)
+        {
+            return new SerializationContext
+            {
+                MinimumVersion = newVersion,
+                AddressWidth = AddressWidth
+            };
+        }
+
+        /// <summary>
+        /// Gets or sets the minimum DLL version to target.
+        /// </summary>
+        public SoftwareVersion MinimumVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of characters to use for addresses.
+        /// </summary>
+        public int AddressWidth { get; set; }
+
+        /// <summary>
+        /// Appends a padded address to the <paramref="builder"/>
+        /// </summary>
+        public string FormatAddress(uint address)
+        {
+            switch (AddressWidth)
+            {
+                case 2:
+                    return String.Format("{0:x2}", address);
+                case 4:
+                    return String.Format("{0:x4}", address);
+                default:
+                    return String.Format("{0:x6}", address);
+            }
+        }
+    }
+}

--- a/Source/Data/Version.cs
+++ b/Source/Data/Version.cs
@@ -1,0 +1,69 @@
+﻿using Jamiras.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RATools.Data
+{
+    public static class Version
+    {
+        public static readonly SoftwareVersion MinimumVersion = new SoftwareVersion(0, 30);
+        public static readonly SoftwareVersion Uninitialized = new SoftwareVersion(0, 0);
+
+        /// <summary>
+        /// 0.76 - 21 Jun 2019
+        ///  Flags: AndNext
+        /// </summary>
+        public static readonly SoftwareVersion _0_76 = new SoftwareVersion(0, 76);
+
+        /// <summary>
+        /// 0.77 - 30 Nov 2019
+        ///  Flags: AddAddress, Measured
+        ///  Sizes: TByte
+        ///  ValueFormats: TimeMinutes, TimeSecsAsMins
+        /// </summary>
+        public static readonly SoftwareVersion _0_77 = new SoftwareVersion(0, 77);
+
+        /// <summary>
+        /// 0.78 - 18 May 2020
+        ///  Flags: MeasuredIf, OrNext
+        ///  Operators: Multiply, Divide, BitwiseAnd
+        ///  Sizes: BitCount
+        /// </summary>
+        public static readonly SoftwareVersion _0_78 = new SoftwareVersion(0, 78);
+
+        /// <summary>
+        /// 0.79 - 22 May 2021
+        ///  Flags: ResetNextIf, Trigger, SubHits
+        ///  Other: RichPresence collapsed lookups
+        /// </summary>
+        public static readonly SoftwareVersion _0_79 = new SoftwareVersion(0, 79);
+
+        /// <summary>
+        /// 1.0 - 29 Jan 2022
+        ///  Flags: MeasuredPercent
+        ///  Sizes: WordBE, TByteBE, DWordBE, Float, MBF32
+        ///  ValueFormats: Float1-6
+        ///  Other: RichPresence built-in macros
+        /// </summary>
+        public static readonly SoftwareVersion _1_0 = new SoftwareVersion(1, 0);
+
+        /// <summary>
+        /// 1.1 - 15 Nov 2022
+        ///  Operators: BitwiseXor
+        ///  Sizes: MBF32LE
+        ///  Otehr: Local code notes
+        /// </summary>
+        public static readonly SoftwareVersion _1_1 = new SoftwareVersion(1, 1);
+
+        /// <summary>
+        /// 1.3 - TBD
+        ///  Sizes: FloatBE
+        ///  ValueFormats: Tens, Hundreds, Thousands, Fixed1-3
+        ///  Other: AchievementTypes
+        /// </summary>
+        public static readonly SoftwareVersion _1_3 = new SoftwareVersion(1, 3);
+    }
+}

--- a/Source/Data/Version.cs
+++ b/Source/Data/Version.cs
@@ -13,8 +13,27 @@ namespace RATools.Data
         public static readonly SoftwareVersion Uninitialized = new SoftwareVersion(0, 0);
 
         /// <summary>
+        /// 0.73 - 31 Aug 2018
+        ///  Other: RichPresence fallback values
+        /// </summary>
+        public static readonly SoftwareVersion _0_73 = new SoftwareVersion(0, 73);
+
+        /// <summary>
+        /// 0.74 - 8 Sep 2018
+        ///  No syntax features
+        /// </summary>
+        public static readonly SoftwareVersion _0_74 = new SoftwareVersion(0, 74);
+
+        /// <summary>
+        /// 0.75 - 4 Feb 2019
+        ///  No syntax features
+        /// </summary>
+        public static readonly SoftwareVersion _0_75 = new SoftwareVersion(0, 75);
+
+        /// <summary>
         /// 0.76 - 21 Jun 2019
         ///  Flags: AndNext
+        ///  Operand type: Prior         
         /// </summary>
         public static readonly SoftwareVersion _0_76 = new SoftwareVersion(0, 76);
 
@@ -57,6 +76,12 @@ namespace RATools.Data
         ///  Otehr: Local code notes
         /// </summary>
         public static readonly SoftwareVersion _1_1 = new SoftwareVersion(1, 1);
+
+        /// <summary>
+        /// 1.2 - 28 Mar 2023
+        ///  No syntax features
+        /// </summary>
+        public static readonly SoftwareVersion _1_2 = new SoftwareVersion(1, 2);
 
         /// <summary>
         /// 1.3 - TBD

--- a/Source/Parser/AchievementBuilder.cs
+++ b/Source/Parser/AchievementBuilder.cs
@@ -1,4 +1,5 @@
-﻿using RATools.Data;
+﻿using Jamiras.Components;
+using RATools.Data;
 using System;
 using System.Diagnostics;
 
@@ -82,12 +83,12 @@ namespace RATools.Parser
             };
         }
 
-        public static double GetMinimumVersion(Achievement achievement)
+        public static SoftwareVersion GetMinimumVersion(Achievement achievement)
         {
             var minimumVersion = achievement.Trigger.MinimumVersion();
 
             if (achievement.Type != AchievementType.Standard)
-                minimumVersion = Math.Max(minimumVersion, 1.3);
+                minimumVersion = minimumVersion.OrNewer(Data.Version._1_3);
 
             return minimumVersion;
         }
@@ -95,9 +96,9 @@ namespace RATools.Parser
         /// <summary>
         /// Creates a serialized requirements string from the core and alt groups of a provided <see cref="Achievement"/>.
         /// </summary>
-        public static string SerializeRequirements(Achievement achievement)
+        public static string SerializeRequirements(Achievement achievement, SerializationContext serializationContext)
         {
-            return achievement.Trigger.Serialize();
+            return achievement.Trigger.Serialize(serializationContext);
         }
 
         /// <summary>

--- a/Source/Parser/AchievementScriptContext.cs
+++ b/Source/Parser/AchievementScriptContext.cs
@@ -5,8 +5,14 @@ namespace RATools.Parser
 {
     public class AchievementScriptContext
     {
+        public AchievementScriptContext()
+        {
+            SerializationContext = new SerializationContext();
+        }
+
         public Dictionary<Achievement, int> Achievements { get; set; }
         public Dictionary<Leaderboard, int> Leaderboards { get; set; }
         public RichPresenceBuilder RichPresence { get; set; }
+        public SerializationContext SerializationContext { get; set; }
     }
 }

--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -277,8 +277,6 @@ namespace RATools.Parser
                 scope = new InterpreterScope(expressionGroups.Scope ?? GetGlobalScope()) { Context = scriptContext };
             }
 
-            SerializationContext = scriptContext.SerializationContext;
-
             expressionGroups.ResetErrors();
 
             bool result = true;
@@ -350,7 +348,7 @@ namespace RATools.Parser
                 }
             }
 
-            SoftwareVersion minimumVersion = Data.Version.Uninitialized;
+            SoftwareVersion minimumVersion = scriptContext.SerializationContext.MinimumVersion;
             foreach (var achievement in _achievements.Keys)
             {
                 var achievementMinimumVersion = AchievementBuilder.GetMinimumVersion(achievement);
@@ -363,12 +361,13 @@ namespace RATools.Parser
                 minimumVersion = minimumVersion.OrNewer(leaderboardMinimumVersion);
             }
 
-            _richPresence.DisableLookupCollapsing = (minimumVersion < Data.Version._0_79);
-            _richPresence.DisableBuiltInMacros = (minimumVersion < Data.Version._1_0);
+            minimumVersion = minimumVersion.OrNewer(RichPresenceBuilder.MinimumVersion());
+
+            SerializationContext = scriptContext.SerializationContext.WithVersion(minimumVersion);
 
             if (!String.IsNullOrEmpty(_richPresence.DisplayString))
             {
-                RichPresence = _richPresence.ToString();
+                RichPresence = _richPresence.Serialize(SerializationContext);
                 RichPresenceLine = _richPresence.Line;
             }
 

--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -91,6 +91,11 @@ namespace RATools.Parser
             _leaderboards[leaderboard] = 0;
         }
 
+        /// <summary>
+        /// Gets the serialization context of the interpreted script.
+        /// </summary>
+        public SerializationContext SerializationContext { get; private set; }
+
         public static ExpressionGroupCollection CreateExpressionGroupCollection()
         {
             return new AssetExpressionGroupCollection() { Scope = CreateScope() };
@@ -272,6 +277,8 @@ namespace RATools.Parser
                 scope = new InterpreterScope(expressionGroups.Scope ?? GetGlobalScope()) { Context = scriptContext };
             }
 
+            SerializationContext = scriptContext.SerializationContext;
+
             expressionGroups.ResetErrors();
 
             bool result = true;
@@ -343,23 +350,21 @@ namespace RATools.Parser
                 }
             }
 
-            double minimumVersion = 0.30;
+            SoftwareVersion minimumVersion = Data.Version.Uninitialized;
             foreach (var achievement in _achievements.Keys)
             {
                 var achievementMinimumVersion = AchievementBuilder.GetMinimumVersion(achievement);
-                if (achievementMinimumVersion > minimumVersion)
-                    minimumVersion = achievementMinimumVersion;
+                minimumVersion = minimumVersion.OrNewer(achievementMinimumVersion);
             }
 
             foreach (var leaderboard in _leaderboards.Keys)
             {
                 var leaderboardMinimumVersion = LeaderboardBuilder.GetMinimumVersion(leaderboard);
-                if (leaderboardMinimumVersion > minimumVersion)
-                    minimumVersion = leaderboardMinimumVersion;
+                minimumVersion = minimumVersion.OrNewer(leaderboardMinimumVersion);
             }
 
-            _richPresence.DisableLookupCollapsing = (minimumVersion < 0.79);
-            _richPresence.DisableBuiltInMacros = (minimumVersion < 1.0);
+            _richPresence.DisableLookupCollapsing = (minimumVersion < Data.Version._0_79);
+            _richPresence.DisableBuiltInMacros = (minimumVersion < Data.Version._1_0);
 
             if (!String.IsNullOrEmpty(_richPresence.DisplayString))
             {

--- a/Source/Parser/Expressions/MathematicExpression.cs
+++ b/Source/Parser/Expressions/MathematicExpression.cs
@@ -252,7 +252,7 @@ namespace RATools.Parser.Expressions
 
         private static ErrorExpression CreateCannotCombineError(ExpressionBase left, MathematicOperation operation, ExpressionBase right)
         {
-            return new ErrorExpression(string.Format("Cannot {0} {1} and {2}", GetOperatorVerb(operation), left.Type, right.Type));
+            return new ErrorExpression(string.Format("Cannot {0} {1} and {2}", GetOperatorVerb(operation), left.Type.ToLowerString(), right.Type.ToLowerString()));
         }
 
         private static bool MergeOperands(ExpressionBase left, MathematicOperation operation, ExpressionBase right, out ExpressionBase result)

--- a/Source/Parser/Expressions/Trigger/BehavioralRequirementExpression.cs
+++ b/Source/Parser/Expressions/Trigger/BehavioralRequirementExpression.cs
@@ -1,5 +1,4 @@
 ﻿using RATools.Data;
-using RATools.Parser.Functions;
 using RATools.Parser.Internal;
 using System;
 using System.Linq;

--- a/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
@@ -134,7 +134,7 @@ namespace RATools.Parser.Expressions.Trigger
             {
                 var trigger = left as ITriggerExpression;
                 if (trigger == null)
-                    return new ErrorExpression(string.Format("Cannot compare {0} in a trigger", left.Type), left);
+                    return new ErrorExpression(string.Format("Cannot compare {0} in a trigger", left.Type.ToLowerString()), left);
 
                 error = trigger.BuildTrigger(context);
             }
@@ -150,7 +150,7 @@ namespace RATools.Parser.Expressions.Trigger
                 lastRequirement.Right = FieldFactory.CreateField(right);
 
             if (lastRequirement.Right.Type == FieldType.None)
-                return new ErrorExpression(string.Format("Cannot compare {0} in a trigger", Right.Type), Right);
+                return new ErrorExpression(string.Format("Cannot compare {0} in a trigger", Right.Type.ToLowerString()), Right);
 
             lastRequirement.Operator = ConvertToRequirementOperator(comparison);
             return null;

--- a/Source/Parser/Functions/LeaderboardFunction.cs
+++ b/Source/Parser/Functions/LeaderboardFunction.cs
@@ -43,19 +43,23 @@ namespace RATools.Parser.Functions
                 return false;
             leaderboard.Description = stringExpression.Value;
 
-            leaderboard.Start = ProcessTrigger(scope, "start", out result);
+            var context = scope.GetContext<AchievementScriptContext>();
+            Debug.Assert(context != null);
+            var serializationContext = context.SerializationContext;
+
+            leaderboard.Start = ProcessTrigger(scope, "start", serializationContext, out result);
             if (leaderboard.Start == null)
                 return false;
 
-            leaderboard.Cancel = ProcessTrigger(scope, "cancel", out result);
+            leaderboard.Cancel = ProcessTrigger(scope, "cancel", serializationContext, out result);
             if (leaderboard.Cancel == null)
                 return false;
 
-            leaderboard.Submit = ProcessTrigger(scope, "submit", out result);
+            leaderboard.Submit = ProcessTrigger(scope, "submit", serializationContext, out result);
             if (leaderboard.Submit == null)
                 return false;
 
-            leaderboard.Value = ProcessValue(scope, "value", out result);
+            leaderboard.Value = ProcessValue(scope, "value", serializationContext, out result);
             if (leaderboard.Value == null)
                 return false;
 
@@ -85,22 +89,20 @@ namespace RATools.Parser.Functions
             if (functionCall != null && functionCall.FunctionName.Name == this.Name.Name)
                 sourceLine = functionCall.Location.Start.Line;
 
-            var context = scope.GetContext<AchievementScriptContext>();
-            Debug.Assert(context != null);
             context.Leaderboards[leaderboard] = sourceLine;
             return true;
         }
 
-        private string ProcessTrigger(InterpreterScope scope, string parameter, out ExpressionBase result)
+        private string ProcessTrigger(InterpreterScope scope, string parameter, SerializationContext serializationContext, out ExpressionBase result)
         {
             var expression = GetRequirementParameter(scope, parameter, out result);
             if (expression == null)
                 return null;
 
-            return TriggerBuilderContext.GetConditionString(expression, scope, out result);
+            return TriggerBuilderContext.GetConditionString(expression, scope, serializationContext, out result);
         }
 
-        private string ProcessValue(InterpreterScope scope, string parameter, out ExpressionBase result)
+        private static string ProcessValue(InterpreterScope scope, string parameter, SerializationContext serializationContext, out ExpressionBase result)
         {
             var expression = GetParameter(scope, parameter, out result);
             if (expression == null)
@@ -118,13 +120,13 @@ namespace RATools.Parser.Functions
                         if (builder.Length > 0)
                             builder.Append('$');
 
-                        builder.Append(ValueBuilderContext.GetValueString(value, scope, out result));
+                        builder.Append(ValueBuilderContext.GetValueString(value, scope, serializationContext, out result));
                     }
                     return builder.ToString();
                 }
             }
 
-            return ValueBuilderContext.GetValueString(expression, scope, out result);
+            return ValueBuilderContext.GetValueString(expression, scope, serializationContext, out result);
         }
     }
 

--- a/Source/Parser/Functions/RichPresenceConditionalDisplayFunction.cs
+++ b/Source/Parser/Functions/RichPresenceConditionalDisplayFunction.cs
@@ -1,5 +1,6 @@
 ﻿using RATools.Parser.Expressions;
 using RATools.Parser.Internal;
+using System.Diagnostics;
 
 namespace RATools.Parser.Functions
 {
@@ -19,7 +20,10 @@ namespace RATools.Parser.Functions
             if (expression == null)
                 return false;
 
-            var condition = TriggerBuilderContext.GetConditionString(expression, scope, out result);
+            var scriptContext = scope.GetContext<AchievementScriptContext>();
+            var serializationContext = (scriptContext != null) ? scriptContext.SerializationContext : new Data.SerializationContext();
+
+            var condition = TriggerBuilderContext.GetConditionString(expression, scope, serializationContext, out result);
             if (condition == null)
                 return false;
 

--- a/Source/Parser/Functions/RichPresenceLookupFunction.cs
+++ b/Source/Parser/Functions/RichPresenceLookupFunction.cs
@@ -1,6 +1,7 @@
 ﻿using RATools.Parser.Expressions;
 using RATools.Parser.Internal;
 using System;
+using System.Diagnostics;
 
 namespace RATools.Parser.Functions
 {
@@ -50,7 +51,10 @@ namespace RATools.Parser.Functions
                 }
             }
 
-            var value = ValueBuilderContext.GetValueString(expression, scope, out result);
+            var scriptContext = scope.GetContext<AchievementScriptContext>();
+            var serializationContext = (scriptContext != null) ? scriptContext.SerializationContext : new Data.SerializationContext();
+
+            var value = ValueBuilderContext.GetValueString(expression, scope, serializationContext, out result);
             if (value == null)
                 return false;
 

--- a/Source/Parser/Functions/RichPresenceMacroFunction.cs
+++ b/Source/Parser/Functions/RichPresenceMacroFunction.cs
@@ -2,6 +2,7 @@
 using RATools.Parser.Expressions;
 using RATools.Parser.Internal;
 using System;
+using System.Diagnostics;
 
 namespace RATools.Parser.Functions
 {
@@ -105,7 +106,10 @@ namespace RATools.Parser.Functions
             if (expression == null)
                 return false;
 
-            var value = ValueBuilderContext.GetValueString(expression, scope, out result);
+            var scriptContext = scope.GetContext<AchievementScriptContext>();
+            var serializationContext = (scriptContext != null) ? scriptContext.SerializationContext : new SerializationContext();
+
+            var value = ValueBuilderContext.GetValueString(expression, scope, serializationContext, out result);
             if (value == null)
                 return false;
 

--- a/Source/Parser/Functions/RichPresenceValueFunction.cs
+++ b/Source/Parser/Functions/RichPresenceValueFunction.cs
@@ -2,6 +2,7 @@
 using RATools.Parser.Expressions;
 using RATools.Parser.Internal;
 using System;
+using System.Diagnostics;
 
 namespace RATools.Parser.Functions
 {
@@ -85,7 +86,10 @@ namespace RATools.Parser.Functions
             if (expression == null)
                 return false;
 
-            var value = ValueBuilderContext.GetValueString(expression, scope, out result);
+            var scriptContext = scope.GetContext<AchievementScriptContext>();
+            var serializationContext = (scriptContext != null) ? scriptContext.SerializationContext : new SerializationContext();
+
+            var value = ValueBuilderContext.GetValueString(expression, scope, serializationContext, out result);
             if (value == null)
                 return false;
 

--- a/Source/Parser/Internal/TriggerBuilderContext.cs
+++ b/Source/Parser/Internal/TriggerBuilderContext.cs
@@ -512,7 +512,7 @@ namespace RATools.Parser.Internal
         /// <param name="scope">The scope.</param>
         /// <param name="result">[out] The error if not successful.</param>
         /// <returns><c>true</c> if successful, <c>false</c> if not.</returns>
-        public static string GetConditionString(ExpressionBase expression, InterpreterScope scope, out ExpressionBase result)
+        public static string GetConditionString(ExpressionBase expression, InterpreterScope scope, SerializationContext serializationContext, out ExpressionBase result)
         {
             var requirement = expression as RequirementExpressionBase;
             if (requirement == null)
@@ -525,7 +525,7 @@ namespace RATools.Parser.Internal
             if (!ProcessAchievementConditions(achievement, requirement, scope, out result))
                 return null;
 
-            return achievement.SerializeRequirements();
+            return achievement.SerializeRequirements(serializationContext);
         }
     }
 

--- a/Source/Parser/LeaderboardBuilder.cs
+++ b/Source/Parser/LeaderboardBuilder.cs
@@ -1,4 +1,5 @@
-﻿using RATools.Data;
+﻿using Jamiras.Components;
+using RATools.Data;
 using System;
 using System.Diagnostics;
 
@@ -80,32 +81,32 @@ namespace RATools.Parser
             };
         }
 
-        public static double GetMinimumVersion(Leaderboard leaderboard)
+        public static SoftwareVersion GetMinimumVersion(Leaderboard leaderboard)
         {
             var minimumVersion = GetMinimumVersion(leaderboard.Format);
 
             var trigger = Trigger.Deserialize(leaderboard.Start);
-            minimumVersion = Math.Max(minimumVersion, trigger.MinimumVersion());
+            minimumVersion = minimumVersion.OrNewer(trigger.MinimumVersion());
 
             trigger = Trigger.Deserialize(leaderboard.Cancel);
-            minimumVersion = Math.Max(minimumVersion, trigger.MinimumVersion());
+            minimumVersion = minimumVersion.OrNewer(trigger.MinimumVersion());
 
             trigger = Trigger.Deserialize(leaderboard.Submit);
-            minimumVersion = Math.Max(minimumVersion, trigger.MinimumVersion());
+            minimumVersion = minimumVersion.OrNewer(trigger.MinimumVersion());
 
             var value = Data.Value.Deserialize(leaderboard.Value);
-            minimumVersion = Math.Max(minimumVersion, value.MinimumVersion());
+            minimumVersion = minimumVersion.OrNewer(value.MinimumVersion());
 
             return minimumVersion;
         }
 
-        private static double GetMinimumVersion(ValueFormat format)
+        private static SoftwareVersion GetMinimumVersion(ValueFormat format)
         {
             switch (format)
             {
                 case ValueFormat.TimeMinutes:
                 case ValueFormat.TimeSecsAsMins:
-                    return 0.77;
+                    return Data.Version._0_77;
 
                 case ValueFormat.Float1:
                 case ValueFormat.Float2:
@@ -113,7 +114,7 @@ namespace RATools.Parser
                 case ValueFormat.Float4:
                 case ValueFormat.Float5:
                 case ValueFormat.Float6:
-                    return 1.0;
+                    return Data.Version._1_0;
 
                 case ValueFormat.Thousands:
                 case ValueFormat.Hundreds:
@@ -121,10 +122,10 @@ namespace RATools.Parser
                 case ValueFormat.Fixed1:
                 case ValueFormat.Fixed2:
                 case ValueFormat.Fixed3:
-                    return 1.3;
+                    return Data.Version._1_3;
 
                 default:
-                    return 0.0;
+                    return Data.Version.MinimumVersion;
             }
         }
     }

--- a/Source/Parser/LocalAssets.cs
+++ b/Source/Parser/LocalAssets.cs
@@ -35,11 +35,11 @@ namespace RATools.Parser
 
             _achievements = new List<Achievement>();
             _leaderboards = new List<Leaderboard>();
-            _notes = new Dictionary<int, string>();
+            _notes = new Dictionary<uint, string>();
             RichPresence = null;
 
             _filename = filename;
-            Version = "0.030";
+            Version = Data.Version.MinimumVersion;
 
             Read();
         }
@@ -49,7 +49,7 @@ namespace RATools.Parser
         private readonly List<string> _extraLines;
         private DateTime _lastSave;
 
-        public string Version { get; private set; }
+        public SoftwareVersion Version { get; private set; }
 
         /// <summary>
         /// Gets the title of the associated game.
@@ -79,12 +79,12 @@ namespace RATools.Parser
         /// <summary>
         /// Gets the notes read from the file.
         /// </summary>
-        public Dictionary<int, string> Notes
+        public Dictionary<uint, string> Notes
         {
             get { return _notes; }
         }
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private Dictionary<int, string> _notes;
+        private Dictionary<uint, string> _notes;
 
         public RichPresence RichPresence { get; private set; }
 
@@ -98,7 +98,10 @@ namespace RATools.Parser
 
                 using (var reader = new StreamReader(_fileSystemService.OpenFile(_filename, OpenFileMode.Read)))
                 {
-                    Version = reader.ReadLine();
+                    SoftwareVersion version;
+                    if (SoftwareVersion.TryParse(reader.ReadLine(), out version))
+                        Version = version;
+
                     Title = reader.ReadLine();
 
                     while (!reader.EndOfStream)
@@ -276,9 +279,9 @@ namespace RATools.Parser
 
             if (addressString.StartsWith("0x"))
             {
-                int address;
+                uint address;
                 addressString = addressString.SubToken(2);
-                if (Int32.TryParse(addressString.ToString(), System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.CurrentCulture, out address))
+                if (UInt32.TryParse(addressString.ToString(), System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.CurrentCulture, out address))
                     _notes[address] = note.ToString();
             }
         }
@@ -501,46 +504,45 @@ namespace RATools.Parser
         /// <summary>
         /// Commits the asset list back to the 'XXX-User.txt' file.
         /// </summary>
-        public void Commit(string author, StringBuilder warning, List<AssetBase> assetsToValidate)
+        public void Commit(string author, StringBuilder warning, SerializationContext serializationContext, List<AssetBase> assetsToValidate)
         {
-            double version = 0.30;
+            SoftwareVersion minimumVersion = Version;
 
             foreach (var achievement in _achievements)
             {
                 var achievementMinimumVersion = AchievementBuilder.GetMinimumVersion(achievement);
-                if (achievementMinimumVersion > version)
-                    version = achievementMinimumVersion;
+                minimumVersion = minimumVersion.OrNewer(achievementMinimumVersion);
             }
 
             foreach (var leaderboard in _leaderboards)
             {
                 var leaderboardMinimumVersion = LeaderboardBuilder.GetMinimumVersion(leaderboard);
-                if (leaderboardMinimumVersion > version)
-                    version = leaderboardMinimumVersion;
+                minimumVersion = minimumVersion.OrNewer(leaderboardMinimumVersion);
             }
 
-            if (_notes.Count > 0 && version < 1.1)
-                Version = "1.1";
-            else if (version > 0.30)
-                Version = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:F2}", version);
+            if (_notes.Count > 0)
+                minimumVersion = minimumVersion.OrNewer(Data.Version._1_1);
+
+            if (minimumVersion > serializationContext.MinimumVersion)
+                serializationContext = serializationContext.WithVersion(minimumVersion);
 
             using (var writer = new StreamWriter(_fileSystemService.CreateFile(_filename)))
             {
-                writer.WriteLine(Version);
+                writer.WriteLine(minimumVersion);
                 writer.WriteLine(Title);
 
                 foreach (var note in _notes)
                 {
-                    writer.Write("N0:0x{0:x6}:\"", note.Key);
+                    writer.Write("N0:0x{0}:\"", serializationContext.FormatAddress((uint)note.Key));
                     WriteEscaped(writer, note.Value);
                     writer.WriteLine("\"");
                 }
 
                 foreach (var achievement in _achievements)
-                    WriteAchievement(writer, author, achievement, (assetsToValidate == null || assetsToValidate.Contains(achievement)) ? warning : null);
+                    WriteAchievement(writer, author, achievement, serializationContext, (assetsToValidate == null || assetsToValidate.Contains(achievement)) ? warning : null);
 
                 foreach (var leaderboard in _leaderboards)
-                    WriteLeaderboard(writer, leaderboard, (assetsToValidate == null || assetsToValidate.Contains(leaderboard)) ? warning : null);
+                    WriteLeaderboard(writer, leaderboard, serializationContext, (assetsToValidate == null || assetsToValidate.Contains(leaderboard)) ? warning : null);
 
                 foreach (var line in _extraLines)
                     writer.WriteLine(line);
@@ -579,12 +581,12 @@ namespace RATools.Parser
             }
         }
 
-        private static void WriteAchievement(StreamWriter writer, string author, Achievement achievement, StringBuilder warning)
+        private static void WriteAchievement(StreamWriter writer, string author, Achievement achievement, SerializationContext serializationContext, StringBuilder warning)
         {
             writer.Write(achievement.Id);
             writer.Write(":\"");
 
-            var requirements = AchievementBuilder.SerializeRequirements(achievement);
+            var requirements = AchievementBuilder.SerializeRequirements(achievement, serializationContext);
             if (requirements.Length > AchievementMaxLength && warning != null)
             {
                 warning.AppendFormat("Achievement \"{0}\" exceeds serialized limit ({1}/{2})", achievement.Title, requirements.Length, AchievementMaxLength);
@@ -617,7 +619,7 @@ namespace RATools.Parser
             writer.WriteLine();
         }
 
-        private static void WriteLeaderboard(StreamWriter writer, Leaderboard leaderboard, StringBuilder warning)
+        private static void WriteLeaderboard(StreamWriter writer, Leaderboard leaderboard, SerializationContext serializationContext, StringBuilder warning)
         {
             writer.Write('L');
             writer.Write(leaderboard.Id);

--- a/Source/Parser/TriggerBuilder.cs
+++ b/Source/Parser/TriggerBuilder.cs
@@ -94,10 +94,10 @@ namespace RATools.Parser
         /// <summary>
         /// Creates a serialized requirements string from the core and alt groups.
         /// </summary>
-        public string SerializeRequirements()
+        public string SerializeRequirements(SerializationContext serializationContext)
         {
             var trigger = new Trigger(_core, _alts);
-            return trigger.Serialize();
+            return trigger.Serialize(serializationContext);
         }
 
         internal string RequirementsDebugString

--- a/Source/Parser/ValueBuilder.cs
+++ b/Source/Parser/ValueBuilder.cs
@@ -61,10 +61,10 @@ namespace RATools.Parser
         /// <summary>
         /// Creates a serialized requirements string from the core and alt groups.
         /// </summary>
-        public string SerializeRequirements()
+        public string SerializeRequirements(SerializationContext serializationContext)
         {
             var value = new Value(_values);
-            return value.Serialize();
+            return value.Serialize(serializationContext);
         }
 
 

--- a/Source/ViewModels/AchievementViewModel.cs
+++ b/Source/ViewModels/AchievementViewModel.cs
@@ -94,7 +94,7 @@ namespace RATools.ViewModels
                 var numberFormat = ServiceRepository.Instance.FindService<ISettings>().HexValues ? NumberFormat.Hexadecimal : NumberFormat.Decimal;
                 return new TriggerViewModel[]
                 {
-                    new TriggerViewModel("", achievement, numberFormat, _owner != null ? _owner.Notes : new TinyDictionary<int, string>())
+                    new TriggerViewModel("", achievement, numberFormat, _owner != null ? _owner.Notes : new Dictionary<uint, string>())
                 };
             }
 

--- a/Source/ViewModels/GameViewModel.cs
+++ b/Source/ViewModels/GameViewModel.cs
@@ -34,7 +34,7 @@ namespace RATools.ViewModels
             /* unit tests call this constructor directly and will provide their own Script object and don't need Resources */
             GameId = gameId;
             Title = title;
-            Notes = new Dictionary<int, string>();
+            Notes = new Dictionary<uint, string>();
             GoToSourceCommand = new DelegateCommand<int>(GoToSource);
 
             _publishedAchievements = new List<Achievement>();
@@ -76,7 +76,8 @@ namespace RATools.ViewModels
 
         internal int GameId { get; private set; }
         internal string RACacheDirectory { get; private set; }
-        internal Dictionary<int, string> Notes { get; private set; }
+        internal Dictionary<uint, string> Notes { get; private set; }
+        internal SerializationContext SerializationContext { get; set; }
 
         public ScriptViewModel Script { get; protected set; }
 
@@ -218,6 +219,8 @@ namespace RATools.ViewModels
 
             if (interpreter != null)
             {
+                SerializationContext = interpreter.SerializationContext;
+
                 GeneratedAchievementCount = interpreter.Achievements.Count();
                 editors.Capacity += GeneratedAchievementCount;
 
@@ -380,7 +383,8 @@ namespace RATools.ViewModels
 
             if (_localAchievementCommitSuspendCount == 0)
             {
-                _localAssets.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, validateAll ? null : new List<AssetBase>() { achievement });
+                _localAssets.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning,
+                    SerializationContext, validateAll ? null : new List<AssetBase>() { achievement });
                 LocalAchievementCount = _localAssets.Achievements.Count();
                 LocalAchievementPoints = _localAssets.Achievements.Sum(a => a.Points);
             }
@@ -416,7 +420,7 @@ namespace RATools.ViewModels
             }
 
             if (_localAchievementCommitSuspendCount == 0)
-                _localAssets.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, validateAll ? null : new List<AssetBase>() { leaderboard });
+                _localAssets.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, SerializationContext, validateAll ? null : new List<AssetBase>() { leaderboard });
         }
 
         internal void UpdateLocal(RichPresence richPresence, RichPresence localRichPresence, StringBuilder warning, bool validateAll)
@@ -449,7 +453,7 @@ namespace RATools.ViewModels
             }
 
             if (_localAchievementCommitSuspendCount == 0)
-                _localAssets.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, validateAll ? null : new List<AssetBase>() { _localAssets.RichPresence });
+                _localAssets.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, SerializationContext, validateAll ? null : new List<AssetBase>() { _localAssets.RichPresence });
         }
 
         private int _localAchievementCommitSuspendCount = 0;
@@ -465,7 +469,7 @@ namespace RATools.ViewModels
         {
             if (_localAchievementCommitSuspendCount > 0 && --_localAchievementCommitSuspendCount == 0)
             {
-                _localAssets.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, assetsToValidate);
+                _localAssets.Commit(ServiceRepository.Instance.FindService<ISettings>().UserName, warning, SerializationContext, assetsToValidate);
 
                 LocalAchievementCount = _localAssets.Achievements.Count();
                 LocalAchievementPoints = _localAssets.Achievements.Sum(a => a.Points);
@@ -608,7 +612,7 @@ namespace RATools.ViewModels
                     {
                         foreach (var note in notes.ObjectArrayValue)
                         {
-                            var address = Int32.Parse(note.GetField("Address").StringValue.Substring(2), System.Globalization.NumberStyles.HexNumber);
+                            var address = UInt32.Parse(note.GetField("Address").StringValue.Substring(2), System.Globalization.NumberStyles.HexNumber);
                             var text = note.GetField("Note").StringValue;
                             if (text.Length > 0 && text != "''") // a long time ago notes were "deleted" by setting their text to ''
                                 Notes[address] = text;

--- a/Source/ViewModels/LeaderboardViewModel.cs
+++ b/Source/ViewModels/LeaderboardViewModel.cs
@@ -52,7 +52,7 @@ namespace RATools.ViewModels
             {
                 var numberFormat = ServiceRepository.Instance.FindService<ISettings>().HexValues ? NumberFormat.Hexadecimal : NumberFormat.Decimal;
 
-                var notes = _owner != null ? _owner.Notes : new Dictionary<int, string>();
+                var notes = _owner != null ? _owner.Notes : new Dictionary<uint, string>();
 
                 triggers.Add(new TriggerViewModel("Start Conditions", leaderboard.Start, numberFormat, notes));
                 triggers.Add(new TriggerViewModel("Cancel Conditions", leaderboard.Cancel, numberFormat, notes));

--- a/Source/ViewModels/NewScriptDialogViewModel.cs
+++ b/Source/ViewModels/NewScriptDialogViewModel.cs
@@ -555,7 +555,7 @@ namespace RATools.ViewModels
             }
 
             string notes;
-            if (!_game.Notes.TryGetValue((int)field.Value, out notes))
+            if (!_game.Notes.TryGetValue(field.Value, out notes))
                 return null;
 
             var item = new MemoryItem(field.Value, field.Size, notes.Replace("\r\n", " ").Replace('\n', ' '));
@@ -828,7 +828,7 @@ namespace RATools.ViewModels
                 if (functionNameStyle != FunctionNameStyle.None)
                 {
                     string note;
-                    if (_game.Notes.TryGetValue((int)memoryItem.Address, out note))
+                    if (_game.Notes.TryGetValue(memoryItem.Address, out note))
                         memoryItem.UpdateFunctionName(functionNameStyle, note);
                 }
 
@@ -851,7 +851,7 @@ namespace RATools.ViewModels
                 var memoryItem = (MemoryItem)row.Model;
 
                 string note;
-                if (_game.Notes.TryGetValue((int)memoryItem.Address, out note))
+                if (_game.Notes.TryGetValue(memoryItem.Address, out note))
                     memoryItem.UpdateFunctionName(functionNameStyle, note);
             }
         }
@@ -1130,7 +1130,7 @@ namespace RATools.ViewModels
                 string notes = null;
                 if (dumpNotes != NoteDump.None)
                 {
-                    if (_game.Notes.TryGetValue((int)memoryItem.Address, out notes))
+                    if (_game.Notes.TryGetValue(memoryItem.Address, out notes))
                     {
                         if (String.IsNullOrEmpty(memoryItem.FunctionName))
                         {
@@ -1435,7 +1435,7 @@ namespace RATools.ViewModels
         private void DumpRichPresence(StreamWriter stream, RichPresenceMacro displayMacro, DumpAsset dumpRichPresence, NumberFormat numberFormat)
         {
             int index;
-            var notes = new Dictionary<int, string>();
+            var notes = new Dictionary<uint, string>();
 
             foreach (var line in displayMacro.DisplayLines)
             {

--- a/Source/ViewModels/RequirementComparisonViewModel.cs
+++ b/Source/ViewModels/RequirementComparisonViewModel.cs
@@ -7,7 +7,7 @@ namespace RATools.ViewModels
 {
     public class RequirementComparisonViewModel : RequirementViewModel
     {
-        public RequirementComparisonViewModel(Requirement requirement, Requirement compareRequirement, NumberFormat numberFormat, IDictionary<int, string> notes)
+        public RequirementComparisonViewModel(Requirement requirement, Requirement compareRequirement, NumberFormat numberFormat, IDictionary<uint, string> notes)
             : base(requirement, numberFormat, notes)
         {
             if (compareRequirement == null)

--- a/Source/ViewModels/RequirementGroupViewModel.cs
+++ b/Source/ViewModels/RequirementGroupViewModel.cs
@@ -12,7 +12,7 @@ namespace RATools.ViewModels
     [DebuggerDisplay("{Label}")]
     public class RequirementGroupViewModel : ViewModelBase
     {
-        public RequirementGroupViewModel(string label, IEnumerable<Requirement> requirements, NumberFormat numberFormat, IDictionary<int, string> notes)
+        public RequirementGroupViewModel(string label, IEnumerable<Requirement> requirements, NumberFormat numberFormat, IDictionary<uint, string> notes)
         {
             Label = label;
 
@@ -190,7 +190,7 @@ namespace RATools.ViewModels
             return (bestLeft != -1);
         }
 
-        private void AppendRequirements(List<RequirementViewModel> list, RequirementEx left, RequirementEx right, NumberFormat numberFormat, IDictionary<int, string> notes)
+        private void AppendRequirements(List<RequirementViewModel> list, RequirementEx left, RequirementEx right, NumberFormat numberFormat, IDictionary<uint, string> notes)
         {
             if (right == null)
             {
@@ -287,7 +287,7 @@ namespace RATools.ViewModels
             }
         }
 
-        public RequirementGroupViewModel(string label, IEnumerable<Requirement> requirements, IEnumerable<Requirement> compareRequirements, NumberFormat numberFormat, IDictionary<int, string> notes)
+        public RequirementGroupViewModel(string label, IEnumerable<Requirement> requirements, IEnumerable<Requirement> compareRequirements, NumberFormat numberFormat, IDictionary<uint, string> notes)
         {
             Label = label;
 
@@ -447,7 +447,7 @@ namespace RATools.ViewModels
             Requirements = list;
         }
 
-        public RequirementGroupViewModel(string label, IEnumerable<string> requirements, IEnumerable<string> compareRequirements, NumberFormat numberFormat, IDictionary<int, string> notes)
+        public RequirementGroupViewModel(string label, IEnumerable<string> requirements, IEnumerable<string> compareRequirements, NumberFormat numberFormat, IDictionary<uint, string> notes)
         {
             Label = label;
 

--- a/Source/ViewModels/RequirementViewModel.cs
+++ b/Source/ViewModels/RequirementViewModel.cs
@@ -15,7 +15,7 @@ namespace RATools.ViewModels
     [DebuggerDisplay("{Requirement}")]
     public class RequirementViewModel : ViewModelBase
     {
-        public RequirementViewModel(Requirement requirement, NumberFormat numberFormat, IDictionary<int, string> notes)
+        public RequirementViewModel(Requirement requirement, NumberFormat numberFormat, IDictionary<uint, string> notes)
         {
             Requirement = requirement;
 
@@ -30,10 +30,10 @@ namespace RATools.ViewModels
                         var builder = new StringBuilder();
 
                         string note;
-                        if (notes.TryGetValue((int)requirement.Left.Value, out note))
+                        if (notes.TryGetValue(requirement.Left.Value, out note))
                             builder.AppendFormat("0x{0:x6}:{1}", requirement.Left.Value, note);
 
-                        if (notes.TryGetValue((int)requirement.Right.Value, out note))
+                        if (notes.TryGetValue(requirement.Right.Value, out note))
                         {
                             if (builder.Length > 0)
                                 builder.AppendLine();
@@ -45,14 +45,14 @@ namespace RATools.ViewModels
                     else
                     {
                         string note;
-                        if (notes.TryGetValue((int)requirement.Left.Value, out note))
+                        if (notes.TryGetValue(requirement.Left.Value, out note))
                             Notes = note;
                     }
                 }
                 else if (requirement.Right.IsMemoryReference)
                 {
                     string note;
-                    if (notes.TryGetValue((int)requirement.Right.Value, out note))
+                    if (notes.TryGetValue(requirement.Right.Value, out note))
                         Notes = note;
                 }
             }

--- a/Source/ViewModels/TriggerComparisonViewModel.cs
+++ b/Source/ViewModels/TriggerComparisonViewModel.cs
@@ -6,7 +6,7 @@ namespace RATools.ViewModels
 {
     public class TriggerComparisonViewModel : TriggerViewModel
     {
-        public TriggerComparisonViewModel(TriggerViewModel trigger, TriggerViewModel compareTrigger, NumberFormat numberFormat, IDictionary<int, string> notes)
+        public TriggerComparisonViewModel(TriggerViewModel trigger, TriggerViewModel compareTrigger, NumberFormat numberFormat, IDictionary<uint, string> notes)
             : base(trigger.Label, (Achievement)null, numberFormat, notes)
         {
             var compareTriggerGroups = new List<RequirementGroupViewModel>(compareTrigger.Groups);

--- a/Source/ViewModels/TriggerViewModel.cs
+++ b/Source/ViewModels/TriggerViewModel.cs
@@ -12,7 +12,7 @@ namespace RATools.ViewModels
     [DebuggerDisplay("{Label}")]
     public class TriggerViewModel : ViewModelBase
     {
-        public TriggerViewModel(string label, Achievement achievement, NumberFormat numberFormat, IDictionary<int, string> notes)
+        public TriggerViewModel(string label, Achievement achievement, NumberFormat numberFormat, IDictionary<uint, string> notes)
         {
             Label = label;
 
@@ -49,7 +49,7 @@ namespace RATools.ViewModels
             Groups = groups.ToArray();
         }
 
-        public TriggerViewModel(string label, string definition, NumberFormat numberFormat, IDictionary<int, string> notes)
+        public TriggerViewModel(string label, string definition, NumberFormat numberFormat, IDictionary<uint, string> notes)
             : this(label, CreateAchievement(definition), numberFormat, notes)
         {
         }
@@ -75,7 +75,7 @@ namespace RATools.ViewModels
 
     public class ValueViewModel : TriggerViewModel
     {
-        public ValueViewModel(string label, string definition, NumberFormat numberFormat, IDictionary<int, string> notes)
+        public ValueViewModel(string label, string definition, NumberFormat numberFormat, IDictionary<uint, string> notes)
             : base(label, CreateValue(definition), numberFormat, notes)
         {
         }

--- a/Source/rascript-cli/RAScriptCLI.cs
+++ b/Source/rascript-cli/RAScriptCLI.cs
@@ -176,17 +176,20 @@ namespace RATools
                 stream.WriteLine(error.Message);
 
                 stream.WriteLine(_currentLineText);
-                stream.Write(new String(' ', error.Location.Front.Column - 1));
-                Console.ForegroundColor = ConsoleColor.DarkGreen;
-                stream.Write('^');
-                if (error.Location.Front.Line == error.Location.Back.Line)
+                if (error.Location.Front.Column > 0)
                 {
-                    var distance = error.Location.Back.Column - error.Location.Front.Column;
-                    if (distance > 0)
-                        stream.Write(new String('~', distance));
+                    stream.Write(new String(' ', error.Location.Front.Column - 1));
+                    Console.ForegroundColor = ConsoleColor.DarkGreen;
+                    stream.Write('^');
+                    if (error.Location.Front.Line == error.Location.Back.Line)
+                    {
+                        var distance = error.Location.Back.Column - error.Location.Front.Column;
+                        if (distance > 0)
+                            stream.Write(new String('~', distance));
+                    }
+                    Console.ResetColor();
+                    stream.WriteLine();
                 }
-                Console.ResetColor();
-                stream.WriteLine();
             }
         }
 

--- a/Source/rascript-cli/RAScriptCLI.cs
+++ b/Source/rascript-cli/RAScriptCLI.cs
@@ -276,33 +276,17 @@ namespace RATools
 
             if (!String.IsNullOrEmpty(interpreter.RichPresence))
             {
-                string richPresence;
-                var minimumVersion = localAchievements.Version;
-                if (minimumVersion < Data.Version._1_0)
-                {
-                    interpreter.RichPresenceBuilder.DisableBuiltInMacros = true;
-
-                    if (minimumVersion < Data.Version._0_79)
-                        interpreter.RichPresenceBuilder.DisableLookupCollapsing = true;
-
-                    richPresence = interpreter.RichPresenceBuilder.ToString();
-                }
-                else
-                {
-                    richPresence = interpreter.RichPresence;
-                }
-
                 outputFileName = Path.Combine(OutputDirectory, String.Format("{0}-Rich.txt", interpreter.GameId));
                 using (var stream = _fileSystemService.CreateFile(outputFileName))
                 {
                     using (var writer = new StreamWriter(stream))
                     {
-                        writer.Write(richPresence);
+                        writer.Write(interpreter.RichPresence);
                     }
                 }
 
                 if (!_quiet)
-                    OutputStream.WriteLine("Wrote {0} bytes to {1}-Rich.txt", richPresence.Length, interpreter.GameId);
+                    OutputStream.WriteLine("Wrote {0} bytes to {1}-Rich.txt", interpreter.RichPresence.Length, interpreter.GameId);
             }
 
             return ReturnCode.Success;

--- a/Source/rascript-cli/RAScriptCLI.cs
+++ b/Source/rascript-cli/RAScriptCLI.cs
@@ -266,7 +266,7 @@ namespace RATools
                 }
                 localAchievements.Replace(existingLeaderboard, leaderboard);
             }
-            localAchievements.Commit(Author, null, null);
+            localAchievements.Commit(Author, null, interpreter.SerializationContext, null);
 
             if (!_quiet)
             {
@@ -277,12 +277,12 @@ namespace RATools
             if (!String.IsNullOrEmpty(interpreter.RichPresence))
             {
                 string richPresence;
-                var minimumVersion = Double.Parse(localAchievements.Version, System.Globalization.NumberFormatInfo.InvariantInfo);
-                if (minimumVersion < 1.0)
+                var minimumVersion = localAchievements.Version;
+                if (minimumVersion < Data.Version._1_0)
                 {
                     interpreter.RichPresenceBuilder.DisableBuiltInMacros = true;
 
-                    if (minimumVersion < 0.79)
+                    if (minimumVersion < Data.Version._0_79)
                         interpreter.RichPresenceBuilder.DisableLookupCollapsing = true;
 
                     richPresence = interpreter.RichPresenceBuilder.ToString();

--- a/Tests/Data/FieldTests.cs
+++ b/Tests/Data/FieldTests.cs
@@ -140,7 +140,7 @@ namespace RATools.Data.Tests
         {
             var field = new Field { Size = fieldSize, Type = fieldType, Value = (uint)value };
             var builder = new StringBuilder();
-            field.Serialize(builder);
+            field.Serialize(builder, new SerializationContext());
             Assert.That(builder.ToString(), Is.EqualTo(expected));
         }
 

--- a/Tests/Parser/Expressions/Trigger/MemoryValueExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/MemoryValueExpressionTests.cs
@@ -410,7 +410,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
 
             var achievementBuilder = new ScriptInterpreterAchievementBuilder();
             achievementBuilder.PopulateFromExpression(result);
-            var serialized = achievementBuilder.SerializeRequirements();
+            var serialized = achievementBuilder.SerializeRequirements(new SerializationContext());
             Assert.That(serialized, Is.EqualTo(expectedSerialized));
         }
 

--- a/Tests/Parser/Expressions/Trigger/RequirementClauseExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementClauseExpression_Tests.cs
@@ -1,5 +1,6 @@
 using Jamiras.Components;
 using NUnit.Framework;
+using RATools.Data;
 using RATools.Parser.Expressions;
 using RATools.Parser.Expressions.Trigger;
 using RATools.Parser.Internal;
@@ -90,7 +91,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             var result = clause.BuildSubclauseTrigger(context);
             Assert.That(result, Is.Null);
 
-            Assert.That(context.Achievement.SerializeRequirements(), Is.EqualTo(expected));
+            Assert.That(context.Achievement.SerializeRequirements(new SerializationContext()), Is.EqualTo(expected));
         }
 
         [Test]
@@ -196,7 +197,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             var builder = new ScriptInterpreterAchievementBuilder();
             builder.PopulateFromExpression(result);
             builder.Optimize();
-            Assert.That(builder.SerializeRequirements(), Is.EqualTo(expected));
+            Assert.That(builder.SerializeRequirements(new SerializationContext()), Is.EqualTo(expected));
         }
 
         [Test]
@@ -236,7 +237,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             var builder = new ScriptInterpreterAchievementBuilder();
             builder.PopulateFromExpression(result);
             builder.Optimize();
-            Assert.That(builder.SerializeRequirements(), Is.EqualTo(expected));
+            Assert.That(builder.SerializeRequirements(new SerializationContext()), Is.EqualTo(expected));
         }
 
         [Test]
@@ -262,7 +263,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             var builder = new ScriptInterpreterAchievementBuilder();
             builder.PopulateFromExpression(result);
             builder.Optimize();
-            Assert.That(builder.SerializeRequirements(), Is.EqualTo(expected));
+            Assert.That(builder.SerializeRequirements(new SerializationContext()), Is.EqualTo(expected));
         }
     }
 }

--- a/Tests/Parser/Expressions/Trigger/TriggerExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/TriggerExpressionTests.cs
@@ -107,7 +107,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             foreach (var requirement in requirements)
                 builder.CoreRequirements.Add(requirement);
 
-            return builder.SerializeRequirements();
+            return builder.SerializeRequirements(new SerializationContext());
         }
 
         public static void AssertSerialize(ITriggerExpression expression, string expected)
@@ -127,7 +127,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             foreach (var requirement in requirements)
                 builder.CoreRequirements.Add(requirement);
 
-            return builder.SerializeRequirements();
+            return builder.SerializeRequirements(new SerializationContext());
         }
 
         public static void AssertSerializeValue(ITriggerExpression expression, string expected)
@@ -142,7 +142,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             var result = expression.BuildTrigger(context);
             Assert.That(result, Is.Null);
 
-            return context.Achievement.SerializeRequirements();
+            return context.Achievement.SerializeRequirements(new SerializationContext());
         }
 
         public static void AssertSerializeAchievement(ITriggerExpression expression, string expected)

--- a/Tests/Parser/Functions/AchievementFunctionTests.cs
+++ b/Tests/Parser/Functions/AchievementFunctionTests.cs
@@ -71,7 +71,7 @@ namespace RATools.Parser.Tests.Functions
             Assert.That(achievement.Points, Is.EqualTo(5));
 
             var builder = new AchievementBuilder(achievement);
-            Assert.That(builder.SerializeRequirements(), Is.EqualTo("0xH001234=1"));
+            Assert.That(builder.SerializeRequirements(new SerializationContext()), Is.EqualTo("0xH001234=1"));
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace RATools.Parser.Tests.Functions
                 expected.AppendFormat("S0x {0:x6}=10_d0x {0:x6}<10", i + 0x1000);
 
             var builder = new AchievementBuilder(achievement);
-            Assert.That(builder.SerializeRequirements(), Is.EqualTo(expected.ToString()));
+            Assert.That(builder.SerializeRequirements(new SerializationContext()), Is.EqualTo(expected.ToString()));
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace RATools.Parser.Tests.Functions
                 expected.AppendFormat("S0x {0:x6}=10_d0x {0:x6}<10", i + 0x1000);
 
             var builder = new AchievementBuilder(achievement);
-            Assert.That(builder.SerializeRequirements(), Is.EqualTo(expected.ToString()));
+            Assert.That(builder.SerializeRequirements(new SerializationContext()), Is.EqualTo(expected.ToString()));
         }
 
         [Test]

--- a/Tests/Parser/Functions/PrevPriorFunctionTests.cs
+++ b/Tests/Parser/Functions/PrevPriorFunctionTests.cs
@@ -47,7 +47,7 @@ namespace RATools.Parser.Tests.Functions
             Assert.That(parser.Achievements.Count(), Is.EqualTo(1));
             var achievement = parser.Achievements.First();
             var builder = new AchievementBuilder(achievement);
-            return builder.SerializeRequirements();
+            return builder.SerializeRequirements(new SerializationContext());
         }
 
         private static string GetInnerErrorMessage(AchievementScriptInterpreter parser)

--- a/Tests/Parser/Functions/RichPresenceMacroFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceMacroFunctionTests.cs
@@ -1,5 +1,6 @@
 ﻿using Jamiras.Components;
 using NUnit.Framework;
+using RATools.Data;
 using RATools.Parser.Expressions;
 using RATools.Parser.Functions;
 using System.Linq;
@@ -68,7 +69,8 @@ namespace RATools.Parser.Tests.Functions
         public void TestMacro(string macro)
         {
             var rp = Evaluate("rich_presence_macro(\"" + macro + "\", byte(0x1234))");
-            Assert.That(rp.ToString(), Is.EqualTo("Display:\r\n@" + macro  +"(0xH001234)\r\n"));
+            var serializationContext = new SerializationContext { MinimumVersion = Version._1_0 };
+            Assert.That(rp.Serialize(serializationContext), Is.EqualTo("Display:\r\n@" + macro  +"(0xH001234)\r\n"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/RequirementsOptimizerTests.cs
+++ b/Tests/Parser/Internal/RequirementsOptimizerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Jamiras.Components;
 using NUnit.Framework;
+using RATools.Data;
 using RATools.Parser.Expressions;
 
 namespace RATools.Parser.Internal.Tests
@@ -465,7 +466,7 @@ namespace RATools.Parser.Internal.Tests
                 "trigger_when(byte(0x2345) == 2 && byte(0x2346) == 3 && (byte(0x2347) == 0 || byte(0x2347) == 1)) && " +
                 "never(byte(0x3456) == 2)");
             achievement.Optimize();
-            Assert.That(achievement.SerializeRequirements(), 
+            Assert.That(achievement.SerializeRequirements(new SerializationContext()), 
                 Is.EqualTo("0xH001234=1.1._T:0xH002345=2_T:0xH002346=3_R:0xH003456=2ST:0xH002347=0ST:0xH002347=1"));
         }
 
@@ -475,7 +476,7 @@ namespace RATools.Parser.Internal.Tests
             var achievement = CreateAchievement("(byte(0x1234) == 1 || byte(0x1234) == 2) && " +
                 "never(byte(0x2345) == 3) && once(byte(0x3456) == 4)");
             achievement.Optimize();
-            Assert.That(achievement.SerializeRequirements(),
+            Assert.That(achievement.SerializeRequirements(new SerializationContext()),
                 Is.EqualTo("R:0xH002345=3_0xH003456=4.1.S0xH001234=1S0xH001234=2"));
         }
 
@@ -487,7 +488,7 @@ namespace RATools.Parser.Internal.Tests
                 " never(byte(0x2345) == 2) && unless(byte(0x3456) == 3))) && " +
                 "(byte(0x4567) == 1 || byte(0x004567) == 2)");
             achievement.Optimize();
-            Assert.That(achievement.SerializeRequirements(),
+            Assert.That(achievement.SerializeRequirements(new SerializationContext()),
                 Is.EqualTo("0xH001234=1.1.S0xH004567=1S0xH004567=2SR:0xH002345=2_P:0xH003456=3_0=1"));
         }
 
@@ -496,7 +497,7 @@ namespace RATools.Parser.Internal.Tests
         {
             var achievement = CreateAchievement("byte(0x1234) == 1 && trigger_when(measured(repeated(3, byte(0x2345) == 6)))");
             achievement.Optimize();
-            Assert.That(achievement.SerializeRequirements(),
+            Assert.That(achievement.SerializeRequirements(new SerializationContext()),
                 Is.EqualTo("0xH001234=1SM:0xH002345=6.3.ST:0=1"));
         }
     }

--- a/Tests/Parser/Internal/ScriptBuilderContextTests.cs
+++ b/Tests/Parser/Internal/ScriptBuilderContextTests.cs
@@ -78,7 +78,7 @@ namespace RATools.Parser.Internal.Tests
             Assert.That(builder.ToString(), Is.EqualTo(expected));
 
             // make sure we didn't modify the source requirements
-            Assert.That(trigger.Serialize(), Is.EqualTo(input));
+            Assert.That(trigger.Serialize(new SerializationContext()), Is.EqualTo(input));
         }
 
         [TestCase("N:0xH001234=1_M:0xH002345=2",
@@ -103,7 +103,7 @@ namespace RATools.Parser.Internal.Tests
             Assert.That(builder.ToString(), Is.EqualTo(expected));
 
             // make sure we didn't modify the source requirements
-            Assert.That(trigger.Serialize(), Is.EqualTo(input));
+            Assert.That(trigger.Serialize(new SerializationContext()), Is.EqualTo(input));
         }
     }
 }

--- a/Tests/Parser/Internal/TriggerBuilderContextTests.cs
+++ b/Tests/Parser/Internal/TriggerBuilderContextTests.cs
@@ -1,5 +1,6 @@
 ﻿using Jamiras.Components;
 using NUnit.Framework;
+using RATools.Data;
 using RATools.Parser.Expressions;
 using RATools.Parser.Internal;
 using RATools.Parser.Tests.Expressions;
@@ -31,7 +32,7 @@ namespace RATools.Parser.Tests.Internal
             ExpressionBase processed;
             Assert.That(expression.ReplaceVariables(scope, out processed), Is.True);
 
-            var result = TriggerBuilderContext.GetConditionString(processed, scope, out error);
+            var result = TriggerBuilderContext.GetConditionString(processed, scope, new SerializationContext(), out error);
             if (error != null)
             {
                 ExpressionTests.AssertError(error, expected);

--- a/Tests/Parser/Internal/ValueBuilderContextTests.cs
+++ b/Tests/Parser/Internal/ValueBuilderContextTests.cs
@@ -1,5 +1,6 @@
 ﻿using Jamiras.Core.Tests;
 using NUnit.Framework;
+using RATools.Data;
 using RATools.Data.Tests;
 using RATools.Parser.Expressions;
 using RATools.Parser.Internal;
@@ -70,7 +71,7 @@ namespace RATools.Parser.Tests.Internal
 
             ExpressionBase error;
             InterpreterScope scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
-            var serialized = ValueBuilderContext.GetValueString(clause, scope, out error);
+            var serialized = ValueBuilderContext.GetValueString(clause, scope, new SerializationContext(), out error);
             Assert.That(serialized, Is.EqualTo(expected));
         }
 
@@ -91,7 +92,7 @@ namespace RATools.Parser.Tests.Internal
             {
                 ExpressionBase error;
                 InterpreterScope scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
-                var serialized = ValueBuilderContext.GetValueString(clause, scope, out error);
+                var serialized = ValueBuilderContext.GetValueString(clause, scope, new SerializationContext(), out error);
                 Assert.That(serialized, Is.EqualTo(expected));
             }
         }

--- a/Tests/Parser/LocalAssetsTests.cs
+++ b/Tests/Parser/LocalAssetsTests.cs
@@ -34,7 +34,7 @@ namespace RATools.Parser.Tests
         [Test]
         public void TestInitialize()
         {
-            var achievements = Initialize("0.099\nTitle\n0:0xH0000c5=0_0xH0000b9=1:I Need Your Help:Talk to the ghost to begin your quest: : : :Jamiras:5:0:0:0:0:53352\n", null);
+            var achievements = Initialize("0.99\nTitle\n0:0xH0000c5=0_0xH0000b9=1:I Need Your Help:Talk to the ghost to begin your quest: : : :Jamiras:5:0:0:0:0:53352\n", null);
             Assert.That(achievements.Title, Is.EqualTo("Title"));
             Assert.That(achievements.Achievements.Count(), Is.EqualTo(1));
 
@@ -52,7 +52,7 @@ namespace RATools.Parser.Tests
         [Test]
         public void TestReplace()
         {
-            var achievements = Initialize("0.099\nTitle\n0:0xH001234=0:A:B: : : :U:5:0:0:D:R:B\n", null);
+            var achievements = Initialize("0.99\nTitle\n0:0xH001234=0:A:B: : : :U:5:0:0:D:R:B\n", null);
             Assert.That(achievements.Achievements.Count(), Is.EqualTo(1));
 
             var achievement = achievements.Achievements.First();
@@ -73,7 +73,7 @@ namespace RATools.Parser.Tests
         [Test]
         public void TestReplaceAppend()
         {
-            var achievements = Initialize("0.099\nTitle\n0:0xH001234=0:A:B: : : :U:5:0:0:D:R:B\n", null);
+            var achievements = Initialize("0.99\nTitle\n0:0xH001234=0:A:B: : : :U:5:0:0:D:R:B\n", null);
             Assert.That(achievements.Achievements.Count(), Is.EqualTo(1));
 
             var achievement = achievements.Achievements.First();
@@ -95,7 +95,7 @@ namespace RATools.Parser.Tests
         [Test]
         public void TestReplaceRemove()
         {
-            var achievements = Initialize("0.099\nTitle\n0:0xH001234=0:A:B: : : :U:5:0:0:D:R:B\n", null);
+            var achievements = Initialize("0.99\nTitle\n0:0xH001234=0:A:B: : : :U:5:0:0:D:R:B\n", null);
             Assert.That(achievements.Achievements.Count(), Is.EqualTo(1));
 
             var achievement = achievements.Achievements.First();
@@ -110,7 +110,7 @@ namespace RATools.Parser.Tests
         public void TestCommit()
         {
             var memoryStream = new MemoryStream();
-            var achievements = Initialize("0.099\nTitle\n", memoryStream);
+            var achievements = Initialize("0.99\nTitle\n", memoryStream);
             Assert.That(achievements.Achievements.Count(), Is.EqualTo(0));
 
             var builder = new AchievementBuilder();
@@ -126,10 +126,10 @@ namespace RATools.Parser.Tests
 
             achievements.Replace(null, achievement);
 
-            achievements.Commit("Test", null, null);
+            achievements.Commit("Test", null, new SerializationContext(), null);
 
             var output = Encoding.UTF8.GetString(memoryStream.ToArray());
-            Assert.That(output, Is.EqualTo("0.099\r\nTitle\r\n0:\"0xH001234=1\":\"T\":\"D\": : ::Test:1:0:0:0:0:\r\n"));
+            Assert.That(output, Is.EqualTo("0.99\r\nTitle\r\n0:\"0xH001234=1\":\"T\":\"D\": : ::Test:1:0:0:0:0:\r\n"));
         }
 
         [Test]
@@ -154,10 +154,10 @@ namespace RATools.Parser.Tests
 
             achievements.Replace(null, achievement);
 
-            achievements.Commit("Test", null, null);
+            achievements.Commit("Test", null, new SerializationContext(),null);
 
             var output = Encoding.UTF8.GetString(memoryStream.ToArray());
-            Assert.That(output, Is.EqualTo("0.030\r\nFromScript\r\n0:\"0xH001234=1\":\"T\":\"D\": : ::Test:1:0:0:0:0:\r\n"));
+            Assert.That(output, Is.EqualTo("0.30\r\nFromScript\r\n0:\"0xH001234=1\":\"T\":\"D\": : ::Test:1:0:0:0:0:\r\n"));
         }
 
         [Test]
@@ -182,10 +182,10 @@ namespace RATools.Parser.Tests
 
             achievements.Replace(null, achievement);
 
-            achievements.Commit("Test", null, null);
+            achievements.Commit("Test", null, new SerializationContext(),null);
 
             var output = Encoding.UTF8.GetString(memoryStream.ToArray());
-            Assert.That(output, Is.EqualTo("0.030\r\nTitle\r\n0:\"0xH001234=1\":\"T\":\"D\": : ::Test:1:0:0:0:0:\r\n"));
+            Assert.That(output, Is.EqualTo("0.30\r\nTitle\r\n0:\"0xH001234=1\":\"T\":\"D\": : ::Test:1:0:0:0:0:\r\n"));
         }
 
         [Test]
@@ -211,7 +211,7 @@ namespace RATools.Parser.Tests
 
             achievements.Replace(null, achievement);
 
-            achievements.Commit("Test", null, null);
+            achievements.Commit("Test", null, new SerializationContext(),null);
 
             var output = Encoding.UTF8.GetString(memoryStream.ToArray());
             Assert.That(output, Is.EqualTo("0.79\r\nTitle\r\n0:\"T:0xH001234=1\":\"T\":\"D\": : ::Test:1:0:0:0:0:\r\n"));
@@ -242,7 +242,7 @@ namespace RATools.Parser.Tests
 
                 achievements.Replace(null, achievement);
 
-                achievements.Commit("Test", null, null);
+                achievements.Commit("Test", null, new SerializationContext(),null);
 
                 var output = Encoding.UTF8.GetString(memoryStream.ToArray());
                 Assert.That(output, Is.EqualTo("0.79\r\nTitle\r\n0:\"T:0xH001234=1\":\"T\":\"D\": : ::Test:1:0:0:0:0:\r\n"));
@@ -253,7 +253,7 @@ namespace RATools.Parser.Tests
         public void TestCommitMissable()
         {
             var memoryStream = new MemoryStream();
-            var achievements = Initialize("0.099\nTitle\n", memoryStream);
+            var achievements = Initialize("0.99\nTitle\n", memoryStream);
             Assert.That(achievements.Achievements.Count(), Is.EqualTo(0));
 
             var builder = new AchievementBuilder();
@@ -271,10 +271,10 @@ namespace RATools.Parser.Tests
 
             achievements.Replace(null, achievement);
 
-            achievements.Commit("Test", null, null);
+            achievements.Commit("Test", null, new SerializationContext(),null);
 
             var output = Encoding.UTF8.GetString(memoryStream.ToArray());
-            Assert.That(output, Is.EqualTo("1.30\r\nTitle\r\n0:\"0xH001234=1\":\"T\":\"D\": : :missable:Test:1:0:0:0:0:\r\n"));
+            Assert.That(output, Is.EqualTo("1.3\r\nTitle\r\n0:\"0xH001234=1\":\"T\":\"D\": : :missable:Test:1:0:0:0:0:\r\n"));
         }
     }
 }

--- a/Tests/Parser/RichPresenceBuilderTests.cs
+++ b/Tests/Parser/RichPresenceBuilderTests.cs
@@ -25,7 +25,8 @@ namespace RATools.Parser.Tests
             builder.AddConditionalDisplayString("0xH1234=2", "Two");
             builder.DisplayString = "Something Else";
 
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            var serializationContext = new SerializationContext { MinimumVersion = Version.MinimumVersion };
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Display:\n" +
                 "?0xH1234=1?One\n" +
                 "?0xH1234=2?Two\n" +
@@ -38,12 +39,11 @@ namespace RATools.Parser.Tests
         {
             // explicitly initialize out of order
             var builder = new RichPresenceBuilder();
-            builder.DisableBuiltInMacros = true;
             builder.AddValueField(null, "Val", ValueFormat.Value);
             builder.AddValueField(null, "Score", ValueFormat.Score);
             builder.DisplayString = "@Val(0xH1234) @Score(0xH2345)";
 
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            Assert.That(builder.Serialize(new SerializationContext()).Replace("\r\n", "\n"), Is.EqualTo(
                 "Format:Val\n" +
                 "FormatType=VALUE\n" +
                 "\n" +
@@ -59,12 +59,12 @@ namespace RATools.Parser.Tests
         public void TestValueFieldsBuiltIn()
         {
             var builder = new RichPresenceBuilder();
-            builder.DisableBuiltInMacros = false;
             builder.AddValueField(null, "Val", ValueFormat.Value);
             builder.AddValueField(null, "Score", ValueFormat.Score);
             builder.DisplayString = "@Val(0xH1234) @Score(0xH2345)";
 
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            var serializationContext = new SerializationContext { MinimumVersion = Data.Version._1_0 };
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Format:Val\n" +
                 "FormatType=VALUE\n" +
                 "\n" +
@@ -88,7 +88,8 @@ namespace RATools.Parser.Tests
             Assert.That(builder.AddLookupField(null, "L", dict, new StringConstantExpression("")), Is.Null);
             builder.DisplayString = "@L(0xH1234)";
 
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            var serializationContext = new SerializationContext { MinimumVersion = Version.MinimumVersion };
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:L\n" +
                 "1=One\n" +
                 "2=Two\n" +
@@ -116,7 +117,8 @@ namespace RATools.Parser.Tests
                 CreateDictionaryExpression(dict), new StringConstantExpression("?")), Is.Null);
             builder.DisplayString = "@YesNo(0xH1234)";
 
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            var serializationContext = new SerializationContext { MinimumVersion = Version.MinimumVersion };
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:YesNo\n" +
                 "0=No\n" +
                 "1=Yes\n" +
@@ -145,7 +147,8 @@ namespace RATools.Parser.Tests
             builder.DisplayString = "@LCF(0xH1234)";
 
             // 4 of 5 items are unique - don't collapse
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            var serializationContext = new SerializationContext { MinimumVersion = Version._0_79 };
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:LCF\n" +
                 "1=One\n" +
                 "2=Two\n" +
@@ -164,7 +167,7 @@ namespace RATools.Parser.Tests
             dict[9] = "Three";
             Assert.That(builder.AddLookupField(null, "LCF", CreateDictionaryExpression(dict),
                 new StringConstantExpression("")), Is.Null);
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:LCF\n" +
                 "1=One\n" +
                 "2=Two\n" +
@@ -184,7 +187,7 @@ namespace RATools.Parser.Tests
             dict[7] = "Two";
             Assert.That(builder.AddLookupField(null, "LCF", CreateDictionaryExpression(dict),
                 new StringConstantExpression("")), Is.Null);
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:LCF\n" +
                 "1=One\n" +
                 "2,4,6-8=Two\n" +
@@ -201,7 +204,7 @@ namespace RATools.Parser.Tests
             dict[11] = "Eleven";
             Assert.That(builder.AddLookupField(null, "LCF", CreateDictionaryExpression(dict),
                 new StringConstantExpression("")), Is.Null);
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:LCF\n" +
                 "1=One\n" +
                 "2,4,6,8,10=Two\n" +
@@ -233,8 +236,8 @@ namespace RATools.Parser.Tests
                 new StringConstantExpression("")), Is.Null);
             builder.DisplayString = "@OddOrEven(0xH1234)";
 
-            Assert.That(builder.DisableLookupCollapsing, Is.False);
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            var serializationContext = new SerializationContext { MinimumVersion = Version._0_79 };
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:OddOrEven\n" +
                 "1,3,5=Odd\n" +
                 "2,4,6=Even\n" +
@@ -243,9 +246,8 @@ namespace RATools.Parser.Tests
                 "@OddOrEven(0xH1234)\n"
             ));
 
-            builder.DisableLookupCollapsing = true;
-            Assert.That(builder.DisableLookupCollapsing, Is.True);
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            serializationContext = new SerializationContext { MinimumVersion = Version.MinimumVersion };
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:OddOrEven\n" +
                 "1=Odd\n" +
                 "2=Even\n" +
@@ -277,7 +279,8 @@ namespace RATools.Parser.Tests
             builder.DisplayString = "@T(0xH1234)";
 
             // 4 of 5 items are unique - don't collapse
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            var serializationContext = new SerializationContext { MinimumVersion = Version._0_79 };
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:T\n" +
                 "1-5=Test\n" +
                 "\n" +
@@ -304,8 +307,8 @@ namespace RATools.Parser.Tests
                 new StringConstantExpression("Even")), Is.Null);
             builder.DisplayString = "@OddOrEven(0xH1234)";
 
-            Assert.That(builder.DisableLookupCollapsing, Is.False);
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            var serializationContext = new SerializationContext { MinimumVersion = Version._0_79 };
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:OddOrEven\n" +
                 "1,3,5=Odd\n" +
                 "*=Even\n" +
@@ -314,9 +317,8 @@ namespace RATools.Parser.Tests
                 "@OddOrEven(0xH1234)\n"
             ));
 
-            builder.DisableLookupCollapsing = true;
-            Assert.That(builder.DisableLookupCollapsing, Is.True);
-            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(
+            serializationContext = new SerializationContext { MinimumVersion = Version.MinimumVersion };
+            Assert.That(builder.Serialize(serializationContext).Replace("\r\n", "\n"), Is.EqualTo(
                 "Lookup:OddOrEven\n" +
                 "1=Odd\n" +
                 "3=Odd\n" +

--- a/Tests/ViewModels/AssetViewModelBaseTests.cs
+++ b/Tests/ViewModels/AssetViewModelBaseTests.cs
@@ -42,7 +42,7 @@ namespace RATools.Tests.ViewModels
             {
                 return new TriggerViewModel[]
                 {
-                    new TriggerViewModel("Trigger" + Id, (Achievement)null, NumberFormat.Decimal, new Dictionary<int, string>())
+                    new TriggerViewModel("Trigger" + Id, (Achievement)null, NumberFormat.Decimal, new Dictionary<uint, string>())
                 };
             }
 

--- a/Tests/ViewModels/RequirementComparisonViewModelTests.cs
+++ b/Tests/ViewModels/RequirementComparisonViewModelTests.cs
@@ -25,7 +25,7 @@ namespace RATools.Tests.ViewModels
         public void TestDefinitions(string leftSerialized, string rightSerialized, 
             string expectedDefinition, string expectedOtherDefinition, bool expectedModified)
         {
-            var notes = new Dictionary<int, string>();
+            var notes = new Dictionary<uint, string>();
 
             var builder = new AchievementBuilder();
             builder.ParseRequirements(Tokenizer.CreateTokenizer(leftSerialized));
@@ -45,7 +45,7 @@ namespace RATools.Tests.ViewModels
         [Test]
         public void TestAddedRequirement()
         {
-            var notes = new Dictionary<int, string>();
+            var notes = new Dictionary<uint, string>();
 
             var builder = new AchievementBuilder();
             builder.ParseRequirements(Tokenizer.CreateTokenizer("0xH1234=7"));
@@ -61,7 +61,7 @@ namespace RATools.Tests.ViewModels
         [Test]
         public void TestRemovedRequirement()
         {
-            var notes = new Dictionary<int, string>();
+            var notes = new Dictionary<uint, string>();
 
             var builder = new AchievementBuilder();
             builder.ParseRequirements(Tokenizer.CreateTokenizer("0xH1234=7"));

--- a/Tests/ViewModels/RequirementGroupViewModelTests.cs
+++ b/Tests/ViewModels/RequirementGroupViewModelTests.cs
@@ -40,7 +40,7 @@ namespace RATools.Tests.ViewModels
             "byte(0x001234) == 7|AndNext byte(0x001234) == 7\nbyte(0x001235) == 6|byte(0x001235) == 6")]
         public void TestDiff(string leftSerialized, string rightSerialized, string expected)
         {
-            var notes = new Dictionary<int, string>();
+            var notes = new Dictionary<uint, string>();
 
             var builder = new AchievementBuilder();
             builder.ParseRequirements(Tokenizer.CreateTokenizer(leftSerialized));

--- a/Tests/ViewModels/RequirementViewModelTests.cs
+++ b/Tests/ViewModels/RequirementViewModelTests.cs
@@ -27,7 +27,7 @@ namespace RATools.Tests.ViewModels
             builder.ParseRequirements(Tokenizer.CreateTokenizer(serialized));
 
             var requirement = builder.ToAchievement().CoreRequirements.First();
-            var notes = new Dictionary<int, string>();
+            var notes = new Dictionary<uint, string>();
             var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes);
 
             Assert.That(vmRequirement.Definition, Is.EqualTo(expected));
@@ -46,7 +46,7 @@ namespace RATools.Tests.ViewModels
         [TestCase("0xH4567", "This note\nis multiple\nlines.")]
         public void TestNotes(string serialized, string expected)
         {
-            var notes = new Dictionary<int, string>();
+            var notes = new Dictionary<uint, string>();
             notes[0x1234] = "Addr1";
             notes[0x2345] = "Addr2";
             notes[0x3456] = "This note is long enough that it will need to be wrapped.";
@@ -65,7 +65,7 @@ namespace RATools.Tests.ViewModels
         [TestCase("0xH2345=7", "Addr2")]
         public void TestNoteShortening(string serialized, string expected)
         {
-            var notes = new Dictionary<int, string>();
+            var notes = new Dictionary<uint, string>();
             notes[0x1234] = "Addr1";
             notes[0x2345] = "Addr2\r\n0=True\r\n1=False";
 


### PR DESCRIPTION
Modifies the serialization functions to accept a `SerializationContext`, which contains the version and address width, and maintains a single context for the scope of the script, allowing the minimum version from achievements/leaderboards to affect each other.

Adds `Version` constants to document changes instead of having changes documented each place where they were checked.