### PR TITLE
include modification when looking for equal ModifiedMemoryAccessors

### DIFF
--- a/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
+++ b/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
@@ -115,7 +115,10 @@ namespace RATools.Parser.Expressions.Trigger
         protected override bool Equals(ExpressionBase obj)
         {
             var that = obj as ModifiedMemoryAccessorExpression;
-            return (that != null && MemoryAccessor == that.MemoryAccessor);
+            return (that != null &&
+                    ModifyingOperator == that.ModifyingOperator &&
+                    MemoryAccessor == that.MemoryAccessor &&
+                    (ModifyingOperator == RequirementOperator.None || Modifier == that.Modifier));
         }
 
         internal override void AppendString(StringBuilder builder)

--- a/Tests/Parser/Expressions/Trigger/RequirementClauseExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementClauseExpression_Tests.cs
@@ -113,6 +113,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("A == 1 && B == 1 && A == 1", "A == 1 && B == 1")]
         [TestCase("A == 1 && B == 1 && A == 3", "always_false()")]
         [TestCase("A > 1 && B == 1 && A == 3", "B == 1 && A == 3")]
+        [TestCase("A & 7 == 4 && A < 24", "A & 0x00000007 == 4 && A < 24")] // "& 7" should prevent collapse to "A == 4"
         [TestCase("(A == 1 && B == 1) || (A == 1 && B == 2) || (A == 1 && B == 3)", "A == 1 && (B == 1 || B == 2 || B == 3)")]
         [TestCase("(A == 1 || B != 1) && (A == 1 || B != 2) && (A == 1 || B != 3)", "A == 1 || (B != 1 && B != 2 && B != 3)")]
         [TestCase("A == 1 && ((once(B == 1 && C == 1) && D == 1) || (once(B == 2 && C == 1) && D == 1))",


### PR DESCRIPTION
fixes #456

The requirement merging code was ignoring the mask, so instead of seeing
```
a & 0xFFEF == 0x4 && a < 0x10
```

It only saw
```
a == 0x4 && a < 10
```

Since a value of 4 is automatically less than 10, it jut dropped the less than 10 check.

I've modified the logic to not compare two requirements if their modifiers differ.