### PR TITLE
discard empty subclause when cross-multiplying ORs

### DIFF
--- a/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
@@ -297,11 +297,14 @@ namespace RATools.Parser.Expressions.Trigger
                     }
                     else if (newConditions.Count != subclause._conditions.Count)
                     {
-                        newComplexSubclauses.Add(new RequirementClauseExpression
+                        if (newConditions.Count > 0)
                         {
-                            Operation = ConditionalOperation.Or,
-                            _conditions = newConditions
-                        });
+                            newComplexSubclauses.Add(new RequirementClauseExpression
+                            {
+                                Operation = ConditionalOperation.Or,
+                                _conditions = newConditions
+                            });
+                        }
 
                         updated = true;
                     }

--- a/Tests/Parser/Internal/RequirementsOptimizerTests.cs
+++ b/Tests/Parser/Internal/RequirementsOptimizerTests.cs
@@ -384,6 +384,8 @@ namespace RATools.Parser.Tests.Internal
                   "A && ((B && D) || (B && E) || (C && D) || (C && E))")]
         [TestCase("A && (B || (C && D)) && (E || F)",
                   "A && ((B && E) || (B && F) || (C && D && E) || (C && D && F))")]
+        [TestCase("(always_false() || always_false()) && (A || D)",
+                  "A || D")] // always_false() cross multiples can be eliminated
         public void TestOrExpansion(string input, string expected)
         {
             input = input.Replace("A", "byte(0x00000A) == 1");


### PR DESCRIPTION
fixes #471 

Evaluation of the provided script resulted in the following condition:
```
(always_false() || always_false()) && (byte(0x100000) == 0 || byte(0x100000) == 1)
```
Since you can't AND two OR groups, it tried to cross multiply them to get four AND conditions. To minimize the number of resulting groups, a first pass is made to eliminate the `always_false`s, which left the left clause empty and broke the cross-multiplication logic.

Solution: If clause ends up empty, discard it.