### PR TITLE
generate error if passing or chain to tally

### DIFF
--- a/Source/Parser/Functions/TallyFunction.cs
+++ b/Source/Parser/Functions/TallyFunction.cs
@@ -68,6 +68,13 @@ namespace RATools.Parser.Functions
                 if (!entry.ReplaceVariables(scope, out result))
                     return false;
 
+                var clause = result as RequirementClauseExpression;
+                if (clause != null && clause.Conditions.OfType<TalliedRequirementExpression>().Count() > 1)
+                {
+                    result = new ErrorExpression("Cannot tally subclause with multiple hit targets");
+                    return false;
+                }
+
                 var functionCall = result as FunctionCallExpression;
                 if (functionCall != null && functionCall.FunctionName.Name == "deduct")
                 {

--- a/Tests/Parser/Expressions/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Expressions/FunctionCallExpressionTests.cs
@@ -720,5 +720,22 @@ namespace RATools.Parser.Tests.Expressions
             Assert.That(value, Is.InstanceOf<StringConstantExpression>());
             Assert.That(((StringConstantExpression)value).Value, Is.EqualTo("yes"));
         }
+
+        [Test]
+        public void TestDeferenceReturnedArray()
+        {
+            var userFunc = Parse("function f() => [\"no\",\"yes\"]");
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+            scope.AddFunction(userFunc);
+
+            var tokenizer = Tokenizer.CreateTokenizer("v = f()[1]");
+            var assignment = ExpressionBase.Parse(new PositionalTokenizer(tokenizer));
+            Assert.That(assignment, Is.InstanceOf<AssignmentExpression>());
+            Assert.That(((AssignmentExpression)assignment).Execute(scope), Is.Null);
+
+            var value = scope.GetVariable("v");
+            Assert.That(value, Is.InstanceOf<StringConstantExpression>());
+            Assert.That(((StringConstantExpression)value).Value, Is.EqualTo("yes"));
+        }
     }
 }

--- a/Tests/Parser/Internal/RequirementsOptimizerTests.cs
+++ b/Tests/Parser/Internal/RequirementsOptimizerTests.cs
@@ -356,8 +356,6 @@ namespace RATools.Parser.Tests.Internal
                   "once(word(0x001234) >= 284 && word(0x001234) <= 301)")] // OrNext will move always_false to end, which will have the HitCount, HitCount should be kept when always_false is eliminated
         [TestCase("tally(2, always_false() || word(0x1234) >= 284 && word(0x1234) <= 301)",
                   "repeated(2, word(0x001234) >= 284 && word(0x001234) <= 301)")] // always_false() inside once() is optimized out
-        [TestCase("tally(2, once(byte(0x1234) == 1) || once(byte(0x1234) == 2) || once(byte(0x1234) == 3))", // malformed: tally(3, repeated(2, A) || repeated(2, B))
-                  "tally(2, (once(once(once(byte(0x001234) == 1) || byte(0x001234) == 2) || byte(0x001234) == 3)))")]
         [TestCase("measured(byte(0x1234) == 120, when = (byte(0x2345) == 6 || byte(0x2346) == 7))", // OrNext in MeasuredIf should not be split into alts
                   "measured(byte(0x001234) == 120, when=(byte(0x002345) == 6 || byte(0x002346) == 7))")]
         public void TestOptimizeComplex(string input, string expected)


### PR DESCRIPTION
The logical construct to capture two of three things happening:
```
tally(2, once(A) || once(B) || once(C))
```
is incorrect. It should be written as:
```
tally(2, once(A), once(B), once(C))
```

In the first case, it generates an OrNext chain:
```
OrNext A (1)
OrNext B (1)
AddHits C (1)
       false (2)
```
This is wrong because line 3 can only ever generate a single hit, so the target of 2 hits on line 4 can never be reached.

It also doesn't correctly represent the original code. Converting it back to RAScript generates `tally(2, once(once(once(A) || B) || C))`.

The `tally` function will now detect this and report an error:
> Cannot tally subclause with multiple hit targets