### PR TITLE
add #MinimumVersion header meta-comment

### DIFF
--- a/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
@@ -173,7 +173,7 @@ namespace RATools.Parser.Expressions.Trigger
                     // single explicit OrNext should be joined to any other conditions via AndNext
                     joinBehavior = RequirementType.AndNext;
                 }
-                else
+                else if (context.MinimumVersion < RATools.Data.Version._0_78)
                 {
                     // no explicit OrNexts. if building an achievement, put the ORs into alts
                     var achievementContext = context as AchievementBuilderContext;
@@ -696,7 +696,7 @@ namespace RATools.Parser.Expressions.Trigger
             if (_conditions == null)
                 return null;
 
-            var achievementContext = new AchievementBuilderContext();
+            var achievementContext = new AchievementBuilderContext() { MinimumVersion = subclauseContext.MinimumVersion };
             ErrorExpression error;
 
             if (Operation == ConditionalOperation.Or && NeedAltsForOr(_conditions))

--- a/Source/Parser/Internal/TriggerBuilderContext.cs
+++ b/Source/Parser/Internal/TriggerBuilderContext.cs
@@ -1,4 +1,5 @@
-﻿using RATools.Data;
+﻿using Jamiras.Components;
+using RATools.Data;
 using RATools.Parser.Expressions;
 using RATools.Parser.Expressions.Trigger;
 using RATools.Parser.Functions;
@@ -22,6 +23,8 @@ namespace RATools.Parser.Internal
         {
             get { return Trigger.LastOrDefault(); }
         }
+
+        public SoftwareVersion MinimumVersion { get; set; }
 
         [DebuggerDisplay("{field} * {Multiplier}")]
         private class Term
@@ -482,6 +485,10 @@ namespace RATools.Parser.Internal
             RequirementExpressionBase expression, InterpreterScope scope, out ExpressionBase result)
         {
             var context = new AchievementBuilderContext(achievement);
+
+            var scriptContext = scope.GetContext<AchievementScriptContext>();
+            if (scriptContext != null)
+                context.MinimumVersion = scriptContext.SerializationContext.MinimumVersion;
 
             var error = ((ITriggerExpression)expression).BuildTrigger(context);
             if (error != null)


### PR DESCRIPTION
#448 added support for a script-wide minimum version, derived from the minimum version needed from all defined achievements, leaderboards, and rich presence.

This allows the author to explicitly specify a script-wide minimum version (which may be automatically increased if any achievement, leaderboard, or rich presence features require a higher minimum version).

The primary use case of this is to disable the logic that converts a series of ANDed ORs into multiple alt groups and use OrNext instead. Previously, authors had to explicitly state they wanted to use OrNext by using the `__ornext` helper function.

Note: This does not prevent the optimizer from generating simple alts: `A && (B || C)` will still get alts for `B` and `C`, even if the minimum version is set above 0.78. `__ornext` can still be used to force an OrNext if it's really desirable.

Example:
```
// GameName
// #ID=123456
achievement("Title", "Description", 5,
  byte(0x1234) == 1 && (byte(0x2345) == 5 || byte(0x2345) == 6) && (byte(0x3456) == 6 || byte(0x3456) == 7)
)
```

-> `0xH1234=1S0xH2345=5_0xH3456=6S0xH2345=5_0xH3456=7S0xH2345=6_0xH3456=6S0xH2345=6_0xH3456=7`

As this logic does not use any new enough features to automatically enable OrNext, the interpreter would turn the two ANDed ORs into four ORd ANDs, and each of those would be a separate alt group.

By specifying a minimum version of 0.78 (when OrNext was introduced), the interpreter will use OrNext instead of creating the four alt groups.

```
// GameName
// #ID=123456
// #MinimumVersion=0.78
achievement("Title", "Description", 5,
  byte(0x1234) == 1 && (byte(0x2345) == 5 || byte(0x2345) == 6) && (byte(0x3456) == 6 || byte(0x3456) == 7)
)
```

-> `0xH1234=1_O:0xH2345=5_0xH2345=6_O:0xH3456=6_0xH3456=7`

Any version 0.78 or newer would work. 1.3 is the newest released DLL version. Individual version features are documented [here](https://github.com/Jamiras/RATools/blob/master/Source/Data/Version.cs).