### PR TITLE
move Requirement enum helpers into extension methods

### DIFF
--- a/Source/Data/RequirementOperator.cs
+++ b/Source/Data/RequirementOperator.cs
@@ -1,0 +1,159 @@
+﻿namespace RATools.Data
+{
+    /// <summary>
+    /// Specifies how the <see cref="Requirement.Left"/> and <see cref="Requirement.Right"/> values should be compared.
+    /// </summary>
+    public enum RequirementOperator
+    {
+        /// <summary>
+        /// Unspecified.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The left and right values are equivalent.
+        /// </summary>
+        Equal,
+
+        /// <summary>
+        /// The left and right values are not equivalent.
+        /// </summary>
+        NotEqual,
+
+        /// <summary>
+        /// The left value is less than the right value.
+        /// </summary>
+        LessThan,
+
+        /// <summary>
+        /// The left value is less than or equal to the right value.
+        /// </summary>
+        LessThanOrEqual,
+
+        /// <summary>
+        /// The left value is greater than the right value.
+        /// </summary>
+        GreaterThan,
+
+        /// <summary>
+        /// The left value is greater than or equal to the right value.
+        /// </summary>
+        GreaterThanOrEqual,
+
+        /// <summary>
+        /// The left value is multiplied by the right value. (combining conditions only)
+        /// </summary>
+        Multiply,
+
+        /// <summary>
+        /// The left value is divided by the right value. (combining conditions only)
+        /// </summary>
+        Divide,
+
+        /// <summary>
+        /// The left value is masked by the right value. (combining conditions only)
+        /// </summary>
+        BitwiseAnd,
+
+        /// <summary>
+        /// The bits in the left value are toggled by the bits in the right value. (combining conditions only)
+        /// </summary>
+        BitwiseXor,
+    }
+
+    public static class RequirementOperatorExtension
+    {
+        /// <summary>
+        /// Gets the equivalent operator if the operands are switched.
+        /// </summary>
+        public static string ToOperatorString(this RequirementOperator op)
+        {
+            switch (op)
+            {
+                case RequirementOperator.Equal: return "==";
+                case RequirementOperator.NotEqual: return "!=";
+                case RequirementOperator.LessThan: return "<";
+                case RequirementOperator.LessThanOrEqual: return "<=";
+                case RequirementOperator.GreaterThan: return ">";
+                case RequirementOperator.GreaterThanOrEqual: return ">=";
+                case RequirementOperator.Multiply: return "*";
+                case RequirementOperator.Divide: return "/";
+                case RequirementOperator.BitwiseAnd: return "&";
+                case RequirementOperator.BitwiseXor: return "^";
+                default: return "";
+            }
+        }
+
+        /// <summary>
+        /// Gets the equivalent operator if the operands are switched.
+        /// </summary>
+        public static RequirementOperator ReverseOperator(this RequirementOperator op)
+        {
+            switch (op)
+            {
+                case RequirementOperator.Equal: return RequirementOperator.Equal;
+                case RequirementOperator.NotEqual: return RequirementOperator.NotEqual;
+                case RequirementOperator.LessThan: return RequirementOperator.GreaterThan;
+                case RequirementOperator.LessThanOrEqual: return RequirementOperator.GreaterThanOrEqual;
+                case RequirementOperator.GreaterThan: return RequirementOperator.LessThan;
+                case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.LessThanOrEqual;
+                default: return RequirementOperator.None;
+            }
+        }
+
+        /// <summary>
+        /// Gets the logically opposite operator.
+        /// </summary>
+        public static RequirementOperator OppositeOperator(this RequirementOperator op)
+        {
+            switch (op)
+            {
+                case RequirementOperator.Equal: return RequirementOperator.NotEqual;
+                case RequirementOperator.NotEqual: return RequirementOperator.Equal;
+                case RequirementOperator.LessThan: return RequirementOperator.GreaterThanOrEqual;
+                case RequirementOperator.LessThanOrEqual: return RequirementOperator.GreaterThan;
+                case RequirementOperator.GreaterThan: return RequirementOperator.LessThanOrEqual;
+                case RequirementOperator.GreaterThanOrEqual: return RequirementOperator.LessThan;
+                default: return RequirementOperator.None;
+            }
+        }
+
+        /// <summary>
+        /// Gets whether or not the operator is used to compare two operands.
+        /// </summary>
+        public static bool IsComparison(this RequirementOperator op)
+        {
+            switch (op)
+            {
+                case RequirementOperator.Equal:
+                case RequirementOperator.NotEqual:
+                case RequirementOperator.LessThan:
+                case RequirementOperator.LessThanOrEqual:
+                case RequirementOperator.GreaterThan:
+                case RequirementOperator.GreaterThanOrEqual:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets whether or not the operator is used to modify an operand.
+        /// </summary>
+        public static bool IsModifier(this RequirementOperator op)
+        {
+            switch (op)
+            {
+                case RequirementOperator.Multiply:
+                case RequirementOperator.Divide:
+                case RequirementOperator.BitwiseAnd:
+                case RequirementOperator.BitwiseXor:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/Source/Data/RequirementType.cs
+++ b/Source/Data/RequirementType.cs
@@ -1,0 +1,125 @@
+﻿namespace RATools.Data
+{
+    /// <summary>
+    /// Special requirement behaviors
+    /// </summary>
+    public enum RequirementType
+    {
+        /// <summary>
+        /// No special behavior.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Resets any HitCounts in the current requirement group if true.
+        /// </summary>
+        ResetIf,
+
+        /// <summary>
+        /// Pauses processing of the achievement if true.
+        /// </summary>
+        PauseIf,
+
+        /// <summary>
+        /// Adds the Left part of the requirement to the Left part of the next requirement.
+        /// </summary>
+        AddSource,
+
+        /// <summary>
+        /// Subtracts the Left part of the next requirement from the Left part of the requirement.
+        /// </summary>
+        SubSource,
+
+        /// <summary>
+        /// Adds the HitsCounts from this requirement to the next requirement.
+        /// </summary>
+        AddHits,
+
+        /// <summary>
+        /// Subtracts the HitsCounts from this requirement from the next requirement.
+        /// </summary>
+        SubHits,
+
+        /// <summary>
+        /// This requirement must also be true for the next requirement to be true.
+        /// </summary>
+        AndNext,
+
+        /// <summary>
+        /// This requirement or the following requirement must be true for the next requirement to be true.
+        /// </summary>
+        OrNext,
+
+        /// <summary>
+        /// Meta-flag indicating that this condition tracks progress as a raw value.
+        /// </summary>
+        Measured,
+
+        /// <summary>
+        /// Meta-flag indicating that this condition must be true to track progress.
+        /// </summary>
+        MeasuredIf,
+
+        /// <summary>
+        /// Adds the Left part of the requirement to the addresses in the next requirement.
+        /// </summary>
+        AddAddress,
+
+        /// <summary>
+        /// Resets any HitCounts on the next requirement group if true.
+        /// </summary>
+        ResetNextIf,
+
+        /// <summary>
+        /// While all non-Trigger conditions are true, a challenge indicator will be displayed.
+        /// </summary>
+        Trigger,
+
+        /// <summary>
+        /// Meta-flag indicating that this condition tracks progress as a percentage.
+        /// </summary>
+        MeasuredPercent,
+    }
+
+    internal static class RequirementTypeExtension
+    {
+        /// <summary>
+        /// Gets whether or not the requirement affects the following requirement.
+        /// </summary>
+        public static bool IsCombining(this RequirementType type)
+        {
+            switch (type)
+            {
+                case RequirementType.AddHits:
+                case RequirementType.SubHits:
+                case RequirementType.AddSource:
+                case RequirementType.SubSource:
+                case RequirementType.AndNext:
+                case RequirementType.OrNext:
+                case RequirementType.AddAddress:
+                case RequirementType.ResetNextIf:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets whether or not the requirement can be scaled.
+        /// </summary>
+        public static bool IsScalable(this RequirementType type)
+        {
+            switch (type)
+            {
+                case RequirementType.AddSource:
+                case RequirementType.SubSource:
+                case RequirementType.AddAddress:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/Source/Parser/Internal/RequirementMerger.cs
+++ b/Source/Parser/Internal/RequirementMerger.cs
@@ -42,8 +42,8 @@ namespace RATools.Parser.Internal
             {
                 if (mergeCondition == ConditionalOperation.Or)
                 {
-                    comparison1 = Requirement.GetOpposingOperator(comparison1);
-                    comparison2 = Requirement.GetOpposingOperator(comparison2);
+                    comparison1 = comparison1.OppositeOperator();
+                    comparison2 = comparison2.OppositeOperator();
                 }
 
                 switch (GetMoreRestrictiveRequirement(comparison1, value1, comparison2, value2))
@@ -94,7 +94,7 @@ namespace RATools.Parser.Internal
                             break;
 
                         default:
-                            mergedOperator = Requirement.GetOpposingOperator(mergedOperator);
+                            mergedOperator = mergedOperator.OppositeOperator();
                             break;
                     }
                 }
@@ -568,7 +568,7 @@ namespace RATools.Parser.Internal
                     {
                         Type = left.Type,
                         Left = left.Left,
-                        Operator = Requirement.GetOpposingOperator(left.Operator),
+                        Operator = left.Operator.OppositeOperator(),
                         Right = left.Right,
                         HitCount = left.HitCount
                     };
@@ -577,7 +577,7 @@ namespace RATools.Parser.Internal
                     {
                         Type = right.Type,
                         Left = right.Left,
-                        Operator = Requirement.GetOpposingOperator(right.Operator),
+                        Operator = right.Operator.OppositeOperator(),
                         Right = right.Right,
                         HitCount = right.HitCount
                     };
@@ -602,7 +602,7 @@ namespace RATools.Parser.Internal
                         }
                         else
                         {
-                            merged.Operator = Requirement.GetOpposingOperator(merged.Operator);
+                            merged.Operator = merged.Operator.OppositeOperator();
                         }
                     }
                 }

--- a/Source/Parser/Internal/RequirementsOptimizer.cs
+++ b/Source/Parser/Internal/RequirementsOptimizer.cs
@@ -65,7 +65,7 @@ namespace RATools.Parser.Internal
                 var value = requirement.Left;
                 requirement.Left = requirement.Right;
                 requirement.Right = value;
-                requirement.Operator = Requirement.GetReversedRequirementOperator(requirement.Operator);
+                requirement.Operator = requirement.Operator.ReverseOperator();
             }
 
             // comparing float to integer - integer will be cast to float, so don't enforce integer limits
@@ -401,7 +401,7 @@ namespace RATools.Parser.Internal
                     if (r.Type == RequirementType.AndNext)
                     {
                         r.Type = RequirementType.OrNext;
-                        r.Operator = Requirement.GetOpposingOperator(r.Operator);
+                        r.Operator = r.Operator.OppositeOperator();
                     }
                 }
             }
@@ -413,13 +413,13 @@ namespace RATools.Parser.Internal
                     if (r.Type == RequirementType.OrNext)
                     {
                         r.Type = RequirementType.AndNext;
-                        r.Operator = Requirement.GetOpposingOperator(r.Operator);
+                        r.Operator = r.Operator.OppositeOperator();
                     }
                 }
             }
 
             var lastRequirement = requirementEx.Requirements.Last();
-            lastRequirement.Operator = Requirement.GetOpposingOperator(lastRequirement.Operator);
+            lastRequirement.Operator = lastRequirement.Operator.OppositeOperator();
             return true;
         }
 
@@ -824,7 +824,7 @@ namespace RATools.Parser.Internal
                         if (requirement.Left != compareRequirement.Left || requirement.Right != compareRequirement.Right)
                             continue;
 
-                        var opposingOperator = Requirement.GetOpposingOperator(requirement.Operator);
+                        var opposingOperator = requirement.Operator.OppositeOperator();
                         if (compareRequirement.Operator == opposingOperator)
                         {
                             // if a HitCount exists, keep the ResetIf, otherwise keep the non-ResetIf

--- a/Source/Parser/ScriptBuilderContext.cs
+++ b/Source/Parser/ScriptBuilderContext.cs
@@ -898,8 +898,8 @@ namespace RATools.Parser
                     if (requirement.Type == RequirementType.AddHits)
                     {
                         bool hasAlwaysFalse = false;
-                        if (requirementEx.Requirements.Count(r => !r.IsScalable) > 1 &&
-                            requirementEx.Requirements.All(r => r.HitCount != 0 || r.IsScalable))
+                        if (requirementEx.Requirements.Count(r => !r.Type.IsScalable()) > 1 &&
+                            requirementEx.Requirements.All(r => r.HitCount != 0 || r.Type.IsScalable()))
                         {
                             requirementEx.Requirements.Last().Type = RequirementType.OrNext;
                             requirementEx.Requirements.Add(Requirement.CreateAlwaysFalseRequirement());


### PR DESCRIPTION
Allows writing
```
r.Operator = r.Operator.OppositeOperator();
```

instead of
```
r.Operator = Requirement.GetOpposingOperator(r.Operator);
```