### PR TITLE
fix missing inversion flag on modifier

### DIFF
--- a/Source/Parser/Expressions/Trigger/FieldFactory.cs
+++ b/Source/Parser/Expressions/Trigger/FieldFactory.cs
@@ -5,7 +5,7 @@ namespace RATools.Parser.Expressions.Trigger
 {
     internal static class FieldFactory
     {
-        internal static Field CreateField(ExpressionBase expression)
+        internal static Field CreateField(ExpressionBase expression, bool ignorePointerChain = false)
         {
             switch (expression.Type)
             {
@@ -19,7 +19,7 @@ namespace RATools.Parser.Expressions.Trigger
                     var memoryAccessor = expression as MemoryAccessorExpression;
                     if (memoryAccessor != null)
                     {
-                        if (memoryAccessor.PointerChain.Any())
+                        if (memoryAccessor.HasPointerChain && !ignorePointerChain)
                             break;
                         if (expression is BinaryCodedDecimalExpression)
                             return memoryAccessor.Field.ChangeType(FieldType.BinaryCodedDecimal);

--- a/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
+++ b/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
@@ -1,6 +1,5 @@
 ﻿using RATools.Data;
 using RATools.Parser.Internal;
-using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
@@ -403,7 +402,7 @@ namespace RATools.Parser.Expressions.Trigger
                 }
 
                 // pointer chain matched. extract the field
-                field = rightAccessor.Field;
+                field = FieldFactory.CreateField(right, true);
             }
             else
             {

--- a/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
@@ -347,7 +347,7 @@ namespace RATools.Parser.Expressions.Trigger
                 expression = new RequirementConditionExpression()
                 {
                     Left = newLeft,
-                    Comparison = condition.Comparison,
+                    Comparison = ComparisonExpression.ReverseComparisonOperation(condition.Comparison),
                     Right = newRight,
                     Location = condition.Location,
                 };

--- a/Tests/Parser/Expressions/Trigger/ModifiedMemoryAcessorExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/ModifiedMemoryAcessorExpressionTests.cs
@@ -39,6 +39,8 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("byte(0x001234) & byte(0x002345)", "0xH001234&0xH002345")]
         [TestCase("byte(0x001234) ^ byte(0x002345)", "0xH001234^0xH002345")]
         [TestCase("byte(0x001234) * byte(0x001234)", "0xH001234*0xH001234")]
+        [TestCase("byte(0x001234) * ~byte(0x002345)", "0xH001234*~0xH002345")]
+        [TestCase("~byte(0x001234) * ~byte(0x002345)", "~0xH001234*~0xH002345")]
         [TestCase("low4(word(0x001234)) * 20", "I:0x 001234_0xL000000*20")]
         [TestCase("prev(high4(0x001234)) * prior(bit3(0x001235))", "d0xU001234*p0xP001235")]
         [TestCase("low4(word(0x001234)) * high4(word(0x001234) + 10)", "I:0x 001234_0xL000000*0xU00000a")]

--- a/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
@@ -161,9 +161,12 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("~prev(byte(1)) == 15", "prev(byte(0x000001)) == 240")]
         [TestCase("~byte(1) != prev(~byte(1))", "byte(0x000001) != prev(byte(0x000001))")]
         [TestCase("byte(1) & ~0x3F == 0x80", "byte(0x000001) & 0x000000C0 == 128")]
+        [TestCase("~byte(1) == ~byte(2)", "byte(0x000001) == byte(0x000002)")]
+        [TestCase("~byte(1) > ~byte(2)", "byte(0x000001) < byte(0x000002)")]
         // invert cannot be factored out
         [TestCase("~byte(1) != byte(2)", "~byte(0x000001) != byte(0x000002)")]
         [TestCase("byte(1) != ~byte(2)", "byte(0x000001) != ~byte(0x000002)")]
+        [TestCase("~byte(1) > byte(2)", "~byte(0x000001) > byte(0x000002)")]
         public void TestNormalizeInvert(string input, string expected)
         {
             var result = TriggerExpressionTests.Parse(input);


### PR DESCRIPTION
Fixes #504 

For the first error (`~byte(0x1234) * ~byte(0x2345)`), the inversion flag was just being ignored. That has been fixed.

For the second error (`~byte(0x1234) > ~byte(0x2345)`), inverting both sides is intentional. The logic was only testing the equality case, where the operator should not be modified. When testing greater than/less than, the operator should also be reversed, so the expected outcome would be `byte(0x1234) < byte(0x2345)`.

Here's a simplified truth table showing that reversing the operator is correct if the inversion is removed from both sides:
```
  < 00 01 10 11     > 11 10 01 00
 00  N  Y  Y  Y    11  N  Y  Y  Y
 01  N  N  Y  Y    10  N  N  Y  Y 
 10  N  N  N  Y    01  N  N  N  Y
 11  N  N  N  N    00  N  N  N  N
 ```