### PR TITLE
support for simple runtime modulus

### DIFF
--- a/Source/Data/Requirement.cs
+++ b/Source/Data/Requirement.cs
@@ -148,6 +148,7 @@ namespace RATools.Data
                 {
                     case RequirementOperator.Multiply: builder.Append('*'); break;
                     case RequirementOperator.Divide: builder.Append('/'); break;
+                    case RequirementOperator.Modulus: builder.Append('%'); break;
                     case RequirementOperator.BitwiseAnd: builder.Append('&'); break;
                     case RequirementOperator.BitwiseXor: builder.Append('^'); break;
                     default:
@@ -170,6 +171,7 @@ namespace RATools.Data
                     case RequirementOperator.GreaterThanOrEqual: builder.Append(">="); break;
                     case RequirementOperator.Multiply: builder.Append('*'); break;
                     case RequirementOperator.Divide: builder.Append('/'); break;
+                    case RequirementOperator.Modulus: builder.Append('%'); break;
                     case RequirementOperator.BitwiseAnd: builder.Append('&'); break;
                     case RequirementOperator.BitwiseXor: builder.Append('^'); break;
                     case RequirementOperator.None: return;
@@ -236,6 +238,10 @@ namespace RATools.Data
 
                 case RequirementOperator.BitwiseXor:
                     minimumVersion = minimumVersion.OrNewer(Version._1_1);
+                    break;
+
+                case RequirementOperator.Modulus:
+                    minimumVersion = minimumVersion.OrNewer(Version._1_3_1);
                     break;
 
                 default:

--- a/Source/Data/RequirementOperator.cs
+++ b/Source/Data/RequirementOperator.cs
@@ -59,6 +59,11 @@
         /// The bits in the left value are toggled by the bits in the right value. (combining conditions only)
         /// </summary>
         BitwiseXor,
+
+        /// <summary>
+        /// The left value is divided by the right value and the remainder is returned. (combining conditions only)
+        /// </summary>
+        Modulus,
     }
 
     public static class RequirementOperatorExtension
@@ -78,6 +83,7 @@
                 case RequirementOperator.GreaterThanOrEqual: return ">=";
                 case RequirementOperator.Multiply: return "*";
                 case RequirementOperator.Divide: return "/";
+                case RequirementOperator.Modulus: return "%";
                 case RequirementOperator.BitwiseAnd: return "&";
                 case RequirementOperator.BitwiseXor: return "^";
                 default: return "";
@@ -147,6 +153,7 @@
             {
                 case RequirementOperator.Multiply:
                 case RequirementOperator.Divide:
+                case RequirementOperator.Modulus:
                 case RequirementOperator.BitwiseAnd:
                 case RequirementOperator.BitwiseXor:
                     return true;

--- a/Source/Data/Version.cs
+++ b/Source/Data/Version.cs
@@ -68,7 +68,7 @@ namespace RATools.Data
         /// 1.1 - 15 Nov 2022
         ///  Operators: BitwiseXor
         ///  Sizes: MBF32LE
-        ///  Otehr: Local code notes
+        ///  Other: Local code notes
         /// </summary>
         public static readonly SoftwareVersion _1_1 = new SoftwareVersion(1, 1);
 
@@ -85,5 +85,12 @@ namespace RATools.Data
         ///  Other: AchievementTypes
         /// </summary>
         public static readonly SoftwareVersion _1_3 = new SoftwareVersion(1, 3);
+
+        /// <summary>
+        /// 1.3.1 - TBD
+        ///  Flags: Remember/Recall
+        ///  Operators: Modulus, Add, Subtract
+        /// </summary>
+        public static readonly SoftwareVersion _1_3_1 = new SoftwareVersion(1, 3, 1);
     }
 }

--- a/Source/Parser/Expressions/Trigger/FieldFactory.cs
+++ b/Source/Parser/Expressions/Trigger/FieldFactory.cs
@@ -86,6 +86,9 @@ namespace RATools.Parser.Expressions.Trigger
                         case RequirementOperator.Divide:
                             intResult /= right.Value;
                             break;
+                        case RequirementOperator.Modulus:
+                            intResult %= right.Value;
+                            break;
                         case RequirementOperator.BitwiseAnd:
                             intResult &= right.Value;
                             break;
@@ -107,6 +110,9 @@ namespace RATools.Parser.Expressions.Trigger
                             break;
                         case RequirementOperator.Divide:
                             floatResult /= right.Float;
+                            break;
+                        case RequirementOperator.Modulus:
+                            floatResult %= right.Float;
                             break;
                         default:
                             return new Field();

--- a/Source/Parser/Expressions/Trigger/MemoryAccessorExpression.cs
+++ b/Source/Parser/Expressions/Trigger/MemoryAccessorExpression.cs
@@ -232,6 +232,10 @@ namespace RATools.Parser.Expressions.Trigger
                             builder.Append(" / ");
                             _pointerChain[i].Right.AppendString(builder, NumberFormat.Decimal);
                             break;
+                        case RequirementOperator.Modulus:
+                            builder.Append(" % ");
+                            _pointerChain[i].Right.AppendString(builder, NumberFormat.Decimal);
+                            break;
                         case RequirementOperator.BitwiseAnd:
                             builder.Append(" & ");
                             builder.AppendFormat("0x{0:X6}", _pointerChain[i].Right.Value);

--- a/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
+++ b/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
@@ -146,6 +146,10 @@ namespace RATools.Parser.Expressions.Trigger
                     builder.Append(" / ");
                     break;
 
+                case RequirementOperator.Modulus:
+                    builder.Append(" % ");
+                    break;
+
                 case RequirementOperator.BitwiseAnd:
                     builder.Append(" & ");
                     break;
@@ -175,6 +179,7 @@ namespace RATools.Parser.Expressions.Trigger
 
                     case RequirementOperator.Multiply:
                     case RequirementOperator.Divide:
+                    case RequirementOperator.Modulus:
                         if (Modifier.Type != FieldType.Value)
                             goto default; // default formating for floats
 
@@ -494,6 +499,9 @@ namespace RATools.Parser.Expressions.Trigger
                     }
                     else if (ModifyingOperator != newModifyingOperator)
                     {
+                        if (newModifyingOperator == RequirementOperator.Modulus)
+                            return new ErrorExpression("Cannot modulus using a runtime value");
+
                         if (Modifier.Type == FieldType.Value && field.Type == FieldType.Value)
                         {
                             if (ModifyingOperator == RequirementOperator.Multiply && newModifyingOperator == RequirementOperator.Divide)
@@ -568,6 +576,7 @@ namespace RATools.Parser.Expressions.Trigger
                 switch (ModifyingOperator)
                 {
                     case RequirementOperator.Divide:
+                    case RequirementOperator.Modulus:
                         return new ErrorExpression("Division by zero");
 
                     case RequirementOperator.Multiply:   // a * 0  =>  0
@@ -588,6 +597,9 @@ namespace RATools.Parser.Expressions.Trigger
                     case RequirementOperator.Divide:   // a / 1  =>  a
                         ModifyingOperator = RequirementOperator.None;
                         break;
+
+                    case RequirementOperator.Modulus:  // a % 1 => 0
+                        return new IntegerConstantExpression(0);
                 }
             }
 
@@ -660,6 +672,7 @@ namespace RATools.Parser.Expressions.Trigger
             {
                 case MathematicOperation.Multiply: return RequirementOperator.Multiply;
                 case MathematicOperation.Divide: return RequirementOperator.Divide;
+                case MathematicOperation.Modulus: return RequirementOperator.Modulus;
                 case MathematicOperation.BitwiseAnd: return RequirementOperator.BitwiseAnd;
                 case MathematicOperation.BitwiseXor: return RequirementOperator.BitwiseXor;
                 default: return RequirementOperator.None;
@@ -672,6 +685,7 @@ namespace RATools.Parser.Expressions.Trigger
             {
                 case RequirementOperator.Multiply: return MathematicOperation.Multiply;
                 case RequirementOperator.Divide: return MathematicOperation.Divide;
+                case RequirementOperator.Modulus: return MathematicOperation.Modulus;
                 case RequirementOperator.BitwiseAnd: return MathematicOperation.BitwiseAnd;
                 case RequirementOperator.BitwiseXor: return MathematicOperation.BitwiseXor;
                 default: return MathematicOperation.None;

--- a/Source/Parser/ScriptBuilderContext.cs
+++ b/Source/Parser/ScriptBuilderContext.cs
@@ -707,6 +707,7 @@ namespace RATools.Parser
 
                 case RequirementOperator.Multiply:
                 case RequirementOperator.Divide:
+                case RequirementOperator.Modulus:
                 case RequirementOperator.BitwiseAnd:
                 // handled by AppendFieldModifier above, treat like none
 
@@ -758,6 +759,11 @@ namespace RATools.Parser
 
                 case RequirementOperator.Divide:
                     builder.Append(" / ");
+                    requirement.Right.AppendString(builder, NumberFormat, _addAddress?.ToString());
+                    break;
+
+                case RequirementOperator.Modulus:
+                    builder.Append(" % ");
                     requirement.Right.AppendString(builder, NumberFormat, _addAddress?.ToString());
                     break;
 

--- a/Source/ViewModels/ConditionsAnalyzerViewModel.cs
+++ b/Source/ViewModels/ConditionsAnalyzerViewModel.cs
@@ -77,6 +77,7 @@ namespace RATools.ViewModels
                 new LookupItem((int)RequirementOperator.GreaterThanOrEqual, ">="),
                 new LookupItem((int)RequirementOperator.Multiply, "*"),
                 new LookupItem((int)RequirementOperator.Divide, "/"),
+                new LookupItem((int)RequirementOperator.Modulus, "%"),
                 new LookupItem((int)RequirementOperator.BitwiseAnd, "&"),
             };
 

--- a/Tests/Data/RequirementTests.cs
+++ b/Tests/Data/RequirementTests.cs
@@ -99,6 +99,7 @@ namespace RATools.Data.Tests
         [TestCase(TestField.Byte1234, RequirementOperator.Multiply, TestField.Value99, null)]
         [TestCase(TestField.Byte1234, RequirementOperator.Multiply, TestField.Byte1234, null)]
         [TestCase(TestField.Byte1234, RequirementOperator.Divide, TestField.Value99, null)]
+        [TestCase(TestField.Byte1234, RequirementOperator.Modulus, TestField.Value99, null)]
         [TestCase(TestField.Byte1234, RequirementOperator.BitwiseAnd, TestField.Value99, null)]
         [TestCase(TestField.Value99, RequirementOperator.None, TestField.None, null)]
         public void TestEvaluate(TestField left, RequirementOperator requirementOperator, TestField right, bool? expected)

--- a/Tests/Parser/Expressions/Trigger/MemoryAcessorExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/MemoryAcessorExpressionTests.cs
@@ -56,7 +56,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("byte(0x001234)", "&", "2",
             ExpressionType.MemoryAccessor, "byte(0x001234) & 0x00000002")]
         [TestCase("byte(0x001234)", "%", "2",
-            ExpressionType.Error, "Cannot modulus using a runtime value")]
+            ExpressionType.MemoryAccessor, "byte(0x001234) % 2")]
         [TestCase("byte(0x001234)", "+", "byte(0x002345)",
             ExpressionType.MemoryAccessor, "byte(0x001234) + byte(0x002345)")]
         [TestCase("byte(0x001234)", "-", "byte(0x002345)",
@@ -68,7 +68,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("byte(0x001234)", "&", "byte(0x002345)",
             ExpressionType.MemoryAccessor, "byte(0x001234) & byte(0x002345)")]
         [TestCase("byte(0x001234)", "%", "byte(0x002345)",
-            ExpressionType.Error, "Cannot modulus using a runtime value")]
+            ExpressionType.MemoryAccessor, "byte(0x001234) % byte(0x002345)")]
         [TestCase("float(0x001234)", "&", "10",
             ExpressionType.Error, "Cannot perform bitwise operations on floating point values")]
         [TestCase("float(0x001234)", "^", "10",

--- a/Tests/Parser/Expressions/Trigger/ModifiedMemoryAcessorExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/ModifiedMemoryAcessorExpressionTests.cs
@@ -1,8 +1,6 @@
 ﻿using NUnit.Framework;
-using RATools.Data;
 using RATools.Parser.Expressions;
 using RATools.Parser.Expressions.Trigger;
-using System;
 
 namespace RATools.Parser.Tests.Expressions.Trigger
 {
@@ -12,10 +10,12 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [Test]
         [TestCase("byte(0x001234) * 10")]
         [TestCase("byte(0x001234) / 10")]
+        [TestCase("byte(0x001234) % 10")]
         [TestCase("byte(0x001234) & 0x0000000A")]
         [TestCase("byte(0x001234) ^ 0x0000000A")]
         [TestCase("byte(0x001234) * byte(0x002345)")]
         [TestCase("byte(0x001234) / byte(0x002345)")]
+        [TestCase("byte(0x001234) % byte(0x002345)")]
         [TestCase("byte(0x001234) & byte(0x002345)")]
         [TestCase("byte(0x001234) ^ byte(0x002345)")]
         [TestCase("byte(0x001234) * byte(0x001234)")]
@@ -32,10 +32,12 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [Test]
         [TestCase("byte(0x001234) * 10", "0xH001234*10")]
         [TestCase("byte(0x001234) / 10", "0xH001234/10")]
+        [TestCase("byte(0x001234) % 10", "0xH001234%10")]
         [TestCase("byte(0x001234) & 10", "0xH001234&10")]
         [TestCase("byte(0x001234) ^ 10", "0xH001234^10")]
         [TestCase("byte(0x001234) * byte(0x002345)", "0xH001234*0xH002345")]
         [TestCase("byte(0x001234) / byte(0x002345)", "0xH001234/0xH002345")]
+        [TestCase("byte(0x001234) % byte(0x002345)", "0xH001234%0xH002345")]
         [TestCase("byte(0x001234) & byte(0x002345)", "0xH001234&0xH002345")]
         [TestCase("byte(0x001234) ^ byte(0x002345)", "0xH001234^0xH002345")]
         [TestCase("byte(0x001234) * byte(0x001234)", "0xH001234*0xH001234")]


### PR DESCRIPTION
Allows things like `byte(0x1234) % 10`, but not `byte(0x1234) * 3 % 10`.