### PR TITLE
provide different message when non-executable code is encountered in a function

### DIFF
--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net.Sockets;
 using System.Text;
 
 namespace RATools.Parser
@@ -449,6 +450,9 @@ namespace RATools.Parser
                     // block of code. just ignore them.
                     return null;
             }
+
+            if (scope.GetContext<FunctionCallExpression>() != null)
+                return new ErrorExpression("Expression is not executable. Did you mean to return it?", expression);
 
             return new ErrorExpression("Only assignment statements, function calls and function definitions allowed at outer scope", expression);
         }

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -1330,5 +1330,25 @@ namespace RATools.Parser.Tests
             Assert.That(achievement.Trigger.Serialize(parser.SerializationContext),
                 Is.EqualTo("0xH1234=1_O:0xH2345=5_0xH2345=6_O:0xH3456=6_0xH3456=7"));
         }
+
+        [Test]
+        public void TestNonExecutableExpression()
+        {
+            Evaluate("byte(0x1234) == 6", "1:1 Only assignment statements, function calls and function definitions allowed at outer scope");
+        }
+
+        [Test]
+        public void TestNonExecutableExpressionInFunction()
+        {
+            Evaluate(
+                "function foo()\n" +
+                "{\n" +
+                "    byte(0x1234) == 6" +
+                "}\n" +
+                "foo()\n",
+
+                "4:1 foo call failed\r\n" +
+                "- 3:5 Expression is not executable. Did you mean to return it?");
+        }
     }
 }


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/645777658319208448/1278403150705070101

Instead of saying "Only assignment statements, function calls and function definitions allowed at outer scope", it now says "Expression is not executable. Did you mean to return it?" if the error occurs within a function scope.