### PR TITLE
improve error message when indexing empty array

### DIFF
--- a/Source/Parser/Expressions/IndexedVariableExpression.cs
+++ b/Source/Parser/Expressions/IndexedVariableExpression.cs
@@ -218,9 +218,16 @@ namespace RATools.Parser.Expressions
                 // array index must be an integer in the range 0..count-1
                 var intIndex = index as IntegerConstantExpression;
                 if (intIndex == null)
+                {
                     container = new ErrorExpression("Index does not evaluate to an integer constant", index);
+                }
                 else if (intIndex.Value < 0 || intIndex.Value >= array.Entries.Count)
-                    container = new ErrorExpression(string.Format("Index {0} not in range 0-{1}", intIndex.Value, array.Entries.Count - 1), index);
+                {
+                    if (array.Entries.Count == 0)
+                        container = new ErrorExpression("Cannot index empty array", Index);
+                    else
+                        container = new ErrorExpression(string.Format("Index {0} not in range 0-{1}", intIndex.Value, array.Entries.Count - 1), Index);
+                }
             }
         }
 

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -1360,5 +1360,25 @@ namespace RATools.Parser.Tests
 
                 "3:9 Cannot assign if statement to parameter");
         }
+
+        [Test]
+        public void TestArrayIndexOutOfRangeEmpty()
+        {
+            Evaluate("arr = []\n" +
+                     "index = 5\n" +
+                     "arr[index] = 3",
+
+                     "3:5 Cannot index empty array");
+        }
+
+        [Test]
+        public void TestArrayIndexOutOfRange()
+        {
+            Evaluate("arr = [1,2]\n" +
+                     "index = 5\n" +
+                     "arr[index] = 3",
+
+                     "3:5 Index 5 not in range 0-1");
+        }
     }
 }

--- a/Tests/Parser/Expressions/Trigger/MemoryAccessorExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/MemoryAccessorExpressionTests.cs
@@ -30,6 +30,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("byte(word(dword(0x002345) + 10) + 4660)", "I:0xX002345_I:0x 00000a_0xH001234")]
         [TestCase("byte(4660 + word(dword(0x002345) + 10))", "I:0xX002345_I:0x 00000a_0xH001234")]
         [TestCase("word((dword(0x002345) & 0x1FFFFFF) + 4660)", "I:0xX002345&33554431_0x 001234")]
+        [TestCase("word(dword(0x002345) - 0x8000000)", "I:0xX002345_0x f8000000")]
         [TestCase("byte(0x001234 + byte(0x2345))", "I:0xH002345_0xH001234")]
         [TestCase("byte(0x001234 - byte(0x2345))", "I:0xH002345*4294967295_0xH001234")]
         [TestCase("byte(0x001234 + byte(0x2345) * 0x10)", "I:0xH002345*16_0xH001234")]


### PR DESCRIPTION
Instead of saying "Index 2 is not in range (0--1)", will now say "Cannot index empty array".