### PR TITLE
replace redundant leaderboard submit with always_true

### DIFF
--- a/Source/Data/Requirement.cs
+++ b/Source/Data/Requirement.cs
@@ -431,7 +431,7 @@ namespace RATools.Data
         public override bool Equals(object obj)
         {
             var that = obj as Requirement;
-            if (ReferenceEquals(that, null))
+            if (that is null)
                 return false;
 
             if (that.Type != this.Type || that.Operator != this.Operator || that.HitCount != this.HitCount)
@@ -458,7 +458,7 @@ namespace RATools.Data
         {
             if (ReferenceEquals(left, right))
                 return true;
-            if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
+            if (left is null || right is null)
                 return false;
 
             return left.Equals(right);
@@ -471,7 +471,7 @@ namespace RATools.Data
         {
             if (ReferenceEquals(left, right))
                 return false;
-            if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
+            if (left is null || right is null)
                 return true;
 
             return !left.Equals(right);

--- a/Source/Data/RequirementGroup.cs
+++ b/Source/Data/RequirementGroup.cs
@@ -25,6 +25,60 @@ namespace RATools.Data
             return Serialize(new SerializationContext { AddressWidth = 4 });
         }
 
+        public override bool Equals(object obj)
+        {
+            var that = obj as RequirementGroup;
+            if (that == null)
+                return false;
+
+            var thisEnumerator = Requirements.GetEnumerator();
+            var thatEnumerator = that.Requirements.GetEnumerator();
+            while (thisEnumerator.MoveNext())
+            {
+                if (!thatEnumerator.MoveNext())
+                    return false;
+
+                if (thisEnumerator.Current != thatEnumerator.Current)
+                    return false;
+            }
+
+            if (thatEnumerator.MoveNext())
+                return false;
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        /// <summary>
+        /// Determines if two <see cref="RequirementGroup"/>s are equivalent.
+        /// </summary>
+        public static bool operator ==(RequirementGroup left, RequirementGroup right)
+        {
+            if (ReferenceEquals(left, right))
+                return true;
+            if (left is null || right is null)
+                return false;
+
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines if two <see cref="RequirementGroup"/>s are not equivalent.
+        /// </summary>
+        public static bool operator !=(RequirementGroup left, RequirementGroup right)
+        {
+            if (ReferenceEquals(left, right))
+                return false;
+            if (left is null || right is null)
+                return true;
+
+            return !left.Equals(right);
+        }
+
         /// <summary>
         /// Creates a serialized string from the requirement group.
         /// </summary>

--- a/Source/Data/Trigger.cs
+++ b/Source/Data/Trigger.cs
@@ -48,6 +48,63 @@ namespace RATools.Data
         /// </summary>
         public IEnumerable<RequirementGroup> Alts { get; private set; }
 
+        public override bool Equals(object obj)
+        {
+            var that = obj as Trigger;
+            if (that == null)
+                return false;
+
+            if (Core != that.Core)
+                return false;
+
+            var thisEnumerator = Alts.GetEnumerator();
+            var thatEnumerator = that.Alts.GetEnumerator();
+            while (thisEnumerator.MoveNext())
+            {
+                if (!thatEnumerator.MoveNext())
+                    return false;
+
+                if (thisEnumerator.Current != thatEnumerator.Current)
+                    return false;
+            }
+
+            if (thatEnumerator.MoveNext())
+                return false;
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        /// <summary>
+        /// Determines if two <see cref="Trigger"/>s are equivalent.
+        /// </summary>
+        public static bool operator ==(Trigger left, Trigger right)
+        {
+            if (ReferenceEquals(left, right))
+                return true;
+            if (left is null || right is null)
+                return false;
+
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines if two <see cref="Trigger"/>s are not equivalent.
+        /// </summary>
+        public static bool operator !=(Trigger left, Trigger right)
+        {
+            if (ReferenceEquals(left, right))
+                return false;
+            if (left is null || right is null)
+                return true;
+
+            return !left.Equals(right);
+        }
+
         /// <summary>
         /// Constructs a Trigger from a serialized trigger string.
         /// </summary>

--- a/Source/Parser/Functions/LeaderboardFunction.cs
+++ b/Source/Parser/Functions/LeaderboardFunction.cs
@@ -84,6 +84,16 @@ namespace RATools.Parser.Functions
                 return false;
             leaderboard.Id = integerExpression.Value;
 
+            if (leaderboard.Submit == leaderboard.Start)
+            {
+                // if the submit trigger is true in the same frame that the start trigger activates,
+                // the achievement will automatically submit. therefore, if the submit trigger is the
+                // same as the start trigger, it will automatically submit and we can just replace
+                // the submit trigger with always_true();
+                ErrorExpression error;
+                leaderboard.Submit = TriggerBuilder.BuildTrigger(new AlwaysTrueExpression(), out error);
+            }
+
             int sourceLine = 0;
             var functionCall = scope.GetContext<FunctionCallExpression>();
             if (functionCall != null && functionCall.FunctionName.Name == this.Name.Name)

--- a/Tests/Parser/Functions/LeaderboardFunctionTests.cs
+++ b/Tests/Parser/Functions/LeaderboardFunctionTests.cs
@@ -35,7 +35,7 @@ namespace RATools.Parser.Tests.Functions
             Assert.That(((IntegerConstantExpression)def.DefaultParameters["id"]).Value, Is.EqualTo(0));
         }
 
-        private Leaderboard Evaluate(string input, string expectedError = null)
+        private static Leaderboard Evaluate(string input, string expectedError = null)
         {
             var tokenizer = new PositionalTokenizer(Tokenizer.CreateTokenizer(input));
             var parser = new AchievementScriptInterpreter();
@@ -264,6 +264,15 @@ namespace RATools.Parser.Tests.Functions
                 "measured(repeated(10, byte(0x2345 + word(0x1234) * 4) == 6)))");
             var context = new SerializationContext { MinimumVersion = Version._0_77 };
             Assert.That(leaderboard.Value.Serialize(context), Is.EqualTo("I:0x 001234*4_M:0xH002345=6.10."));
+        }
+
+        [Test]
+        public void TestEliminateSubmitWhenMatchesStart()
+        {
+            var leaderboard = Evaluate("leaderboard(\"T\", \"D\", " +
+                "byte(0x1234) == 1, byte(0x1234) == 2, byte(0x1234) == 1, byte(0x2345))");
+            var context = new SerializationContext();
+            Assert.That(leaderboard.Submit.Serialize(context), Is.EqualTo("1=1"));
         }
     }
 }


### PR DESCRIPTION
closes #457 

If a leaderboard's submit condition is true in the frame where it's start condition becomes true, it will automatically submit. As a result, logically, if the submit and start condition are the same, the submit condition can be simplified to `always_true()`.

This PR changes it so that if a leaderboard's submit conditions _exactly_ match a leaderboard's start conditions, the submit condition will be changed to `always_true()`. This does not attempt to match conditions in an alternate order, or a subset of conditions, though both could logically be converted.