### PR TITLE
add Copy Definition to Clipboard link in achievement viewer

### DIFF
--- a/Source/ViewModels/AchievementViewModel.cs
+++ b/Source/ViewModels/AchievementViewModel.cs
@@ -1,5 +1,7 @@
-﻿using Jamiras.Components;
+﻿using Jamiras.Commands;
+using Jamiras.Components;
 using Jamiras.DataModels;
+using Jamiras.Services;
 using RATools.Data;
 using RATools.Services;
 using System;
@@ -13,6 +15,7 @@ namespace RATools.ViewModels
         public AchievementViewModel(GameViewModel owner)
             : base(owner)
         {
+            CopyDefinitionToClipboardCommand = new DelegateCommand(CopyDefinitionToClipboard);
         }
 
         public override string ViewerType
@@ -95,6 +98,9 @@ namespace RATools.ViewModels
                 return new TriggerViewModel[]
                 {
                     new TriggerViewModel("", achievement.Trigger, numberFormat, _owner != null ? _owner.Notes : new Dictionary<uint, string>())
+                    {
+                        CopyToClipboardCommand = new DelegateCommand(CopyDefinitionToClipboard)
+                    }
                 };
             }
 
@@ -104,6 +110,21 @@ namespace RATools.ViewModels
         protected override void UpdateLocal(AssetBase asset, AssetBase localAsset, StringBuilder warning, bool validateAll)
         {
             _owner.UpdateLocal((Achievement)asset, (Achievement)localAsset, warning, validateAll);
+        }
+
+        public DelegateCommand CopyDefinitionToClipboardCommand { get; private set; }
+
+        private void CopyDefinitionToClipboard()
+        {
+            var achievement = Generated.Asset as Achievement;
+            if (achievement == null)
+                achievement = Published.Asset as Achievement;
+
+            if (achievement != null)
+            {
+                var clipboard = ServiceRepository.Instance.FindService<IClipboardService>();
+                clipboard.SetData(achievement.Trigger.Serialize(_owner.SerializationContext));
+            }
         }
 
         public string MeasuredTarget

--- a/Source/Views/AchievementViewer.xaml
+++ b/Source/Views/AchievementViewer.xaml
@@ -50,7 +50,15 @@
                         <Run> | </Run>
                         <TextBlock Style="{StaticResource achievementTypeStyle}" />                    
                     </TextBlock>
-                    <TextBlock Style="{StaticResource assetIDStyle}" />
+                    <StackPanel Margin="6,0,2,0" Orientation="Horizontal">
+                        <TextBlock Margin="0,0,25,0" Style="{StaticResource assetIDStyle}" />
+
+                        <TextBlock FontSize="10">
+                            <Hyperlink Style="{StaticResource subtleHyperlink}" Command="{Binding CopyDefinitionToClipboardCommand}">
+                                <TextBlock Text="Copy Definition to Clipboard" />
+                            </Hyperlink>
+                        </TextBlock>
+                    </StackPanel>
                 </StackPanel>
                 
                 <ScrollViewer Grid.Row="1" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto"

--- a/Tests/ViewModels/AchievementViewModelTests.cs
+++ b/Tests/ViewModels/AchievementViewModelTests.cs
@@ -1,0 +1,70 @@
+﻿using Jamiras.Components;
+using Jamiras.Services;
+using Moq;
+using NUnit.Framework;
+using RATools.Data;
+using RATools.Parser;
+using RATools.Services;
+using RATools.ViewModels;
+
+namespace RATools.Tests.ViewModels
+{
+    [TestFixture]
+    class AchievementViewModelTests
+    {
+        private string _clipboardString;
+
+        [OneTimeSetUp]
+        public void FixtureSetup()
+        {
+            ServiceRepository.Reset();
+
+            var mockSettings = new Mock<ISettings>();
+            mockSettings.Setup(s => s.HexValues).Returns(true);
+            ServiceRepository.Instance.RegisterInstance<ISettings>(mockSettings.Object);
+
+            var mockClipboardService = new Mock<IClipboardService>();
+            mockClipboardService.Setup(c => c.SetData(It.IsAny<string>())).Callback((string s) => _clipboardString = s);
+            ServiceRepository.Instance.RegisterInstance<IClipboardService>(mockClipboardService.Object);
+        }
+
+        [OneTimeTearDown]
+        public void FixtureTeardown()
+        {
+            ServiceRepository.Reset();
+        }
+
+        private class MockGameViewModel : GameViewModel
+        {
+            public MockGameViewModel()
+                : base(99, "Game", new Mock<ILogger>().Object, new Mock<IFileSystemService>().Object)
+            {
+                SerializationContext = new SerializationContext();
+            }
+        }
+
+        [Test]
+        public void TestInitialization()
+        {
+            var vmAchievement = new AchievementViewModel(new MockGameViewModel());
+            Assert.That(vmAchievement.ViewerType, Is.EqualTo("Achievement"));
+        }
+
+
+        [Test]
+        public void TestCopyDefinitionToClipboard()
+        {
+            var input = "R:0x1234=6_0xh2345<6S0x5555!=d0x5555S0x4444=9";
+            var builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer(input));
+            var achievement = new Achievement();
+            achievement.Trigger = builder.ToTrigger();
+            var vmAchievement = new AchievementViewModel(new MockGameViewModel());
+            vmAchievement.Generated.Asset = achievement;
+
+            _clipboardString = null;
+            vmAchievement.CopyDefinitionToClipboardCommand.Execute();
+            Assert.That(_clipboardString, Is.EqualTo("R:0x 001234=6_0xH002345<6S0x 005555!=d0x 005555S0x 004444=9"));
+        }
+    }
+}


### PR DESCRIPTION
Closes #411 

Added as a link in the header to be similar to the Copy Title/Copy Description links in the leaderboard viewer.
![image](https://github.com/user-attachments/assets/dedef597-1fee-4972-b7c6-8b03b04e686f)
