### PR TITLE
add array_contains and dictionary_contains_key functions

### DIFF
--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -188,6 +188,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new ArrayPushFunction());
                 _globalScope.AddFunction(new ArrayPopFunction());
                 _globalScope.AddFunction(new ArrayMapFunction());
+                _globalScope.AddFunction(new ArrayContainsFunction());
 
                 _globalScope.AddFunction(new ConditionalExpression.OrNextWrapperFunction());
             }

--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -189,6 +189,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new ArrayPopFunction());
                 _globalScope.AddFunction(new ArrayMapFunction());
                 _globalScope.AddFunction(new ArrayContainsFunction());
+                _globalScope.AddFunction(new DictionaryContainsKeyFunction());
 
                 _globalScope.AddFunction(new ConditionalExpression.OrNextWrapperFunction());
             }

--- a/Source/Parser/Expressions/ExpressionBase.cs
+++ b/Source/Parser/Expressions/ExpressionBase.cs
@@ -1035,9 +1035,9 @@ namespace RATools.Parser.Expressions
         /// </summary>
         public static bool operator ==(ExpressionBase left, ExpressionBase right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
-            if (ReferenceEquals(right, null))
+            if (left is null)
+                return right is null;
+            if (right is null)
                 return false;
             if (left.Type != right.Type)
                 return false;
@@ -1050,9 +1050,9 @@ namespace RATools.Parser.Expressions
         /// </summary>
         public static bool operator !=(ExpressionBase left, ExpressionBase right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
-            if (ReferenceEquals(right, null))
+            if (left is null)
+                return right is not null;
+            if (right is null)
                 return true;
             if (left.Type != right.Type)
                 return true;

--- a/Source/Parser/Expressions/FloatConstantExpression.cs
+++ b/Source/Parser/Expressions/FloatConstantExpression.cs
@@ -60,7 +60,7 @@ namespace RATools.Parser.Expressions
         /// </returns>
         protected override bool Equals(ExpressionBase obj)
         {
-            var that = obj as IntegerConstantExpression;
+            var that = obj as FloatConstantExpression;
             return that != null && Value == that.Value;
         }
 

--- a/Source/Parser/Functions/ArrayContainsFunction.cs
+++ b/Source/Parser/Functions/ArrayContainsFunction.cs
@@ -1,0 +1,38 @@
+﻿using RATools.Parser.Expressions;
+
+namespace RATools.Parser.Functions
+{
+    internal class ArrayContainsFunction : FunctionDefinitionExpression
+    {
+        public ArrayContainsFunction()
+            : base("array_contains")
+        {
+            Parameters.Add(new VariableDefinitionExpression("array"));
+            Parameters.Add(new VariableDefinitionExpression("value"));
+        }
+
+        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        {
+            var array = GetArrayParameter(scope, "array", out result);
+            if (array == null)
+                return false;
+
+            var value = GetParameter(scope, "value", out result);
+            if (value == null)
+                return false;
+
+            result = new BooleanConstantExpression(false);
+
+            foreach (var entry in array.Entries)
+            {
+                if (entry == value)
+                {
+                    result = new BooleanConstantExpression(true);
+                    break;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Source/Parser/Functions/DictionaryContainsKeyFunction.cs
+++ b/Source/Parser/Functions/DictionaryContainsKeyFunction.cs
@@ -1,0 +1,38 @@
+﻿using RATools.Parser.Expressions;
+
+namespace RATools.Parser.Functions
+{
+    internal class DictionaryContainsKeyFunction : FunctionDefinitionExpression
+    {
+        public DictionaryContainsKeyFunction()
+            : base("dictionary_contains_key")
+        {
+            Parameters.Add(new VariableDefinitionExpression("dictionary"));
+            Parameters.Add(new VariableDefinitionExpression("key"));
+        }
+
+        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        {
+            var dictionary = GetDictionaryParameter(scope, "dictionary", out result);
+            if (dictionary == null)
+                return false;
+
+            var value = GetParameter(scope, "key", out result);
+            if (value == null)
+                return false;
+
+            result = new BooleanConstantExpression(false);
+
+            foreach (var entry in dictionary.Entries)
+            {
+                if (entry.Key == value)
+                {
+                    result = new BooleanConstantExpression(true);
+                    break;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Tests/Parser/Functions/ArrayContainsFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayContainsFunctionTests.cs
@@ -37,7 +37,7 @@ namespace RATools.Parser.Tests.Functions
         [TestCase("[byte(0x1234),byte(0x2345)]", "byte(0x2345) + 1", false)]
         public void TestEvaluate(string array, string value, bool expected)
         {
-            var scope = AchievementScriptInterpreter.GetGlobalScope();
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
             var result = FunctionTests.Evaluate<ArrayContainsFunction>(
                 string.Format("array_contains({0}, {1}", array, value), scope);
 

--- a/Tests/Parser/Functions/ArrayContainsFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayContainsFunctionTests.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+using RATools.Parser.Expressions;
+using RATools.Parser.Functions;
+using System.Linq;
+
+namespace RATools.Parser.Tests.Functions
+{
+    [TestFixture]
+    class ArrayContainsFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new ArrayContainsFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("array_contains"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(2));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("array"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("value"));
+        }
+
+        [Test]
+        [TestCase("[]", "1", false)]
+        [TestCase("[1]", "1", true)]
+        [TestCase("[1,2]", "2", true)]
+        [TestCase("[1,2,3]", "2", true)]
+        [TestCase("[1,2]", "2.0", false)] // type mismatch
+        [TestCase("[1,2]", "\"2\"", false)] // type mismatch
+        [TestCase("[1.0,2.0]", "2.0", true)]
+        [TestCase("[1.0,2.0]", "1.5", false)]
+        [TestCase("[1.0,2.0]", "2", false)] // type mismatch
+        [TestCase("[\"1\",\"2\"]", "\"2\"", true)]
+        [TestCase("[\"1\",\"2\"]", "\"3\"", false)]
+        [TestCase("[\"1\",\"2\"]", "2", false)] // type mismatch
+        [TestCase("[byte(0x1234),byte(0x2345)]", "byte(0x2345)", true)]
+        [TestCase("[byte(0x1234),byte(0x2345)]", "byte(0x3456)", false)]
+        [TestCase("[byte(0x1234),byte(0x2345)]", "word(0x2345)", false)]
+        [TestCase("[byte(0x1234),byte(0x2345)]", "byte(0x2345) + 1", false)]
+        public void TestEvaluate(string array, string value, bool expected)
+        {
+            var scope = AchievementScriptInterpreter.GetGlobalScope();
+            var result = FunctionTests.Evaluate<ArrayContainsFunction>(
+                string.Format("array_contains({0}, {1}", array, value), scope);
+
+            Assert.That(result, Is.InstanceOf<BooleanConstantExpression>());
+            Assert.That(((BooleanConstantExpression)result).Value, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Tests/Parser/Functions/DictionaryContainsKeyFunctionTests.cs
+++ b/Tests/Parser/Functions/DictionaryContainsKeyFunctionTests.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+using RATools.Parser.Expressions;
+using RATools.Parser.Functions;
+using System.Linq;
+
+namespace RATools.Parser.Tests.Functions
+{
+    [TestFixture]
+    class DictionaryContainsKeyFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new DictionaryContainsKeyFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("dictionary_contains_key"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(2));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("dictionary"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("key"));
+        }
+
+        [Test]
+        [TestCase("{}", "1", false)]
+        [TestCase("{1: true}", "1", true)]
+        [TestCase("{1: true, 2: false}", "2", true)]
+        [TestCase("{1: true, 2: false, 3: true}", "2", true)]
+        [TestCase("{1: true, 2: false}", "2.0", false)] // type mismatch
+        [TestCase("{1: true, 2: false}", "\"2\"", false)] // type mismatch
+        [TestCase("{\"1\": true, \"2\": false}", "\"2\"", true)]
+        [TestCase("{\"1\": true, \"2\": false}", "\"3\"", false)]
+        [TestCase("{\"1\": true, \"2\": false}", "2", false)] // type mismatch
+        public void TestEvaluate(string array, string value, bool expected)
+        {
+            var scope = AchievementScriptInterpreter.GetGlobalScope();
+            var result = FunctionTests.Evaluate<DictionaryContainsKeyFunction>(
+                string.Format("dictionary_contains_key({0}, {1}", array, value), scope);
+
+            Assert.That(result, Is.InstanceOf<BooleanConstantExpression>());
+            Assert.That(((BooleanConstantExpression)result).Value, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Tests/Parser/Functions/DictionaryContainsKeyFunctionTests.cs
+++ b/Tests/Parser/Functions/DictionaryContainsKeyFunctionTests.cs
@@ -30,7 +30,7 @@ namespace RATools.Parser.Tests.Functions
         [TestCase("{\"1\": true, \"2\": false}", "2", false)] // type mismatch
         public void TestEvaluate(string array, string value, bool expected)
         {
-            var scope = AchievementScriptInterpreter.GetGlobalScope();
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
             var result = FunctionTests.Evaluate<DictionaryContainsKeyFunction>(
                 string.Format("dictionary_contains_key({0}, {1}", array, value), scope);
 


### PR DESCRIPTION
`array_contains(array, value)` returns true/false depending on whether or not the provided value was found in the array. Effectively the same as `any_of(array, v => v == value)`.

`dictionary_contains_key(dictionary, key)` returns true/false depending on whether or not the provided key was found in the dictionary. Effectively the same as `any_of(dictionary, k => k == key)`.

While these functions are both wrappers for simple logical constructs that can already be created, there's very little need to actually have them, but they make the code a little bit easier to read. Additionally, they're slightly faster as the processing occurs natively instead of in the interpreter.