### PR TITLE
fix recursively calling nested function

### DIFF
--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net.Sockets;
 using System.Text;
 
 namespace RATools.Parser
@@ -99,7 +98,7 @@ namespace RATools.Parser
         /// <summary>
         /// Gets the serialization context of the interpreted script.
         /// </summary>
-        public SerializationContext SerializationContext { get; private set; }
+        public SerializationContext SerializationContext { get; internal set; }
 
         public static ExpressionGroupCollection CreateExpressionGroupCollection()
         {

--- a/Source/Parser/Expressions/FunctionDefinitionExpression.cs
+++ b/Source/Parser/Expressions/FunctionDefinitionExpression.cs
@@ -2,7 +2,6 @@
 using RATools.Data;
 using RATools.Parser.Expressions.Trigger;
 using RATools.Parser.Internal;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -92,6 +91,11 @@ namespace RATools.Parser.Expressions
         public virtual bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
             var interpreter = new AchievementScriptInterpreter();
+
+            var context = scope.GetContext<AchievementScriptContext>();
+            if (context != null)
+                interpreter.SerializationContext = context.SerializationContext;
+
             var interpreterScope = new InterpreterScope(scope) { Context = interpreter };
 
             result = AchievementScriptInterpreter.Execute(Expressions, interpreterScope);

--- a/Source/Parser/InterpreterScope.cs
+++ b/Source/Parser/InterpreterScope.cs
@@ -78,12 +78,19 @@ namespace RATools.Parser
 
                         do
                         {
+                            // found a script scope - remember it. we only want to return the outermost script scope
                             if (scope.Context is AchievementScriptContext)
                                 outermostScriptScope = scope;
 
+                            // if this scope defines the function being called, don't skip over it.
+                            if (scope._functions != null && scope._functions.ContainsKey(functionCall.FunctionName.Name))
+                                break;
+
+                            // end of list - we're done
                             if (scope._parent == null)
                                 break;
 
+                            // not end of list - keep searching
                             scope = scope._parent;
                         } while (true);
 

--- a/Tests/Parser/Expressions/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Expressions/FunctionCallExpressionTests.cs
@@ -532,6 +532,33 @@ namespace RATools.Parser.Tests.Expressions
         }
 
         [Test]
+        public void TestEvaluateNested()
+        {
+            var script =
+                "function format_number(number)\n" +
+                "{\n" +
+                "  function add_commas(number)\n" +
+                "  {\n" +
+                "    if (length(number) < 4)\n" +
+                "      return number\n" +
+                "\n" +
+                "    return add_commas(substring(number, 0, -3)) + \",\" + substring(number, -3)\n" +
+                "  }\n" +
+                "\n" +
+                "  return add_commas(number + \"\") // convert to string\n" +
+                "}\n" +
+                "\n" +
+                "a = format_number(12345678)";
+            var scope = AchievementScriptTests.Evaluate(script);
+            var a = scope.GetVariable("a");
+            Assert.That(a, Is.InstanceOf<StringConstantExpression>());
+            Assert.That(((StringConstantExpression)a).Value, Is.EqualTo("12,345,678"));
+
+            var add_commas = scope.GetFunction("add_commas");
+            Assert.That(add_commas, Is.Null);
+        }
+
+        [Test]
         public void TestInvokeNoReturnValue()
         {
             var functionDefinition = Parse("function func(i) { j = i }");


### PR DESCRIPTION
The logic to prevent functions from seeing variables defined in another function up the call stack was also preventing the logic from finding functions defined in another function up the call stack, which is necessary to be able to call a function recursively. I've modified the logic to look for function definitions at every point in the stack, but not variables.