### PR TITLE
don't generate legacy value syntax with division by float

### DIFF
--- a/Source/Data/Value.cs
+++ b/Source/Data/Value.cs
@@ -334,8 +334,19 @@ namespace RATools.Data
                             {
                                 if (enumerator.Current.Operator == RequirementOperator.Divide && multiplier < 1.0f)
                                 {
-                                    builder.Append('/');
-                                    multiplier = 1.0 / multiplier;
+                                    // legacy format supports integer division, but not floating point
+                                    // division. if the divisor is a floating point number, we have to
+                                    // multiply by the fraction.
+                                    var divisor = 1.0 / multiplier;
+                                    if (divisor == Math.Floor(divisor))
+                                    {
+                                        builder.Append('/');
+                                        multiplier = 1.0 / multiplier;
+                                    }
+                                    else
+                                    {
+                                        builder.Append('*');
+                                    }
                                 }
                                 else
                                 {

--- a/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
@@ -1,5 +1,6 @@
 ﻿using Jamiras.Components;
 using NUnit.Framework;
+using RATools.Data;
 using RATools.Parser.Expressions;
 using RATools.Parser.Functions;
 using RATools.Parser.Tests.Expressions;
@@ -94,6 +95,18 @@ namespace RATools.Parser.Tests.Functions
             var rp = Evaluate("rich_presence_value(\"Name\", " +
                 "max_of(byte(0x1234) * 3, byte(0x1235) * 5, byte(0x1236) * 8))");
             Assert.That(rp.ToString(), Is.EqualTo("Format:Name\r\nFormatType=VALUE\r\n\r\nDisplay:\r\n@Name(0xH001234*3$0xH001235*5$0xH001236*8)\r\n"));
+        }
+
+        [Test]
+        public void TestValueFloatDivision()
+        {
+            // float division not supported by legacy format, will be converted to multiplication
+            var rp = Evaluate("rich_presence_value(\"Name\", byte(0x1234) / 1.5)");
+            Assert.That(rp.ToString(), Is.EqualTo("Format:Name\r\nFormatType=VALUE\r\n\r\nDisplay:\r\n@Name(0xH001234*0.666667)\r\n"));
+
+            // float division not supported by legacy format. new format is available. use it.
+            var context = new SerializationContext { MinimumVersion = Version._0_77 };
+            Assert.That(rp.Serialize(context), Is.EqualTo("Format:Name\r\nFormatType=VALUE\r\n\r\nDisplay:\r\n@Name(A:0xH001234/f1.5_M:0)\r\n"));
         }
 
         [Test]

--- a/Tests/Parser/ValueBuilderTests.cs
+++ b/Tests/Parser/ValueBuilderTests.cs
@@ -142,7 +142,7 @@ namespace RATools.Parser.Tests
         [Test]
         [TestCase("byte(0x1234) * 2.5", "0xH001234*2.5")]
         [TestCase("byte(0x1234) * 10.0 / 3", "0xH001234*3.333333")]
-        [TestCase("(byte(0) + byte(1)) / 1.5", "0xH000000/1.5_0xH000001/1.5")]
+        [TestCase("(byte(0) + byte(1)) / 1.5", "0xH000000*0.666667_0xH000001*0.666667")]
         [TestCase("byte(0x1234) * 2.0", "0xH001234*2")]
         [TestCase("byte(0x1234) / 2.0", "0xH001234/2")]
         [TestCase("(byte(0x1234) / (2 * 20)) * 100.0", "0xH001234*2.5")]


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1285315597843955773/1294128018834456627

Legacy syntax supports division by integer values, but not division by floating point values. The division must be inverted to a multiplication, or non-legacy syntax used.