### PR TITLE
generate error when repeated clause contains distinct AndNext and OrNext clauses

### DIFF
--- a/Source/Parser/Expressions/FunctionDefinitionExpression.cs
+++ b/Source/Parser/Expressions/FunctionDefinitionExpression.cs
@@ -80,6 +80,13 @@ namespace RATools.Parser.Expressions
             builder.Append(')');
         }
 
+        protected void CopyLocation(ExpressionBase target, InterpreterScope scope)
+        {
+            var functionCall = scope.GetContext<FunctionCallExpression>();
+            if (functionCall != null)
+                functionCall.CopyLocation(target);
+        }
+
         /// <summary>
         /// Gets the return value from calling a function.
         /// </summary>

--- a/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
@@ -147,13 +147,26 @@ namespace RATools.Parser.Expressions.Trigger
             var subclauses = new List<RequirementExpressionBase>();
             foreach (var condition in conditions)
             {
-                var clause = condition as RequirementClauseExpression;
-                if (clause != null && clause._conditions != null)
+                if (HasComplexSubclause(condition))
                 {
-                    if (clause is OrNextRequirementClauseExpression && joinBehavior == RequirementType.None)
+                    if (condition is OrNextRequirementClauseExpression && joinBehavior == RequirementType.None)
+                    {
                         subclauses.Add(condition);
+                    }
                     else
-                        complexSubclauses.Add(clause);
+                    {
+                        var clause = condition as RequirementClauseExpression;
+                        if (clause == null && joinBehavior != RequirementType.None)
+                        {
+                            clause = new RequirementClauseExpression() { Operation = ConditionalOperation.And };
+                            clause.AddCondition(condition);
+                        }
+
+                        if (clause != null)
+                            complexSubclauses.Add(clause);
+                        else
+                            subclauses.Add(condition);
+                    }
                 }
                 else
                 {

--- a/Source/Parser/Expressions/Trigger/TalliedRequirementExpression.cs
+++ b/Source/Parser/Expressions/Trigger/TalliedRequirementExpression.cs
@@ -209,7 +209,8 @@ namespace RATools.Parser.Expressions.Trigger
                 {
                     HitTarget = HitTarget,
                     _conditions = newConditions,
-                    ResetCondition = newResetCondition
+                    ResetCondition = newResetCondition,
+                    Location = Location
                 };
             }
 
@@ -315,7 +316,7 @@ namespace RATools.Parser.Expressions.Trigger
 
                 error = condition.BuildSubclauseTrigger(context);
                 if (error != null)
-                    return error;
+                    return new ErrorExpression("Cannot tally expression", this) { InnerError = error };
 
                 var behaviorRequirement = condition as BehavioralRequirementExpression;
                 if (behaviorRequirement != null && behaviorRequirement.Behavior == RequirementType.SubHits)

--- a/Source/Parser/Functions/AlwaysFalseFunction.cs
+++ b/Source/Parser/Functions/AlwaysFalseFunction.cs
@@ -19,7 +19,7 @@ namespace RATools.Parser.Functions
         public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
             result = new AlwaysFalseExpression();
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
 

--- a/Source/Parser/Functions/AlwaysTrueFunction.cs
+++ b/Source/Parser/Functions/AlwaysTrueFunction.cs
@@ -19,7 +19,7 @@ namespace RATools.Parser.Functions
         public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
             result = new AlwaysTrueExpression();
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
 

--- a/Source/Parser/Functions/BitFunction.cs
+++ b/Source/Parser/Functions/BitFunction.cs
@@ -53,7 +53,7 @@ namespace RATools.Parser.Functions
             if (accessor != null)
                 accessor.Field = new Field { Type = accessor.Field.Type, Size = size, Value = accessor.Field.Value + offset };
 
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
     }

--- a/Source/Parser/Functions/DisableWhenFunction.cs
+++ b/Source/Parser/Functions/DisableWhenFunction.cs
@@ -30,7 +30,7 @@ namespace RATools.Parser.Functions
                 return false;
 
             result = new DisableWhenRequirementExpression() { Condition = comparison, Until = until };
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
     }

--- a/Source/Parser/Functions/FlagConditionFunction.cs
+++ b/Source/Parser/Functions/FlagConditionFunction.cs
@@ -46,7 +46,7 @@ namespace RATools.Parser.Functions
                         result = SplitClause(clause, ConditionalOperation.And, _type);
                     }
 
-                    CopyLocation(result);
+                    CopyLocation(result, scope);
                     return true;
                 }
             }
@@ -57,7 +57,7 @@ namespace RATools.Parser.Functions
                 Condition = comparison,
             };
 
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
 

--- a/Source/Parser/Functions/IdentityTransformFunction.cs
+++ b/Source/Parser/Functions/IdentityTransformFunction.cs
@@ -24,7 +24,7 @@ namespace RATools.Parser.Functions
             if (!parameter.ReplaceVariables(scope, out result))
                 return false;
 
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
     }

--- a/Source/Parser/Functions/MaxOfFunction.cs
+++ b/Source/Parser/Functions/MaxOfFunction.cs
@@ -29,7 +29,7 @@ namespace RATools.Parser.Functions
             }
 
             var maxOf = new MaxOfRequirementExpression();
-            CopyLocation(maxOf);
+            CopyLocation(maxOf, scope);
 
             foreach (var entry in varargs.Entries)
             {

--- a/Source/Parser/Functions/MeasuredFunction.cs
+++ b/Source/Parser/Functions/MeasuredFunction.cs
@@ -55,7 +55,7 @@ namespace RATools.Parser.Functions
             }
 
             result = new MeasuredRequirementExpression() { Condition = expression, When = when, Format = format };
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
     }

--- a/Source/Parser/Functions/MemoryAccessorFunction.cs
+++ b/Source/Parser/Functions/MemoryAccessorFunction.cs
@@ -36,7 +36,7 @@ namespace RATools.Parser.Functions
             if (result.Type == ExpressionType.Error)
                 return false;
 
-            CopyLocation(result);
+            CopyLocation(result, scope);
             result.MakeReadOnly();
             return true;
         }

--- a/Source/Parser/Functions/OnceFunction.cs
+++ b/Source/Parser/Functions/OnceFunction.cs
@@ -24,7 +24,7 @@ namespace RATools.Parser.Functions
             if (!RepeatedFunction.CreateTallyExpression(comparison, 1, out result))
                 return false;
 
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
     }

--- a/Source/Parser/Functions/PrevPriorFunction.cs
+++ b/Source/Parser/Functions/PrevPriorFunction.cs
@@ -33,7 +33,7 @@ namespace RATools.Parser.Functions
             if (!ReplaceVariables(result, scope, out result))
                 return false;
 
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
 

--- a/Source/Parser/Functions/RangeFunction.cs
+++ b/Source/Parser/Functions/RangeFunction.cs
@@ -67,7 +67,7 @@ namespace RATools.Parser.Functions
             }
 
             result = array;
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
     }

--- a/Source/Parser/Functions/RepeatedFunction.cs
+++ b/Source/Parser/Functions/RepeatedFunction.cs
@@ -39,7 +39,7 @@ namespace RATools.Parser.Functions
             if (!CreateTallyExpression(comparison, (uint)count.Value, out result))
                 return false;
 
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
 

--- a/Source/Parser/Functions/RichPresenceAsciiStringLookupFunction.cs
+++ b/Source/Parser/Functions/RichPresenceAsciiStringLookupFunction.cs
@@ -151,7 +151,7 @@ namespace RATools.Parser.Functions
             }
 
             result = new RichPresenceLookupExpression(name, expression) { Items = hashedDictionary, Fallback = fallback };
-            CopyLocation(result);
+            CopyLocation(result, scope);
             result.MakeReadOnly();
             return true;
         }

--- a/Source/Parser/Functions/RichPresenceLookupFunction.cs
+++ b/Source/Parser/Functions/RichPresenceLookupFunction.cs
@@ -53,7 +53,7 @@ namespace RATools.Parser.Functions
             }
 
             result = new RichPresenceLookupExpression(name, expression) { Items = dictionary, Fallback = fallback };
-            CopyLocation(result);
+            CopyLocation(result, scope);
             result.MakeReadOnly();
             return true;
         }

--- a/Source/Parser/Functions/RichPresenceMacroFunction.cs
+++ b/Source/Parser/Functions/RichPresenceMacroFunction.cs
@@ -98,7 +98,7 @@ namespace RATools.Parser.Functions
             }
 
             result = new RichPresenceMacroExpression(macro, expression) { Format = valueFormat };
-            CopyLocation(result);
+            CopyLocation(result, scope);
             result.MakeReadOnly();
             return true;
         }

--- a/Source/Parser/Functions/RichPresenceValueFunction.cs
+++ b/Source/Parser/Functions/RichPresenceValueFunction.cs
@@ -46,7 +46,7 @@ namespace RATools.Parser.Functions
             }
 
             result = new RichPresenceValueExpression(name, expression) { Format = valueFormat };
-            CopyLocation(result);
+            CopyLocation(result, scope);
             result.MakeReadOnly();
             return true;
         }

--- a/Source/Parser/Functions/TallyFunction.cs
+++ b/Source/Parser/Functions/TallyFunction.cs
@@ -55,7 +55,7 @@ namespace RATools.Parser.Functions
             if (!BuildTalliedRequirementExpression((uint)count.Value, varargs, tallyScope, out result))
                 return false;
 
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
 
@@ -142,7 +142,7 @@ namespace RATools.Parser.Functions
                 Condition = (RequirementExpressionBase)comparison
             };
 
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
     }

--- a/Source/Parser/Functions/TallyOfFunction.cs
+++ b/Source/Parser/Functions/TallyOfFunction.cs
@@ -35,7 +35,7 @@ namespace RATools.Parser.Functions
             if (!TallyFunction.BuildTalliedRequirementExpression((uint)count.Value, array, tallyScope, out result))
                 return false;
 
-            CopyLocation(result);
+            CopyLocation(result, scope);
             return true;
         }
     }

--- a/Tests/Parser/Expressions/Trigger/BehavioralRequirementExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/BehavioralRequirementExpression_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using RATools.Parser.Expressions;
 using RATools.Parser.Expressions.Trigger;
+using RATools.Parser.Internal;
 
 namespace RATools.Parser.Tests.Expressions.Trigger
 {
@@ -162,6 +163,19 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             var input = "byte(0x1234) == 1 && trigger_when(measured(repeated(3, byte(0x2345) == 6)))";
             var clause = TriggerExpressionTests.Parse<RequirementClauseExpression>(input);
             TriggerExpressionTests.AssertSerializeAchievement(clause, "0xH001234=1SM:0xH002345=6.3.ST:0=1");
+        }
+
+        [Test]
+        public void TestRepeatedNestedRepeatedWithOr()
+        {
+            var input = "never(repeated(2700, once(prev(byte(0x1234)) == 1 && byte(0x1234) == 2) && " +
+                                             "(byte(0x2345) != prev(byte(0x2345)) || byte(0x3456) != prev(byte(0x3456)))))";
+            var expression = TriggerExpressionTests.Parse<BehavioralRequirementExpression>(input);
+
+            var context = new AchievementBuilderContext();
+            var result = expression.BuildTrigger(context);
+
+            ExpressionTests.AssertError(result, "Cannot logically join multiple subclauses");
         }
     }
 }

--- a/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
@@ -69,6 +69,8 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("word(0x1234) & 0x1FF > prev(word(0x1234)) & 0x1FF", "A:0x 001234&511_B:d0x 001234&511_0>0")] // has to be converted to SubSource to prevent loss of masking
         [TestCase("word(0x1234) & 0x03 > prev(word(0x1234)) & 0xFF", "A:0xH001234&3_0>d0xH001234")] // word&0xFF -> byte
         [TestCase("word(0x1234) & 0x3FF > prev(word(0x1234)) & 0x1FFF", "A:0x 001234&1023_B:d0x 001234&8191_0>0")] // has to be converted to SubSource to prevent loss of masking
+        [TestCase("(bit1(0x001234) ^ 1) + (bit1(0x001235) ^ 1) == 2", "A:0xN001234^1_A:0xN001235^1_0=2")]
+        [TestCase("prev((bit1(0x001234) ^ 1) + (bit1(0x001235) ^ 1)) == 2", "A:d0xN001234^1_A:d0xN001235^1_0=2")]
         public void TestBuildTrigger(string input, string expected)
         {
             var clause = TriggerExpressionTests.Parse<RequirementConditionExpression>(input);


### PR DESCRIPTION
closes #504

Causes the problematic subclause `never(repeated(N, once(A=1 && B=2) && (C=3 || D=4)))` to generate an error instead of being incorrectly interpolated.

The bulk of the modifications are calling a function overload when a function call fails so the line number is reported correctly.