### PR TITLE
fix display of xor operator in achievement display

### DIFF
--- a/Source/Data/Requirement.cs
+++ b/Source/Data/Requirement.cs
@@ -609,6 +609,10 @@ namespace RATools.Data
                 case '&':
                     tokenizer.Advance();
                     return RequirementOperator.BitwiseAnd;
+
+                case '^':
+                    tokenizer.Advance();
+                    return RequirementOperator.BitwiseXor;
             }
 
             return RequirementOperator.None;

--- a/Source/Data/RequirementOperator.cs
+++ b/Source/Data/RequirementOperator.cs
@@ -163,6 +163,8 @@
         {
             switch (op)
             {
+                case RequirementOperator.Add:
+                case RequirementOperator.Subtract:
                 case RequirementOperator.Multiply:
                 case RequirementOperator.Divide:
                 case RequirementOperator.Modulus:

--- a/Tests/Data/RequirementTests.cs
+++ b/Tests/Data/RequirementTests.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using System.Text;
 
 namespace RATools.Data.Tests
 {

--- a/Tests/ViewModels/RequirementComparisonViewModelTests.cs
+++ b/Tests/ViewModels/RequirementComparisonViewModelTests.cs
@@ -22,6 +22,7 @@ namespace RATools.Tests.ViewModels
         [TestCase("0xH1234=7", "0xH1234=7.1.", "byte(0x001234) == 7", "once(byte(0x001234) == 7)", true)]
         [TestCase("0xH1234>0.1.", "0xH1234!=0.1.", "once(byte(0x001234) > 0)", "once(byte(0x001234) != 0)", true)]
         [TestCase("0xM1234>0.1.", "0xM1234=1.1.", "once(bit0(0x001234) > 0)", "once(bit0(0x001234) == 1)", true)]
+        [TestCase("A:0xO1234^1", "A:d0xO1234^1", "bit2(0x001234) ^ 0x01 + ", "prev(bit2(0x001234)) ^ 0x01 + ", true)]
         public void TestDefinitions(string leftSerialized, string rightSerialized, 
             string expectedDefinition, string expectedOtherDefinition, bool expectedModified)
         {


### PR DESCRIPTION
As shown in https://github.com/Jamiras/RATools/issues/541#issuecomment-2477605343, the `^` was not being displayed in the achievement viewer.