### PR TITLE
eliminate non-ResetIf conditions that are always true when ResetIf is not true

### DIFF
--- a/Source/Parser/Internal/RequirementMerger.cs
+++ b/Source/Parser/Internal/RequirementMerger.cs
@@ -471,6 +471,13 @@ namespace RATools.Parser.Internal
             }
         }
 
+        public static Requirement MergeRequirements(Requirement left, Requirement right, ConditionalOperation condition)
+        {
+            Requirement merged;
+            MergeRequirements(left, right, condition, out merged);
+            return merged;
+        }
+
         private static MoreRestrictiveRequirement MergeRequirements(Requirement left, Requirement right, ConditionalOperation condition, out Requirement merged)
         {
             merged = null;

--- a/Tests/Parser/Internal/RequirementMergerTests.cs
+++ b/Tests/Parser/Internal/RequirementMergerTests.cs
@@ -27,7 +27,7 @@ namespace RATools.Parser.Tests.Internal
             return achievement;
         }
 
-        private void AssertLogicalMerge(string input, string y, string expected)
+        private static void AssertLogicalMerge(string input, string y, string expected)
         {
             input = input.Replace("X", "6");
             input = input.Replace("Y", y);

--- a/Tests/Parser/Internal/RequirementsOptimizerTests.cs
+++ b/Tests/Parser/Internal/RequirementsOptimizerTests.cs
@@ -232,6 +232,12 @@ namespace RATools.Parser.Tests.Internal
         [TestCase("prev(byte(0x001234)) == 1 && prev(byte(0x001234)) == 1", "prev(byte(0x001234)) == 1")]
         [TestCase("once(byte(0x001234) == 1) && once(byte(0x001234) == 1)", "once(byte(0x001234) == 1)")]
         [TestCase("never(byte(0x001234) != prev(byte(0x001234))) && never(byte(0x001234) != prev(byte(0x001234)))", "byte(0x001234) == prev(byte(0x001234))")]
+        [TestCase("never(byte(0x001234) != 1) && byte(0x001234) != 3 && once(byte(0x002345) == 1)",
+                  "never(byte(0x001234) != 1) && once(byte(0x002345) == 1)")] // never(a!=1) is effectively a==1, so a!=3 can be eliminated
+        [TestCase("never(byte(0x001234) == 1) && byte(0x001234) == 3 && once(byte(0x002345) == 1)",
+                  "never(byte(0x001234) == 1) && byte(0x001234) == 3 && once(byte(0x002345) == 1)")] // never(a==1) is effectively a!=1, a==3 is more specific and cannot be eliminated
+        [TestCase("never(byte(0x001234) == 1) && byte(0x001234) != 3 && once(byte(0x002345) == 1)",
+                  "never(byte(0x001234) == 1) && byte(0x001234) != 3 && once(byte(0x002345) == 1)")] // never(a==1) is effectively a!=1, so a!=3 cannot be eliminated
         [TestCase("byte(0x001234) == 1 && byte(0x002345) + byte(0x001234) == 1", "byte(0x001234) == 1 && (byte(0x002345) + byte(0x001234)) == 1")] // duplicate in AddSource clause should be ignored
         [TestCase("byte(0x002345) + byte(0x001234) == 1 && byte(0x002345) + byte(0x001234) == 1", "(byte(0x002345) + byte(0x001234)) == 1")] // complete AddSource duplicate should be elimiated
         [TestCase("byte(0x001234) == 1 && once(byte(0x002345) == 1 && byte(0x001234) == 1)", "byte(0x001234) == 1 && once(byte(0x002345) == 1 && byte(0x001234) == 1)")] // duplicate in AndNext clause should be ignored


### PR DESCRIPTION
For example:
```
ResetIf a != 1
        a != 5
```

If `a` is not 1, the achievement cannot possibly trigger because of the ResetIf, so `a` must be something other than 5 at the time it triggers, making the second clause unnecessary.