### PR TITLE
Add array_filter and array_reduce functions

### DIFF
--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -188,6 +188,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new ArrayPushFunction());
                 _globalScope.AddFunction(new ArrayPopFunction());
                 _globalScope.AddFunction(new ArrayMapFunction());
+                _globalScope.AddFunction(new ArrayReduceFunction());
                 _globalScope.AddFunction(new ArrayContainsFunction());
                 _globalScope.AddFunction(new DictionaryContainsKeyFunction());
                 _globalScope.AddFunction(new AssertFunction());

--- a/Source/Parser/AchievementScriptInterpreter.cs
+++ b/Source/Parser/AchievementScriptInterpreter.cs
@@ -189,6 +189,7 @@ namespace RATools.Parser
                 _globalScope.AddFunction(new ArrayPopFunction());
                 _globalScope.AddFunction(new ArrayMapFunction());
                 _globalScope.AddFunction(new ArrayReduceFunction());
+                _globalScope.AddFunction(new ArrayFilterFunction());
                 _globalScope.AddFunction(new ArrayContainsFunction());
                 _globalScope.AddFunction(new DictionaryContainsKeyFunction());
                 _globalScope.AddFunction(new AssertFunction());

--- a/Source/Parser/Functions/AllOfFunction.cs
+++ b/Source/Parser/Functions/AllOfFunction.cs
@@ -11,38 +11,38 @@ namespace RATools.Parser.Functions
         {
         }
 
-        protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
+        protected override ExpressionBase Combine(ExpressionBase accumulator, ExpressionBase predicateResult, ExpressionBase predicateInput)
         {
-            if (left == null)
-                return right;
+            if (accumulator == null)
+                return predicateResult;
 
-            var booleanRight = right as BooleanConstantExpression;
+            var booleanRight = predicateResult as BooleanConstantExpression;
             if (booleanRight != null)
             {
-                var booleanLeft = left as BooleanConstantExpression;
+                var booleanLeft = accumulator as BooleanConstantExpression;
                 if (booleanLeft == null)
                     return new BooleanConstantExpression(booleanRight.Value);
 
                 return new BooleanConstantExpression(booleanLeft.Value && booleanRight.Value);
             }
 
-            right.IsLogicalUnit = true;
+            predicateResult.IsLogicalUnit = true;
 
-            var clause = left as RequirementClauseExpression;
+            var clause = accumulator as RequirementClauseExpression;
             if (clause == null || clause.Operation != ConditionalOperation.And)
             {
                 clause = new RequirementClauseExpression { Operation = ConditionalOperation.And };
 
-                var leftRequirement = left as RequirementExpressionBase;
+                var leftRequirement = accumulator as RequirementExpressionBase;
                 if (leftRequirement == null)
-                    return new ErrorExpression("condition is not a requirement", left);
+                    return new ErrorExpression("condition is not a requirement", accumulator);
 
                 clause.AddCondition(leftRequirement);
             }
 
-            var rightRequirement = right as RequirementExpressionBase;
+            var rightRequirement = predicateResult as RequirementExpressionBase;
             if (rightRequirement == null)
-                return new ErrorExpression("condition is not a requirement", right);
+                return new ErrorExpression("condition is not a requirement", predicateResult);
 
             clause.AddCondition(rightRequirement);
             return clause;

--- a/Source/Parser/Functions/AnyOfFunction.cs
+++ b/Source/Parser/Functions/AnyOfFunction.cs
@@ -10,38 +10,38 @@ namespace RATools.Parser.Functions
         {
         }
 
-        protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
+        protected override ExpressionBase Combine(ExpressionBase accumulator, ExpressionBase predicateResult, ExpressionBase predicateInput)
         {
-            if (left == null)
-                return right;
+            if (accumulator == null)
+                return predicateResult;
 
-            var booleanRight = right as BooleanConstantExpression;
+            var booleanRight = predicateResult as BooleanConstantExpression;
             if (booleanRight != null)
             {
-                var booleanLeft = left as BooleanConstantExpression;
+                var booleanLeft = accumulator as BooleanConstantExpression;
                 if (booleanLeft == null)
                     return new BooleanConstantExpression(booleanRight.Value);
 
                 return new BooleanConstantExpression(booleanLeft.Value || booleanRight.Value);
             }
 
-            right.IsLogicalUnit = true;
+            predicateResult.IsLogicalUnit = true;
 
-            var clause = left as RequirementClauseExpression;
+            var clause = accumulator as RequirementClauseExpression;
             if (clause == null || clause.Operation != ConditionalOperation.Or)
             {
                 clause = new RequirementClauseExpression { Operation = ConditionalOperation.Or };
 
-                var leftRequirement = left as RequirementExpressionBase;
+                var leftRequirement = accumulator as RequirementExpressionBase;
                 if (leftRequirement == null)
-                    return new ErrorExpression("condition is not a requirement", left);
+                    return new ErrorExpression("condition is not a requirement", accumulator);
 
                 clause.AddCondition(leftRequirement);
             }
 
-            var rightRequirement = right as RequirementExpressionBase;
+            var rightRequirement = predicateResult as RequirementExpressionBase;
             if (rightRequirement == null)
-                return new ErrorExpression("condition is not a requirement", right);
+                return new ErrorExpression("condition is not a requirement", predicateResult);
 
             clause.AddCondition(rightRequirement);
             return clause;

--- a/Source/Parser/Functions/ArrayFilterFunction.cs
+++ b/Source/Parser/Functions/ArrayFilterFunction.cs
@@ -22,9 +22,8 @@ namespace RATools.Parser.Functions
 
             var boolResult = predicateResult as BooleanConstantExpression;
             if (boolResult.Value)
-            { 
                 array.Entries.Add(predicateInput);
-            }
+
             return array;
         }
 

--- a/Source/Parser/Functions/ArrayFilterFunction.cs
+++ b/Source/Parser/Functions/ArrayFilterFunction.cs
@@ -1,0 +1,36 @@
+﻿using RATools.Parser.Expressions;
+
+namespace RATools.Parser.Functions
+{
+    internal class ArrayFilterFunction : IterableJoiningFunction
+    {
+        public ArrayFilterFunction()
+            : base("array_filter")
+        {
+        }
+
+        protected ArrayFilterFunction(string name)
+            : base(name)
+        {
+        }
+
+        protected override ExpressionBase Combine(ExpressionBase accumulator, ExpressionBase predicateResult, ExpressionBase predicateInput)
+        {
+            var array = accumulator as ArrayExpression;
+            if (array == null)
+                array = new ArrayExpression();
+
+            var boolResult = predicateResult as BooleanConstantExpression;
+            if (boolResult.Value)
+            { 
+                array.Entries.Add(predicateInput);
+            }
+            return array;
+        }
+
+        protected override ExpressionBase GenerateEmptyResult()
+        {
+            return new ArrayExpression();
+        }
+    }
+}

--- a/Source/Parser/Functions/ArrayMapFunction.cs
+++ b/Source/Parser/Functions/ArrayMapFunction.cs
@@ -14,13 +14,13 @@ namespace RATools.Parser.Functions
         {
         }
 
-        protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
+        protected override ExpressionBase Combine(ExpressionBase accumulator, ExpressionBase predicateResult, ExpressionBase predicateInput)
         {
-            var array = left as ArrayExpression;
+            var array = accumulator as ArrayExpression;
             if (array == null)
                 array = new ArrayExpression();
 
-            array.Entries.Add(right);
+            array.Entries.Add(predicateResult);
             return array;
         }
 

--- a/Source/Parser/Functions/ArrayReduceFunction.cs
+++ b/Source/Parser/Functions/ArrayReduceFunction.cs
@@ -18,13 +18,11 @@ namespace RATools.Parser.Functions
         {
             var array = GetParameter(scope, "inputs", out result);
             if (array == null)
-            {
                 return false;
-            }
+
             if (!array.ReplaceVariables(scope, out result))
-            {
                 return false;
-            }
+
             var inputs = result as IIterableExpression;
             if (inputs == null)
             {
@@ -34,15 +32,12 @@ namespace RATools.Parser.Functions
 
             var accumulator = GetParameter(scope, "initial", out result);
             if (accumulator == null)
-            {
                 return false;
-            }
 
             var reducer = GetFunctionParameter(scope, "reducer", out result);
             if (reducer == null)
-            {
                 return false;
-            }
+
             if ((reducer.Parameters.Count - reducer.DefaultParameters.Count) != 2)
             {
                 result = new ErrorExpression("reducer function must accept two parameters (acc, value)");
@@ -51,9 +46,7 @@ namespace RATools.Parser.Functions
 
             var iteratorScope = reducer.CreateCaptureScope(scope);
             foreach (var kvp in reducer.DefaultParameters)
-            {
                 iteratorScope.AssignVariable(new VariableExpression(kvp.Key), kvp.Value);
-            }
 
             var innerAccumulator = new VariableExpression(reducer.Parameters.First().Name);
             var nextInput = new VariableExpression(reducer.Parameters.ElementAt(1).Name);
@@ -61,21 +54,19 @@ namespace RATools.Parser.Functions
             foreach (var input in inputs.IterableExpressions())
             {
                 if (!input.ReplaceVariables(iteratorScope, out result))
-                {
                     return false;
-                }
+
                 iteratorScope.AssignVariable(innerAccumulator, accumulator);
                 iteratorScope.AssignVariable(nextInput, result);
+
                 if (!reducer.Evaluate(iteratorScope, out result))
-                {
                     return false;
-                }
                 if (result == null)
                 {
                     result = new ErrorExpression("reducer function did not return a value", reducer);
                     return false;
                 }
-                else if (result.Type == ExpressionType.Error)
+                if (result.Type == ExpressionType.Error)
                     return false;
 
                 accumulator = result;

--- a/Source/Parser/Functions/ArrayReduceFunction.cs
+++ b/Source/Parser/Functions/ArrayReduceFunction.cs
@@ -1,0 +1,72 @@
+﻿using RATools.Parser.Expressions;
+using System;
+using System.Linq;
+
+namespace RATools.Parser.Functions
+{
+    internal class ArrayReduceFunction : FunctionDefinitionExpression
+    {
+        public ArrayReduceFunction()
+            : base("array_reduce")
+        {
+            Parameters.Add(new VariableDefinitionExpression("inputs"));
+            Parameters.Add(new VariableDefinitionExpression("initial"));
+            Parameters.Add(new VariableDefinitionExpression("reducer"));
+        }
+
+        public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
+        {
+            var array = GetParameter(scope, "inputs", out result);
+            if (array == null)
+            {
+                return false;
+            }
+            if (!array.ReplaceVariables(scope, out result))
+            {
+                return false;
+            }
+            var inputs = result as IIterableExpression;
+            if (inputs == null)
+            {
+                result = new ErrorExpression("Cannot iterate over " + result.ToString(), result);
+                return false;
+            }
+
+            var accumulatorExpression = GetParameter(scope, "initial", out result);
+
+            var funcParam = GetFunctionParameter(scope, "reducer", out result);
+            if ((funcParam.Parameters.Count - funcParam.DefaultParameters.Count) != 2)
+            {
+                result = new ErrorExpression("reducer function must accept two parameters (acc, value)");
+                return false;
+            }
+
+            var iteratorScope = funcParam.CreateCaptureScope(scope);
+            foreach (var kvp in funcParam.DefaultParameters)
+            {
+                iteratorScope.AssignVariable(new VariableExpression(kvp.Key), kvp.Value);
+            }
+
+            foreach (var input in inputs.IterableExpressions())
+            {
+                input.ReplaceVariables(iteratorScope, out result);
+                iteratorScope.AssignVariable(new VariableExpression(funcParam.Parameters.First().Name), accumulatorExpression);
+                iteratorScope.AssignVariable(new VariableExpression(funcParam.Parameters.Last().Name), input);
+                if (!funcParam.Evaluate(iteratorScope, out result))
+                {
+                    return false;
+                }
+                if (result == null)
+                {
+                    result = new ErrorExpression("reducer function did not return a value", funcParam);
+                    return false;
+                }
+                accumulatorExpression = result;
+
+            }
+
+            result = accumulatorExpression;
+            return true;
+        }
+    }
+}

--- a/Source/Parser/Functions/ArrayReduceFunction.cs
+++ b/Source/Parser/Functions/ArrayReduceFunction.cs
@@ -33,8 +33,16 @@ namespace RATools.Parser.Functions
             }
 
             var accumulatorExpression = GetParameter(scope, "initial", out result);
+            if (accumulatorExpression == null)
+            {
+                return false;
+            }
 
             var funcParam = GetFunctionParameter(scope, "reducer", out result);
+            if (funcParam == null)
+            {
+                return false;
+            }
             if ((funcParam.Parameters.Count - funcParam.DefaultParameters.Count) != 2)
             {
                 result = new ErrorExpression("reducer function must accept two parameters (acc, value)");
@@ -49,7 +57,10 @@ namespace RATools.Parser.Functions
 
             foreach (var input in inputs.IterableExpressions())
             {
-                input.ReplaceVariables(iteratorScope, out result);
+                if (!input.ReplaceVariables(iteratorScope, out result))
+                {
+                    return false;
+                }
                 iteratorScope.AssignVariable(new VariableExpression(funcParam.Parameters.First().Name), accumulatorExpression);
                 iteratorScope.AssignVariable(new VariableExpression(funcParam.Parameters.Last().Name), input);
                 if (!funcParam.Evaluate(iteratorScope, out result))

--- a/Source/Parser/Functions/IterableJoiningFunction.cs
+++ b/Source/Parser/Functions/IterableJoiningFunction.cs
@@ -67,7 +67,7 @@ namespace RATools.Parser.Functions
                     return false;
                 }
 
-                expression = Combine(expression, result);
+                expression = Combine(expression, result, predicateParameter.GetValue(iteratorScope));
                 if (expression.Type == ExpressionType.Error)
                 {
                     result = expression;
@@ -84,7 +84,7 @@ namespace RATools.Parser.Functions
             return true;
         }
 
-        protected abstract ExpressionBase Combine(ExpressionBase left, ExpressionBase right);
+        protected abstract ExpressionBase Combine(ExpressionBase accumulator, ExpressionBase predicateResult, ExpressionBase predicateInput);
 
         protected abstract ExpressionBase GenerateEmptyResult();
     }

--- a/Source/Parser/Functions/NoneOfFunction.cs
+++ b/Source/Parser/Functions/NoneOfFunction.cs
@@ -11,39 +11,39 @@ namespace RATools.Parser.Functions
         {
         }
 
-        protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
+        protected override ExpressionBase Combine(ExpressionBase accumulator, ExpressionBase predicateResult, ExpressionBase predicateInput)
         {
-            var booleanRight = right as BooleanConstantExpression;
+            var booleanRight = predicateResult as BooleanConstantExpression;
             if (booleanRight != null)
             {
-                var booleanLeft = left as BooleanConstantExpression;
+                var booleanLeft = accumulator as BooleanConstantExpression;
                 if (booleanLeft == null)
                     return new BooleanConstantExpression(!booleanRight.Value);
 
                 return new BooleanConstantExpression(booleanLeft.Value && !booleanRight.Value);
             }
 
-            var rightRequirement = right as RequirementExpressionBase;
+            var rightRequirement = predicateResult as RequirementExpressionBase;
             if (rightRequirement == null)
-                return new ErrorExpression("condition is not a requirement", right);
+                return new ErrorExpression("condition is not a requirement", predicateResult);
 
             rightRequirement = rightRequirement.InvertLogic();
             if (rightRequirement == null)
-                return new ErrorExpression("Could not invert logic", right);
+                return new ErrorExpression("Could not invert logic", predicateResult);
 
             rightRequirement.IsLogicalUnit = true;
 
-            if (left == null)
+            if (accumulator == null)
                 return rightRequirement;
 
-            var clause = left as RequirementClauseExpression;
+            var clause = accumulator as RequirementClauseExpression;
             if (clause == null || clause.Operation != ConditionalOperation.And)
             {
                 clause = new RequirementClauseExpression { Operation = ConditionalOperation.And };
 
-                var leftRequirement = left as RequirementExpressionBase;
+                var leftRequirement = accumulator as RequirementExpressionBase;
                 if (leftRequirement == null)
-                    return new ErrorExpression("condition is not a requirement", left);
+                    return new ErrorExpression("condition is not a requirement", accumulator);
 
                 clause.AddCondition(leftRequirement);
             }

--- a/Source/Parser/Functions/SumOfFunction.cs
+++ b/Source/Parser/Functions/SumOfFunction.cs
@@ -9,12 +9,12 @@ namespace RATools.Parser.Functions
         {
         }
 
-        protected override ExpressionBase Combine(ExpressionBase left, ExpressionBase right)
+        protected override ExpressionBase Combine(ExpressionBase accumulator, ExpressionBase predicateResult, ExpressionBase predicateInput)
         {
-            if (left == null)
-                return right;
+            if (accumulator == null)
+                return predicateResult;
 
-            var combined = new MathematicExpression(left, MathematicOperation.Add, right);
+            var combined = new MathematicExpression(accumulator, MathematicOperation.Add, predicateResult);
             return combined.MergeOperands();
         }
 

--- a/Tests/Parser/Functions/ArrayFilterFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayFilterFunctionTests.cs
@@ -64,7 +64,7 @@ namespace RATools.Parser.Tests.Functions
             dict.Add(key, array);
             scope.DefineVariable(new VariableDefinitionExpression("dict"), dict);
 
-            var result = FunctionTests.Evaluate<ArrayMapFunction>("array_filter(dict[0], a => a > 1)", scope);
+            var result = FunctionTests.Evaluate<ArrayFilterFunction>("array_filter(dict[0], a => a > 1)", scope);
             Assert.That(result, Is.Not.Null);
 
             var builder = new StringBuilder();

--- a/Tests/Parser/Functions/ArrayFilterFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayFilterFunctionTests.cs
@@ -1,0 +1,146 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Parser.Expressions;
+using RATools.Parser.Functions;
+using System.Linq;
+using System.Text;
+
+namespace RATools.Parser.Tests.Functions
+{
+    [TestFixture]
+    class ArrayFilterFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new ArrayFilterFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("array_filter"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(2));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("inputs"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("predicate"));
+        }
+
+        private static string Evaluate(string input)
+        {
+            var tokenizer = Tokenizer.CreateTokenizer(input);
+            var expr = ExpressionBase.Parse(new PositionalTokenizer(tokenizer));
+            var funcCall = expr as FunctionCallExpression;
+            if (funcCall != null)
+            {
+                var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+                scope.Context = new AssignmentExpression(new VariableExpression("t"), expr);
+                if (funcCall.Evaluate(scope, out expr))
+                {
+                    var builder = new StringBuilder();
+                    expr.AppendString(builder);
+                    return builder.ToString();
+                }
+            }
+
+            var error = expr as ErrorExpression;
+            if (error != null)
+                return error.InnermostError.Message;
+
+            return expr.ToString();
+        }
+
+        [Test]
+        public void TestSimple()
+        {
+            Assert.That(Evaluate("array_filter([1, 2, 3], a => a > 1)"),
+                Is.EqualTo("[2, 3]"));
+        }
+
+        [Test]
+        public void TestNested()
+        {
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+            var array = new ArrayExpression();
+            array.Entries.Add(new IntegerConstantExpression(1));
+            array.Entries.Add(new IntegerConstantExpression(2));
+            array.Entries.Add(new IntegerConstantExpression(3));
+            var dict = new DictionaryExpression();
+            var key = new IntegerConstantExpression(0);
+            dict.Add(key, array);
+            scope.DefineVariable(new VariableDefinitionExpression("dict"), dict);
+
+            var result = FunctionTests.Evaluate<ArrayMapFunction>("array_filter(dict[0], a => a > 1)", scope);
+            Assert.That(result, Is.Not.Null);
+
+            var builder = new StringBuilder();
+            result.AppendString(builder);
+            Assert.That(builder.ToString(), Is.EqualTo("[2, 3]"));
+        }
+
+        [Test]
+        public void TestSingleElement()
+        {
+            Assert.That(Evaluate("array_filter([1], a => a < 3)"),
+                Is.EqualTo("[1]"));
+        }
+
+        [Test]
+        public void TestNonIterable()
+        {
+            Assert.That(Evaluate("array_filter(1, a => a > 1)"),
+                Is.EqualTo("Cannot iterate over IntegerConstant: 1"));
+        }
+
+        [Test]
+        public void TestNoElements()
+        {
+            Assert.That(Evaluate("array_filter([], a => true)"),
+                Is.EqualTo("[]"));
+        }
+
+        [Test]
+        public void TestLogic()
+        {
+            // if the predicate returns false, ignore the item
+            Assert.That(Evaluate("array_filter([1, 2, 3], (a) { if (a % 2 == 0) { return true } else { return false }})"),
+                Is.EqualTo("[2]"));
+        }
+
+        [Test]
+        public void TestRange()
+        {
+            Assert.That(Evaluate("array_filter(range(1,20), a => a % 3 == 0)"),
+                Is.EqualTo("[3, 6, 9, 12, 15, 18]"));
+        }
+
+        [Test]
+        public void TestDictionary()
+        {
+            Assert.That(Evaluate("array_filter({1:\"One\",2:\"Two\",3:\"Three\"}, a => a > 1)"),
+                Is.EqualTo("[2, 3]"));
+        }
+
+        [Test]
+        public void TestPredicateWithNoParameters()
+        {
+            Assert.That(Evaluate("array_filter([1], () => true)"),
+                Is.EqualTo("predicate function must accept a single parameter"));
+        }
+
+        [Test]
+        public void TestPredicateWithExtraParameters()
+        {
+            Assert.That(Evaluate("array_filter([1], (a, b) => true"),
+                Is.EqualTo("predicate function must accept a single parameter"));
+        }
+
+        [Test]
+        public void TestMissingReturn()
+        {
+            Assert.That(Evaluate("array_filter([1, 2, 3], (a) { if (a == 2) return true })"),
+                Is.EqualTo("predicate did not return a value"));
+        }
+
+        [Test]
+        public void TestErrorInPredicate()
+        {
+            Assert.That(Evaluate("array_filter([1, 2, 3], (a) { return b })"),
+                Is.EqualTo("Unknown variable: b"));
+        }
+    }
+}

--- a/Tests/Parser/Functions/ArrayReduceFunctionTests.cs
+++ b/Tests/Parser/Functions/ArrayReduceFunctionTests.cs
@@ -1,0 +1,154 @@
+﻿using Jamiras.Components;
+using NUnit.Framework;
+using RATools.Parser.Expressions;
+using RATools.Parser.Functions;
+using System.Linq;
+using System.Text;
+
+namespace RATools.Parser.Tests.Functions
+{
+    [TestFixture]
+    class ArrayReduceFunctionTests
+    {
+        [Test]
+        public void TestDefinition()
+        {
+            var def = new ArrayReduceFunction();
+            Assert.That(def.Name.Name, Is.EqualTo("array_reduce"));
+            Assert.That(def.Parameters.Count, Is.EqualTo(3));
+            Assert.That(def.Parameters.ElementAt(0).Name, Is.EqualTo("inputs"));
+            Assert.That(def.Parameters.ElementAt(1).Name, Is.EqualTo("initial"));
+            Assert.That(def.Parameters.ElementAt(2).Name, Is.EqualTo("reducer"));
+        }
+
+        private static string Evaluate(string input)
+        {
+            var tokenizer = Tokenizer.CreateTokenizer(input);
+            var expr = ExpressionBase.Parse(new PositionalTokenizer(tokenizer));
+            var funcCall = expr as FunctionCallExpression;
+            if (funcCall != null)
+            {
+                var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+                scope.Context = new AssignmentExpression(new VariableExpression("t"), expr);
+                if (funcCall.Evaluate(scope, out expr))
+                {
+                    var builder = new StringBuilder();
+                    expr.AppendString(builder);
+                    return builder.ToString();
+                }
+            }
+
+            var error = expr as ErrorExpression;
+            if (error != null)
+                return error.InnermostError.Message;
+
+            return expr.ToString();
+        }
+
+        [Test]
+        public void TestSimple()
+        {
+            Assert.That(Evaluate("array_reduce([1, 2, 3], 0, (acc, v) => acc + v)"),
+                Is.EqualTo("6"));
+        }
+
+        [Test]
+        public void TestComplex()
+        {
+            Assert.That(Evaluate("array_reduce([1, 2, 3], [], (acc, v) { if (v % 2 == 0) { return acc } else { array_push(acc, byte(v)) return acc } })"),
+                Is.EqualTo("[byte(0x000001), byte(0x000003)]"));
+        }
+
+        [Test]
+        public void TestNested()
+        {
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+            var array = new ArrayExpression();
+            array.Entries.Add(new IntegerConstantExpression(1));
+            array.Entries.Add(new IntegerConstantExpression(2));
+            array.Entries.Add(new IntegerConstantExpression(3));
+            var dict = new DictionaryExpression();
+            var key = new IntegerConstantExpression(0);
+            dict.Add(key, array);
+            scope.DefineVariable(new VariableDefinitionExpression("dict"), dict);
+
+            var result = FunctionTests.Evaluate<ArrayReduceFunction>("array_reduce(dict[0], 0, (acc, v) => acc + v)", scope);
+            Assert.That(result, Is.Not.Null);
+
+            var builder = new StringBuilder();
+            result.AppendString(builder);
+            Assert.That(builder.ToString(), Is.EqualTo("6"));
+        }
+
+        [Test]
+        public void TestSingleElement()
+        {
+            Assert.That(Evaluate("array_reduce([1], 3, (acc, v) => acc * v)"),
+                Is.EqualTo("3"));
+        }
+
+        [Test]
+        public void TestNonIterable()
+        {
+            Assert.That(Evaluate("array_reduce(1, 0, a => byte(a))"),
+                Is.EqualTo("Cannot iterate over IntegerConstant: 1"));
+        }
+
+        [Test]
+        public void TestNoElements()
+        {
+            Assert.That(Evaluate("array_reduce([], 100, (acc, v) => acc + v)"),
+                Is.EqualTo("100"));
+        }
+
+        [Test]
+        public void TestLogic()
+        {
+            // if the predicate returns false, ignore the item
+            Assert.That(Evaluate("array_reduce([1, 2, 3], 0, (acc, v) { if (v % 2 == 0) { return acc } else { return acc + v }})"),
+                Is.EqualTo("4"));
+        }
+
+        [Test]
+        public void TestRange()
+        {
+            Assert.That(Evaluate("array_reduce(range(1,100), 0, (acc, v) => acc + v)"),
+                Is.EqualTo("5050"));
+        }
+
+        [Test]
+        public void TestDictionary()
+        {
+            Assert.That(Evaluate("array_reduce({1:\"One\",2:\"Two\",3:\"Three\"}, 0, (acc, v) => acc + v)"),
+                Is.EqualTo("6"));
+        }
+
+        [Test]
+        public void TestReducerWithNoParameters()
+        {
+            Assert.That(Evaluate("array_reduce([1], 0, () => byte(0x1234))"),
+                Is.EqualTo("reducer function must accept two parameters (acc, value)"));
+        }
+
+        [Test]
+        public void TestReducerWithExtraParameters()
+        {
+            Assert.That(Evaluate("array_reduce([1], 0, (a, b, c) => byte(a))"),
+                Is.EqualTo("reducer function must accept two parameters (acc, value)"));
+        }
+
+        [Test]
+        public void TestMissingReturn()
+        {
+            Assert.That(Evaluate("array_reduce([1, 2, 3], 0, (acc, v) { if (v > 4) return acc + v })"),
+                Is.EqualTo("reducer function did not return a value"));
+        }
+
+        [Test]
+        public void TestErrorInReducer()
+        {
+            Assert.That(Evaluate("array_reduce([1, 2, 3], 0, (acc, v) { return b })"),
+                Is.EqualTo("Unknown variable: b"));
+        }
+    }
+}


### PR DESCRIPTION
Really feel these missing when working with any sort of functional paradigm in scripts. Adds both with test cases.

`array_filter` was added as an IterableJoiningFunction. Its base Evaluate method had to be updated to pass the predicate input into the Combine call, and I renamed the variables for clarity since "left" and "right" don't really apply in the general reducer case. This allows future predicate functions to do more general reducer things in their Evaluate functions.

Ironically though, the `array_reduce` function can't inherit that class since its signature is different (as is the signature of its reducer function). I spent some time trying to refactor IterableJoiningFunction to be more general so as to not repeat code, but ended up deciding that exposing the raw reduce functionality to the end user had to be handled differently enough that it made sense to just be its own thing.