### PR TITLE
fix legacy value serialization of combining two memrefs

### DIFF
--- a/Source/Data/Value.cs
+++ b/Source/Data/Value.cs
@@ -301,6 +301,19 @@ namespace RATools.Data
 
                         enumerator.Current.Left.Serialize(builder, serializationContext);
 
+                        if (enumerator.Current.Right.IsMemoryReference)
+                        {
+                            switch (enumerator.Current.Operator)
+                            {
+                                case RequirementOperator.Multiply: builder.Append('*'); break;
+                                case RequirementOperator.Divide: builder.Append('/'); break;
+                                default: builder.Append('?'); break;
+                            }
+
+                            enumerator.Current.Right.Serialize(builder, serializationContext);
+                            return;
+                        }
+
                         double multiplier = 1.0;
                         if (enumerator.Current.Type == RequirementType.SubSource)
                             multiplier = -1.0;

--- a/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
@@ -66,6 +66,7 @@ namespace RATools.Parser.Tests.Functions
         [Test]
         [TestCase("byte(0x1234) + 1", "0xH001234_v1")]
         [TestCase("byte(0x1234) % 3", "A:0xH001234%3_M:0")]
+        [TestCase("float(0x1234) * ~bit(31, 0x2345)", "fF001234*~0xT002348")]
         public void TestValueExpression(string input, string expected)
         {
             // more expressions are validated via ValueBuilderTests.TestGetValueString


### PR DESCRIPTION
fixes #558 

A rich presence macro containing a single expression was assumed to be a memref and a constant multiplier. Using a memref multiplier was unhandled, so it turned the address into a constant and proceeded.