### PR TITLE
prevent null exception highlighting indexed function result

### DIFF
--- a/Source/Parser/Expressions/IndexedVariableExpression.cs
+++ b/Source/Parser/Expressions/IndexedVariableExpression.cs
@@ -241,14 +241,19 @@ namespace RATools.Parser.Expressions
         protected override bool Equals(ExpressionBase obj)
         {
             var that = obj as IndexedVariableExpression;
-            return that != null && Variable == that.Variable && Index == that.Index;
+            return that != null && Variable == that.Variable && Index == that.Index &&
+                _source == that._source;
         }
 
         IEnumerable<ExpressionBase> INestedExpressions.NestedExpressions
         {
             get
             {
-                yield return Variable;
+                if (Variable != null)
+                    yield return Variable;
+                else if (_source is ExpressionBase)
+                    yield return (ExpressionBase)_source;
+
                 yield return Index;
             }
         }
@@ -256,6 +261,10 @@ namespace RATools.Parser.Expressions
         void INestedExpressions.GetDependencies(HashSet<string> dependencies)
         {
             var nested = Variable as INestedExpressions;
+            if (nested != null)
+                nested.GetDependencies(dependencies);
+
+            nested = _source as INestedExpressions;
             if (nested != null)
                 nested.GetDependencies(dependencies);
 

--- a/Source/ViewModels/GameViewModel.cs
+++ b/Source/ViewModels/GameViewModel.cs
@@ -79,7 +79,7 @@ namespace RATools.ViewModels
         internal Dictionary<uint, string> Notes { get; private set; }
         internal SerializationContext SerializationContext { get; set; }
 
-        public string LocalFilePath { get { return _localAssets.Filename; } }
+        public string LocalFilePath { get { return _localAssets?.Filename; } }
 
         public ScriptViewModel Script { get; protected set; }
 

--- a/Tests/Parser/Expressions/FunctionCallExpressionTests.cs
+++ b/Tests/Parser/Expressions/FunctionCallExpressionTests.cs
@@ -749,6 +749,23 @@ namespace RATools.Parser.Tests.Expressions
         }
 
         [Test]
+        public void TestDeferenceReturnedDictionary2()
+        {
+            var userFunc = Parse("function f() { return {0:\"no\",1:\"yes\"}}");
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+            scope.AddFunction(userFunc);
+
+            var tokenizer = Tokenizer.CreateTokenizer("v = f()[1]");
+            var assignment = ExpressionBase.Parse(new PositionalTokenizer(tokenizer));
+            Assert.That(assignment, Is.InstanceOf<AssignmentExpression>());
+            Assert.That(((AssignmentExpression)assignment).Execute(scope), Is.Null);
+
+            var value = scope.GetVariable("v");
+            Assert.That(value, Is.InstanceOf<StringConstantExpression>());
+            Assert.That(((StringConstantExpression)value).Value, Is.EqualTo("yes"));
+        }
+
+        [Test]
         public void TestDeferenceReturnedArray()
         {
             var userFunc = Parse("function f() => [\"no\",\"yes\"]");

--- a/Tests/Parser/Expressions/IndexedVariableExpressionTests.cs
+++ b/Tests/Parser/Expressions/IndexedVariableExpressionTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using Jamiras.Components;
+using NUnit.Framework;
 using RATools.Parser.Expressions;
 using System.Collections.Generic;
 using System.Linq;
@@ -263,6 +264,19 @@ namespace RATools.Parser.Tests.Expressions
         }
 
         [Test]
+        public void TestNestedExpressionsFunctionCall()
+        {
+            var tokenizer = Tokenizer.CreateTokenizer("lookup()[1]");
+            var expr = ExpressionBase.Parse(new PositionalTokenizer(tokenizer));
+
+            var nested = ((INestedExpressions)expr).NestedExpressions;
+
+            Assert.That(nested.Count(), Is.EqualTo(2));
+            Assert.That(nested.First(), Is.InstanceOf<FunctionCallExpression>());
+            Assert.That(nested.ElementAt(1), Is.InstanceOf<IntegerConstantExpression>());
+        }
+
+        [Test]
         public void TestGetDependencies()
         {
             var variable = new VariableExpression("variable1");
@@ -275,6 +289,19 @@ namespace RATools.Parser.Tests.Expressions
             Assert.That(dependencies.Count, Is.EqualTo(2));
             Assert.That(dependencies.Contains("variable1"));
             Assert.That(dependencies.Contains("variable2"));
+        }
+
+        [Test]
+        public void TestGetDependenciesFunctionCall()
+        {
+            var tokenizer = Tokenizer.CreateTokenizer("lookup()[1]");
+            var expr = ExpressionBase.Parse(new PositionalTokenizer(tokenizer));
+
+            var dependencies = new HashSet<string>();
+            ((INestedExpressions)expr).GetDependencies(dependencies);
+
+            Assert.That(dependencies.Count, Is.EqualTo(1));
+            Assert.That(dependencies.Contains("lookup"));
         }
 
         [Test]


### PR DESCRIPTION
fixes #560 

Parsing the logic was working fine. There was an issue trying to apply the syntax highlighting.