### PR TITLE
track divisor separately to avoid rounding error

### DIFF
--- a/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
@@ -66,6 +66,7 @@ namespace RATools.Parser.Tests.Functions
         [Test]
         [TestCase("byte(0x1234) + 1", "0xH001234_v1")]
         [TestCase("byte(0x1234) % 3", "A:0xH001234%3_M:0")]
+        [TestCase("dword(0x1234) / 1000000000", "0xX001234/1000000000")]
         public void TestValueExpression(string input, string expected)
         {
             // more expressions are validated via ValueBuilderTests.TestGetValueString


### PR DESCRIPTION
fixes https://discord.com/channels/310192285306454017/936655398725902356/1352487987770032138

"Division by 1 billion" was being converted to "multiplication by 1E-09", then back to division as "division by 999999999.9999998" (or something similar). Since it wasn't an even integer value, the code chose to keep the multiplication and output 1E-09 to six significant digits, resulting in 0.000000, which was simplified to just 0.

Solution: track division separately instead of deriving it by inverting the multiplication accumulator.