### PR TITLE
support AddSource in Remember inside AddAddress chain

### DIFF
--- a/Source/Parser/Expressions/MathematicExpression.cs
+++ b/Source/Parser/Expressions/MathematicExpression.cs
@@ -161,6 +161,31 @@ namespace RATools.Parser.Expressions
                         result = inverseCombinable.CombineInverse(left, Operation);
 
                     if (result == null)
+                    {
+                        var memoryValue = right as MemoryValueExpression;
+                        if (memoryValue != null)
+                        {
+                            var remember = new RememberRecallExpression(memoryValue);
+                            result = remember.CombineInverse(left, Operation);
+
+                            if (result == null && combinable != null)
+                                result = combinable.Combine(remember, Operation);
+                        }
+                        else
+                        {
+                            memoryValue = left as MemoryValueExpression;
+                            if (memoryValue != null)
+                            {
+                                var remember = new RememberRecallExpression(memoryValue);
+                                result = remember.Combine(right, Operation);
+
+                                if (result == null&& inverseCombinable != null)
+                                    result = inverseCombinable.CombineInverse(remember, Operation);
+                            }
+                        }
+                    }
+
+                    if (result == null)
                         result = CreateCannotCombineError(left, Operation, right);
                 }
             }

--- a/Source/Parser/Expressions/Trigger/MemoryAccessorExpression.cs
+++ b/Source/Parser/Expressions/Trigger/MemoryAccessorExpression.cs
@@ -114,7 +114,6 @@ namespace RATools.Parser.Expressions.Trigger
             if (_pointerChain == null)
                 _pointerChain = new List<Requirement>();
 
-            Debug.Assert(pointer.Type == RequirementType.AddAddress || pointer.Type == RequirementType.Remember);
             _pointerChain.Add(pointer);
         }
 

--- a/Source/Parser/Expressions/Trigger/MemoryValueExpression.cs
+++ b/Source/Parser/Expressions/Trigger/MemoryValueExpression.cs
@@ -1459,7 +1459,7 @@ namespace RATools.Parser.Expressions.Trigger
             for (int i = 1; i < memoryAccessors.Count; i++)
             {
                 var memoryAccessor = memoryAccessors[i];
-                if (memoryAccessor.MemoryAccessor is RememberRecallExpression)
+                if (memoryAccessor.HasRememberRecall)
                 {
                     memoryAccessors.RemoveAt(i);
                     memoryAccessors.Insert(insertIndex++, memoryAccessor);

--- a/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
+++ b/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
@@ -34,6 +34,7 @@ namespace RATools.Parser.Expressions.Trigger
             ModifyingOperator = source.ModifyingOperator;
             Modifier = source.Modifier;
             Location = source.Location;
+            _rememberModifier = source._rememberModifier;
         }
 
         /// <summary>
@@ -80,21 +81,21 @@ namespace RATools.Parser.Expressions.Trigger
         }
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private Field _modifier;
+        protected RememberRecallExpression _rememberModifier;
 
-        /// <summary>
-        /// Gets the remembered value to use as a modifier.
-        /// </summary>
-        public RememberRecallExpression RememberModifier
+        public bool HasRememberRecall
         {
-            get { return _rememberModifier; }
-            set
+            get
             {
-                Debug.Assert(!IsReadOnly);
-                _rememberModifier = value;
+                if (_rememberModifier != null)
+                    return true;
+
+                if (MemoryAccessor is RememberRecallExpression)
+                    return true;
+
+                return false;
             }
         }
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        protected RememberRecallExpression _rememberModifier;
 
         /// <summary>
         /// Gets or sets the operator used to combine this <see cref="ModifiedMemoryAccessorExpression"/>
@@ -366,6 +367,8 @@ namespace RATools.Parser.Expressions.Trigger
 
             Field field;
 
+            right = ReduceToSimpleExpression(right);
+
             var rightAccessor = right as MemoryAccessorExpression;
             if (rightAccessor != null)
             {
@@ -403,7 +406,15 @@ namespace RATools.Parser.Expressions.Trigger
             }
             else
             {
-                if (MemoryAccessor.HasPointerChain)
+                var memoryValue = right as MemoryValueExpression;
+                if (memoryValue != null)
+                {
+                    _rememberModifier = new RememberRecallExpression(memoryValue);
+                    ModifyingOperator = operation.ToRequirementOperator();
+                    _modifier = FieldFactory.CreateField(_rememberModifier);
+                    return this;
+                }
+                else if (MemoryAccessor.HasPointerChain)
                 {
                     var rightModifiedAccessor = right as ModifiedMemoryAccessorExpression;
                     if (rightModifiedAccessor != null && rightModifiedAccessor.ModifyingOperator != RequirementOperator.None)

--- a/Tests/Parser/Functions/AchievementFunctionTests.cs
+++ b/Tests/Parser/Functions/AchievementFunctionTests.cs
@@ -197,5 +197,19 @@ namespace RATools.Parser.Tests.Functions
             var builder = new AchievementBuilder(achievement);
             Assert.That(builder.Type, Is.EqualTo(expectedType));
         }
+
+        [Test]
+        public void TestRememberRecallChain()
+        {
+            var achievement = Evaluate(
+                "function f(x,y) => x/2 + y*(byte(0x1234)*2 + byte(0x1235)*3 + 1)\n" +
+                "function d(n) => byte(0x5555 + n*4)\n" +
+                "achievement(\"T\", \"D\", 5, d(f(byte(0x2222), byte(0x3333))) == 8)");
+            var builder = new AchievementBuilder(achievement);
+            Assert.That(builder.SerializeRequirements(new SerializationContext()), 
+                Is.EqualTo("A:0xH001234*2_A:0xH001235*3_K:1_A:0xH003333*{recall}_K:0xH002222/2_I:{recall}*4_0xH005555=8"));
+            //              ^-----------------------------^ ^------------------^ ^-----------^ ^----------^ ^---------^
+            //              byte(0x1234)*2+byte(0x1235)*3+1         *y    +           x / 2        * 4      byte(0x555+...)=8
+        }
     }
 }


### PR DESCRIPTION
Fixes https://discord.com/channels/310192285306454017/936655398725902356/1365806949257711666

In order to correctly create the indirect pointer, Remember/Recall is needed with an AddSource chain. While Remember/Recall is supported in pointer chains, AddSource was not.