### PR TITLE
prevent IndexOutOfRangeException if multiple clauses of complex subclause can be eliminated

### DIFF
--- a/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
@@ -793,6 +793,7 @@ namespace RATools.Parser.Expressions.Trigger
                     var subclause = clause._conditions[j] as RequirementClauseExpression; // AND
                     if (subclause == null)
                     {
+                        bool wasRemoved = false;
                         foreach (var coreCondition in conditions.OfType<RequirementConditionExpression>())
                         {
                             var intersect = clause._conditions[j].LogicalIntersect(coreCondition, ConditionalOperation.And);
@@ -803,11 +804,16 @@ namespace RATools.Parser.Expressions.Trigger
                                 // and can be removed from conditions.
                                 conditions.RemoveAt(i);
                                 newClause = null;
+
+                                wasRemoved = true; // break out of outer loop
                                 break;
                             }
                         }
 
-                        continue;
+                        if (wasRemoved)
+                            break;
+                        else
+                            continue;
                     }
 
                     RequirementClauseExpression newSubclause = null;


### PR DESCRIPTION
Fixes https://discord.com/channels/310192285306454017/936655398725902356/1367192440666193920

Caused by two very similar conditions being wrapped in `unless()` incorrectly:
```
              unless(String_Compare(Name(), Name1) &&
              unless(String_Compare(Name(), Name2)))
```
instead of
```
              unless(String_Compare(Name(), Name1)) &&
              unless(String_Compare(Name(), Name2))
```
As a result, the second clause was being merged into the first clause, and due to the extreme similarity, it was trying to eliminate the same condition multiple times.