### PR TITLE
fix reading memory at pointer address with no offset

### DIFF
--- a/Source/Parser/Expressions/FunctionDefinitionExpression.cs
+++ b/Source/Parser/Expressions/FunctionDefinitionExpression.cs
@@ -1,6 +1,7 @@
 ﻿using Jamiras.Components;
 using RATools.Data;
 using RATools.Parser.Expressions.Trigger;
+using RATools.Parser.Functions;
 using RATools.Parser.Internal;
 using System.Collections.Generic;
 using System.Linq;
@@ -340,7 +341,7 @@ namespace RATools.Parser.Expressions
             if (accessorParameter != null)
             {
                 var memoryAccessor = new MemoryAccessorExpression(FieldType.MemoryAddress, FieldSize.DWord, 0U);
-                foreach (var pointer in memoryAccessor.PointerChain)
+                foreach (var pointer in accessorParameter.PointerChain)
                     memoryAccessor.AddPointer(pointer);
                 memoryAccessor.AddPointer(new Requirement { Type = RequirementType.AddAddress, Left = accessorParameter.Field });
                 parameter.CopyLocation(memoryAccessor);
@@ -350,7 +351,7 @@ namespace RATools.Parser.Expressions
             var memoryValueParameter = parameter as MemoryValueExpression;
             if (memoryValueParameter != null)
             {
-                var memoryAccessor = memoryValueParameter.ConvertToMemoryAccessor();
+                var memoryAccessor = MemoryAccessorFunction.CreateMemoryAccessorExpression(memoryValueParameter, FieldSize.DWord) as MemoryAccessorExpression;
                 if (memoryAccessor != null)
                     return memoryAccessor;
             }

--- a/Source/Parser/Expressions/Trigger/MemoryValueExpression.cs
+++ b/Source/Parser/Expressions/Trigger/MemoryValueExpression.cs
@@ -1,5 +1,4 @@
 ﻿using RATools.Data;
-using RATools.Parser.Functions;
 using RATools.Parser.Internal;
 using System;
 using System.Collections.Generic;

--- a/Source/Parser/Expressions/Trigger/MemoryValueExpression.cs
+++ b/Source/Parser/Expressions/Trigger/MemoryValueExpression.cs
@@ -1,4 +1,5 @@
 ﻿using RATools.Data;
+using RATools.Parser.Functions;
 using RATools.Parser.Internal;
 using System;
 using System.Collections.Generic;
@@ -1196,40 +1197,15 @@ namespace RATools.Parser.Expressions.Trigger
             return comparison;
         }
 
-        public MemoryAccessorExpression ConvertToMemoryAccessor()
+        private MemoryAccessorExpression ConvertToMemoryAccessor()
         {
             if (_memoryAccessors == null)
                 return null;
 
-            if (_memoryAccessors.Count <= 2 &&
-                _memoryAccessors.All(m => m.CombiningOperator == RequirementType.AddSource &&
-                                          m.ModifyingOperator == RequirementOperator.None))
+            if (_memoryAccessors.Count == 1 && !HasConstant &&
+                _memoryAccessors[0].ModifyingOperator == RequirementOperator.None)
             {
-                if (_memoryAccessors.Count == 1 && !HasConstant)
-                    return _memoryAccessors[0].MemoryAccessor;
-
-                var requirement = new Requirement
-                {
-                    Type = RequirementType.AddAddress,
-                    Left = _memoryAccessors[0].MemoryAccessor.Field
-                };
-
-                if (_memoryAccessors.Count == 2)
-                {
-                    if (HasConstant)
-                        return null;
-
-                    requirement.Operator = RequirementOperator.Add;
-                    requirement.Right = _memoryAccessors[1].MemoryAccessor.Field;
-                }
-
-                var memoryAccessor = new MemoryAccessorExpression(FieldType.MemoryAddress, FieldSize.DWord, (uint)IntegerConstant);
-                foreach (var pointer in _memoryAccessors[0].MemoryAccessor.PointerChain)
-                    memoryAccessor.AddPointer(pointer);
-                memoryAccessor.AddPointer(requirement);
-
-                CopyLocation(memoryAccessor);
-                return memoryAccessor;
+                return _memoryAccessors[0].MemoryAccessor;
             }
 
             return null;

--- a/Source/Parser/Functions/BitFunction.cs
+++ b/Source/Parser/Functions/BitFunction.cs
@@ -45,14 +45,17 @@ namespace RATools.Parser.Functions
                 case 7: size = FieldSize.Bit7; break;
             }
 
-            result = CreateMemoryAccessorExpression(address);
-            if (result.Type == ExpressionType.Error)
+            var accessor = CreateMemoryAccessorExpression(address, size);
+            if (accessor == null)
+            {
+                result = new ConversionErrorExpression(address, "memory address", address.Location);
                 return false;
+            }
 
-            var accessor = result as MemoryAccessorExpression;
-            if (accessor != null)
+            if (offset != 0)
                 accessor.Field = new Field { Type = accessor.Field.Type, Size = size, Value = accessor.Field.Value + offset };
 
+            result = accessor;
             CopyLocation(result, scope);
             return true;
         }

--- a/Source/Parser/Functions/MemoryAccessorFunction.cs
+++ b/Source/Parser/Functions/MemoryAccessorFunction.cs
@@ -31,20 +31,23 @@ namespace RATools.Parser.Functions
             if (address == null)
                 return false;
 
-            result = CreateMemoryAccessorExpression(address);
-            if (result.Type == ExpressionType.Error)
+            result = CreateMemoryAccessorExpression(address, Size);
+            if (result == null)
+            {
+                result = new ConversionErrorExpression(address, "memory address", address.Location);
                 return false;
+            }
 
             CopyLocation(result, scope);
             result.MakeReadOnly();
             return true;
         }
 
-        protected ExpressionBase CreateMemoryAccessorExpression(ExpressionBase address)
+        public static MemoryAccessorExpression CreateMemoryAccessorExpression(ExpressionBase address, FieldSize size)
         {
             var integerConstant = address as IntegerConstantExpression;
             if (integerConstant != null)
-                return new MemoryAccessorExpression(FieldType.MemoryAddress, Size, (uint)integerConstant.Value);
+                return new MemoryAccessorExpression(FieldType.MemoryAddress, size, (uint)integerConstant.Value);
 
             var accessor = address as MemoryAccessorExpression;
             if (accessor != null)
@@ -54,68 +57,88 @@ namespace RATools.Parser.Functions
                     result.AddPointer(pointer);
 
                 result.AddPointer(new Requirement { Type = RequirementType.AddAddress, Left = accessor.Field });
-                result.Field = new Field { Type = FieldType.MemoryAddress, Size = Size, Value = 0 };
+                result.Field = new Field { Type = FieldType.MemoryAddress, Size = size, Value = 0 };
                 return result;
             }
 
             var memoryValue = address as MemoryValueExpression;
             if (memoryValue != null)
             {
-                if (memoryValue.MemoryAccessors.Count() > 1)
-                {
-                    accessor = memoryValue.ConvertToMemoryAccessor();
-                    if (accessor != null)
-                    {
-                        if (accessor.Field.Size != Size)
-                        {
-                            if (accessor.IsReadOnly)
-                                accessor = accessor.Clone();
-
-                            accessor.Field = accessor.Field.ChangeSize(Size);
-                        }
-                        return accessor;
-                    }
-
-                    // chain of logic to build address has to be stored in the recall accumulator
-                    accessor = new MemoryAccessorExpression();
-                    accessor.RememberPointer = new RememberRecallExpression(memoryValue);
-                    accessor.Field = new Field { Type = FieldType.MemoryAddress, Size = Size, Value = 0 };
-                    return accessor;
-                }
-
-                var result = CreateMemoryAccessorExpression(memoryValue.MemoryAccessors.First());
+                var result = CreateMemoryAccessorExpression(memoryValue, size);
                 if (result != null)
-                {
-                    result.Field = new Field
-                    {
-                        Type = FieldType.MemoryAddress,
-                        Size = Size,
-                        Value = (uint)memoryValue.IntegerConstant
-                    };
                     return result;
-                }
             }
 
             var modifiedMemoryAccessor = address as ModifiedMemoryAccessorExpression;
             if (modifiedMemoryAccessor != null)
             {
-                var result = CreateMemoryAccessorExpression(modifiedMemoryAccessor);
+                var result = CreateMemoryAccessorExpression(modifiedMemoryAccessor, size, 0);
                 if (result != null)
-                {
-                    result.Field = new Field
-                    {
-                        Type = FieldType.MemoryAddress,
-                        Size = Size,
-                        Value = 0 // no offset
-                    };
                     return result;
-                }
             }
 
-            return new ConversionErrorExpression(address, "memory address", address.Location);
+            return null;
         }
 
-        private static MemoryAccessorExpression CreateMemoryAccessorExpression(ModifiedMemoryAccessorExpression modifiedMemoryAccessor)
+        private static MemoryAccessorExpression CreateMemoryAccessorExpression(MemoryValueExpression memoryValue, FieldSize size)
+        {
+            var count = memoryValue.MemoryAccessors.Count();
+            if (count == 1)
+                return CreateMemoryAccessorExpression(memoryValue.MemoryAccessors.First(), size, (uint)memoryValue.IntegerConstant);
+
+            var first = memoryValue.MemoryAccessors.First();
+            bool needRemember = false;
+
+            if (count > 2)
+            {
+                needRemember = true;
+            }
+            else if (memoryValue.HasConstant)
+            {
+                needRemember = true;
+            }
+            else if (!memoryValue.MemoryAccessors.All(m => m.ModifyingOperator == RequirementOperator.None))
+            {
+                needRemember = true;
+            }
+            else
+            {
+                var second = memoryValue.MemoryAccessors.ElementAt(1).MemoryAccessor;
+                needRemember = !first.MemoryAccessor.PointerChainMatches(second);
+            }
+
+            MemoryAccessorExpression memoryAccessor;
+
+            if (needRemember)
+            {
+                memoryAccessor = new MemoryAccessorExpression(FieldType.MemoryAddress, size, 0U);
+                memoryAccessor.RememberPointer = new RememberRecallExpression(memoryValue);
+            }
+            else
+            {
+                memoryAccessor = new MemoryAccessorExpression(FieldType.MemoryAddress, size, (uint)memoryValue.IntegerConstant);
+
+                foreach (var pointer in first.MemoryAccessor.PointerChain)
+                    memoryAccessor.AddPointer(pointer);
+
+                var requirement = new Requirement
+                {
+                    Type = RequirementType.AddAddress,
+                    Left = first.MemoryAccessor.Field
+                };
+
+                var second = memoryValue.MemoryAccessors.ElementAt(1);
+                requirement.Operator = second.CombiningOperator == RequirementType.AddSource ? RequirementOperator.Add : RequirementOperator.Subtract;
+                requirement.Right = second.MemoryAccessor.Field;
+
+                memoryAccessor.AddPointer(requirement);
+            }
+
+            memoryValue.CopyLocation(memoryAccessor);
+            return memoryAccessor;
+        }
+
+        private static MemoryAccessorExpression CreateMemoryAccessorExpression(ModifiedMemoryAccessorExpression modifiedMemoryAccessor, FieldSize size, uint offset)
         {
             if (modifiedMemoryAccessor.CombiningOperator == RequirementType.SubSource)
             {
@@ -128,7 +151,7 @@ namespace RATools.Parser.Functions
                         var negativeMemoryAccessor = modifiedMemoryAccessor.Clone();
                         negativeMemoryAccessor.Modifier = negativeValue;
                         negativeMemoryAccessor.CombiningOperator = RequirementType.AddSource;
-                        return CreateMemoryAccessorExpression(negativeMemoryAccessor);
+                        return CreateMemoryAccessorExpression(negativeMemoryAccessor, size, offset);
                     }
                 }
                 else if (modifiedMemoryAccessor.ModifyingOperator == RequirementOperator.None)
@@ -137,7 +160,7 @@ namespace RATools.Parser.Functions
                     multipliedMemoryAccessor.Modifier = FieldFactory.CreateField(new IntegerConstantExpression(-1));
                     multipliedMemoryAccessor.ModifyingOperator = RequirementOperator.Multiply;
                     multipliedMemoryAccessor.CombiningOperator = RequirementType.AddSource;
-                    return CreateMemoryAccessorExpression(multipliedMemoryAccessor);
+                    return CreateMemoryAccessorExpression(multipliedMemoryAccessor, size, offset);
                 }
 
                 return null;
@@ -155,6 +178,13 @@ namespace RATools.Parser.Functions
                     requirement.Type = RequirementType.AddAddress;
                 result.AddPointer(requirement);
             }
+
+            result.Field = new Field
+            {
+                Type = FieldType.MemoryAddress,
+                Size = size,
+                Value = offset
+            };
 
             return result;
         }

--- a/Tests/Parser/Functions/RichPresenceAsciiStringLookupFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceAsciiStringLookupFunctionTests.cs
@@ -82,6 +82,32 @@ namespace RATools.Parser.Tests.Functions
         }
 
         [Test]
+        public void TestPointerChain()
+        {
+            var rp = new RichPresenceAsciiStringLookupFunctionHarness();
+            var lookup = rp.DefineLookup("lookup");
+            lookup.Add(new StringConstantExpression("Zero"), new StringConstantExpression("False"));
+            lookup.Add(new StringConstantExpression("One"), new StringConstantExpression("True"));
+
+            var builder = rp.Evaluate("rich_presence_ascii_string_lookup(\"Name\", dword(dword(0x1234)), lookup)");
+            var serializationContext = new SerializationContext { MinimumVersion = builder.MinimumVersion() };
+            Assert.That(builder.Serialize(serializationContext), Is.EqualTo("Lookup:Name\r\n6647375=True\r\n1869768026=False\r\n\r\nDisplay:\r\n@Name(I:0xX001234_I:0xX000000_M:0xX000000)\r\n"));
+        }
+
+        [Test]
+        public void TestPointerChainWithOffset()
+        {
+            var rp = new RichPresenceAsciiStringLookupFunctionHarness();
+            var lookup = rp.DefineLookup("lookup");
+            lookup.Add(new StringConstantExpression("Zero"), new StringConstantExpression("False"));
+            lookup.Add(new StringConstantExpression("One"), new StringConstantExpression("True"));
+
+            var builder = rp.Evaluate("rich_presence_ascii_string_lookup(\"Name\", dword(dword(0x1234) + 0x10) + 6, lookup)");
+            var serializationContext = new SerializationContext { MinimumVersion = builder.MinimumVersion() };
+            Assert.That(builder.Serialize(serializationContext), Is.EqualTo("Lookup:Name\r\n6647375=True\r\n1869768026=False\r\n\r\nDisplay:\r\n@Name(I:0xX001234_I:0xX000010_M:0xX000006)\r\n"));
+        }
+
+        [Test]
         public void TestIntegerDictionaryKey()
         {
             var input = "lookup = {\"Zero\": \"False\", 1: \"True\" }\r\n" +


### PR DESCRIPTION
Fixes #562.

The three functions that accept an address as a parameter (`rich_presence_ascii_string_lookup`, `ascii_string_equals` and `unicode_string_equals`) all use the same helper function to convert an address into a memory accessor. Since `dword(....)` is already a memory accessor, no conversion was being made, but the intent was to wrap it in another layer of `dword()`.

I've separated the logic that converts a memory value into a memory accessor from the logic that wraps a memory value in a memory accessor, and the affected functions will now always wrap the address parameter in a memory accessor.