### PR TITLE
add additional parenthesis when dumping clause with ResetNextIf and OrNext

### DIFF
--- a/Source/Parser/ScriptBuilderContext.cs
+++ b/Source/Parser/ScriptBuilderContext.cs
@@ -558,30 +558,41 @@ namespace RATools.Parser
         {
             if (requirement.HitCount == 0 && NullOrEmpty(_addHits))
             {
-                bool wrapInParenthesis = false;
-
-                if (!NullOrEmpty(_andNext) && _andNext[0] != '(')
-                {
-                    var andNext = _andNext.ToString();
-                    if (andNext.Contains(" && ") || andNext.Contains(" || "))
-                        wrapInParenthesis = true;
-                }
-
-                if (wrapInParenthesis)
-                    builder.Append('(');
-
-                AppendCondition(builder, requirement);
-
                 if (!NullOrEmpty(_resetNextIf))
                 {
+                    bool wrapInParenthesis = _lastAndNext?.Type == RequirementType.OrNext;
+                    if (wrapInParenthesis)
+                        builder.Append('(');
+
+                    AppendCondition(builder, requirement);
+
+                    if (wrapInParenthesis)
+                        builder.Append(')');
+
                     builder.Append(" && never(");
                     builder.Append(RemoveOuterParentheses(_resetNextIf));
                     builder.Append(')');
                     _resetNextIf.Clear();
                 }
+                else
+                {
+                    bool wrapInParenthesis = false;
 
-                if (wrapInParenthesis)
-                    builder.Append(')');
+                    if (!NullOrEmpty(_andNext) && _andNext[0] != '(')
+                    {
+                        var andNext = _andNext.ToString();
+                        if (andNext.Contains(" && ") || andNext.Contains(" || "))
+                            wrapInParenthesis = true;
+                    }
+
+                    if (wrapInParenthesis)
+                        builder.Append('(');
+
+                    AppendCondition(builder, requirement);
+
+                    if (wrapInParenthesis)
+                        builder.Append(')');
+                }
             }
             else
             {
@@ -593,12 +604,8 @@ namespace RATools.Parser
                     builder.AppendFormat("repeated({0}, ", requirement.HitCount);
 
                 bool wrapInParenthesis = false;
-                if (!NullOrEmpty(_resetNextIf) && !NullOrEmpty(_andNext))
-                {
-                    var andNext = _andNext.ToString();
-                    if (andNext.LastIndexOf(" || ") > andNext.LastIndexOf(')'))
-                        wrapInParenthesis = true;
-                }
+                if (!NullOrEmpty(_resetNextIf))
+                    wrapInParenthesis = _lastAndNext?.Type == RequirementType.OrNext;
 
                 if (wrapInParenthesis)
                     builder.Append('(');

--- a/Tests/Parser/Internal/ScriptBuilderContextTests.cs
+++ b/Tests/Parser/Internal/ScriptBuilderContextTests.cs
@@ -64,6 +64,8 @@ namespace RATools.Parser.Tests.Internal
                   "measured(tally(0, byte(0x001234) == 1 && byte(0x002345) == 2, byte(0x001234) == 2 && byte(0x002345) == 3))")]
         [TestCase("K:0xH001234*2_I:0xX002345+{recall}_0xH000000=3", "byte(dword(0x002345) + (byte(0x001234) * 2)) == 3")]
         [TestCase("K:0xH001234*2_I:0xX002345+{recall}_0xH000000={recall}", "byte(dword(0x002345) + (byte(0x001234) * 2)) == (byte(0x001234) * 2)")]
+        [TestCase("Z:0x 000001=1_N:0x 000002=2.1._O:0x 000003=3_0x 000004=4",
+            "((once(word(0x000002) == 2) && word(0x000003) == 3) || word(0x000004) == 4) && never(word(0x000001) == 1)")]
         public void TestAppendRequirements(string input, string expected)
         {
             var trigger = Trigger.Deserialize(input);


### PR DESCRIPTION
fixes https://discord.com/channels/310192285306454017/936655398725902356/1373759776428785685

When dumping a clause containing a ResetNextIf and an OrNext, the OrNext was not being logically grouped with its neighbors so the thing being ORed got ANDed to the ResetNextIf.