### PR TITLE
fix bcd extraction for modified memory read; report error when bcd cannot be extracted

### DIFF
--- a/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
@@ -204,6 +204,35 @@ namespace RATools.Parser.Expressions.Trigger
                 return true;
             }
 
+            var memoryValue = simpleExpression as MemoryValueExpression;
+            if (memoryValue != null && memoryValue.MemoryAccessors.Count() == 1)
+            {
+                bcdWrapper = memoryValue.MemoryAccessors.First().MemoryAccessor as BinaryCodedDecimalExpression;
+                if (bcdWrapper != null)
+                {
+                    // this removes the wrapper from the BCD expression by copying it into
+                    // an unwrapped MemoryAccessorExpression
+                    newExpression = new MemoryAccessorExpression(bcdWrapper);
+
+                    var newMemoryValue = new MemoryValueExpression();
+                    newMemoryValue.ApplyMathematic(newExpression, MathematicOperation.Add);
+
+                    if (memoryValue.HasConstant)
+                    {
+                        if (!ConvertToBCD(memoryValue.ExtractConstant(), out newExpression))
+                        {
+                            newExpression = expression;
+                            return false;
+                        }
+
+                        newMemoryValue.ApplyMathematic(newExpression, MathematicOperation.Add);
+                    }
+
+                    newExpression = newMemoryValue;
+                    return true;
+                }
+            }
+
             newExpression = expression;
             return false;
         }
@@ -239,7 +268,7 @@ namespace RATools.Parser.Expressions.Trigger
             return false;
         }
 
-        private RequirementExpressionBase NormalizeBCD()
+        private ErrorExpression NormalizeBCD(out RequirementExpressionBase result)
         {
             ExpressionBase newLeft;
             ExpressionBase newRight;
@@ -249,7 +278,10 @@ namespace RATools.Parser.Expressions.Trigger
             if (!rightHasBCD)
             {
                 if (!leftHasBCD)
-                    return this;
+                {
+                    result = this;
+                    return null;
+                }
 
                 rightHasBCD = ConvertToBCD(Right, out newRight);
                 if (newRight == null)
@@ -260,10 +292,12 @@ namespace RATools.Parser.Expressions.Trigger
                         case ComparisonOperation.NotEqual:
                         case ComparisonOperation.LessThan:
                         case ComparisonOperation.LessThanOrEqual:
-                            return new AlwaysTrueExpression();
+                            result = new AlwaysTrueExpression();
+                            return null;
 
                         default:
-                            return new AlwaysFalseExpression();
+                            result = new AlwaysFalseExpression();
+                            return null;
                     }
                 }
             }
@@ -278,26 +312,48 @@ namespace RATools.Parser.Expressions.Trigger
                         case ComparisonOperation.NotEqual:
                         case ComparisonOperation.GreaterThan:
                         case ComparisonOperation.GreaterThanOrEqual:
-                            return new AlwaysTrueExpression();
+                            result = new AlwaysTrueExpression();
+                            return null;
 
                         default:
-                            return new AlwaysFalseExpression();
+                            result = new AlwaysFalseExpression();
+                            return null;
                     }
                 }
             }
 
             if (leftHasBCD && rightHasBCD)
             {
-                return new RequirementConditionExpression()
+                if (Comparison == ComparisonOperation.Equal || Comparison == ComparisonOperation.NotEqual)
+                {
+                    var leftMemoryValue = newLeft as MemoryValueExpression;
+                    if (leftMemoryValue != null && leftMemoryValue.HasConstant)
+                    {
+                        result = null;
+                        return new ErrorExpression("Cannot eliminate bcd from equality comparison with modifier", leftMemoryValue);
+                    }
+
+                    var rightMemoryValue = newLeft as MemoryValueExpression;
+                    if (rightMemoryValue != null && rightMemoryValue.HasConstant)
+                    {
+                        result = null;
+                        return new ErrorExpression("Cannot eliminate bcd from equality comparison with modifier", rightMemoryValue);
+                    }
+                }
+
+                result = new RequirementConditionExpression()
                 {
                     Left = newLeft,
                     Comparison = Comparison,
                     Right = newRight,
                     Location = Location,
                 };
+
+                return null;
             }
 
-            return this;
+            result = this;
+            return null;
         }
 
         private static bool ExtractInversion(ExpressionBase expression, out ExpressionBase newExpression)
@@ -582,7 +638,11 @@ namespace RATools.Parser.Expressions.Trigger
                 Left = new MemoryValueExpression(modifiedMemoryAccessor);
             }
 
-            var result = NormalizeBCD();
+            RequirementExpressionBase result;
+            var error = NormalizeBCD(out result);
+            if (error != null)
+                return error;
+
             NormalizeInvert(ref result);
             NormalizeLimits(ref result);
 

--- a/Source/Parser/Functions/PrevPriorFunction.cs
+++ b/Source/Parser/Functions/PrevPriorFunction.cs
@@ -186,6 +186,12 @@ namespace RATools.Parser.Functions
 
         private bool WrapMemoryValue(MemoryValueExpression memoryValue, out ExpressionBase result)
         {
+            if (_fieldType == FieldType.BinaryCodedDecimal && memoryValue.HasConstant)
+            {
+                result = new ErrorExpression("Cannot apply bcd() to a modified memory accessor", memoryValue);
+                return false;
+            }
+
             var clone = memoryValue.Clone();
             foreach (var memoryAccessor in clone.MemoryAccessors)
             {

--- a/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
@@ -145,9 +145,12 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("bcd(dword(1)) <= 100000000", "always_true()")]
         [TestCase("bcd(dword(1)) > 100000000", "always_false()")]
         [TestCase("bcd(dword(1)) >= 100000000", "always_false()")]
+        // adjustments can be converted too
         [TestCase("prev(bcd(byte(1)) - 1) >= 12", "prev(byte(0x000001)) >= 19")]
         [TestCase("prev(bcd(byte(1)) - 1) == 14", "prev(byte(0x000001)) == 21")]
         [TestCase("prev(bcd(byte(1)) - 1) == 19", "prev(byte(0x000001)) == 32")]
+        [TestCase("prev(bcd(byte(1))) - 1 >= 19", "prev(byte(0x000001)) >= 32")]
+        [TestCase("bcd(byte(1)) >= prev(bcd(byte(1))) + 10", "prev(byte(0x000001)) + 16 <= byte(0x000001)")]
         public void TestNormalizeBCD(string input, string expected)
         {
             var result = TriggerExpressionTests.Parse(input);
@@ -157,6 +160,15 @@ namespace RATools.Parser.Tests.Expressions.Trigger
                 result = condition.Normalize();
 
             ExpressionTests.AssertAppendString(result, expected);
+        }
+
+        [Test]
+        // bcd adjustment cannot be applied after adjustment
+        [TestCase("prev(bcd(byte(1) - 1)) >= 19", "Cannot apply bcd() to a modified memory accessor")]
+        [TestCase("bcd(byte(1)) == prev(bcd(byte(1))) + 10", "Cannot eliminate bcd from equality comparison with modifier")]
+        public void TestNormalizeBCDError(string input, string expectedError)
+        {
+            TriggerExpressionTests.AssertParseError(input, expectedError);
         }
 
         [Test]


### PR DESCRIPTION
Addresses incorrect extraction of BCD from comparison with modification as described [here](https://github.com/Jamiras/RATools/issues/573#issuecomment-2891902564).

This does not attempt to convert `prev(bcd(X)) + n` into an `AddSource` chain of `high4`/`low4` memory reads, but that will now generate an error.

