### PR TITLE
generate error when trying to use conflicting Remembers in AddSource chain

### DIFF
--- a/Source/Parser/Internal/TriggerBuilderContext.cs
+++ b/Source/Parser/Internal/TriggerBuilderContext.cs
@@ -24,7 +24,15 @@ namespace RATools.Parser.Internal
             get { return Trigger.LastOrDefault(); }
         }
 
+        /// <summary>
+        /// Gets or sets the MinimumVersion for supported serialization features.
+        /// </summary>
         public SoftwareVersion MinimumVersion { get; set; }
+
+        /// <summary>
+        /// Gets the last Remembered expression.
+        /// </summary>
+        public MemoryValueExpression RememberedValue { get; internal set; }
 
         [DebuggerDisplay("{field} * {Multiplier}")]
         private class Term

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -611,6 +611,29 @@ namespace RATools.Parser.Tests
         }
 
         [Test]
+        public void TestDoubleRecall()
+        {
+            var parser = AchievementScriptTests.Parse(
+                "p1 = dword(0x1234)\n" +
+                "p2 = dword(0x2345)\n" +
+                "v1 = byte(p1 + 4)\n" +
+                "v2 = byte(p2 + 8)\n" +
+                "achievement(\"T\", \"D\", 5, (prev(v1) ^ v2) - (v1 ^ v2) == 200)\n");
+
+            // Remember  v2
+            // AddSource prev(v1) ^ recall
+            // Remember  v2
+            // SubSource v1 ^ recall
+            //           0 = 200
+
+            // second remember should be eliminated. it's redundant with the first, and breaks the AddSource chain
+
+            var achievement = parser.Achievements.First();
+            var serialized = achievement.Trigger.Serialize(new SerializationContext { AddressWidth = 4 });
+            Assert.That(serialized, Is.EqualTo("I:0xX2345_K:0xH0008_I:0xX1234_A:d0xH0004^{recall}_I:0xX1234_B:0xH0004^{recall}_0=200"));
+        }
+
+        [Test]
         public void TestRichPresenceDisplay()
         {
             var parser = AchievementScriptTests.Parse("rich_presence_display(\"simple string\")");

--- a/Tests/Parser/Functions/AchievementFunctionTests.cs
+++ b/Tests/Parser/Functions/AchievementFunctionTests.cs
@@ -215,12 +215,26 @@ namespace RATools.Parser.Tests.Functions
         [Test]
         public void TestRememberRecallChain2()
         {
-            var achievement = Evaluate(
+            var input =
                 "function d(n) => byte(n) * (byte(n + 1) / 8)\n" +
-                "achievement(\"T\", \"D\", 5, d(0x2222) + d(0x2224) == 6)");
-            var builder = new AchievementBuilder(achievement);
-            Assert.That(builder.SerializeRequirements(new SerializationContext()),
-                Is.EqualTo("K:0xH002225/8_A:0xH002224*{recall}_K:0xH002223/8_A:0xH002222*{recall}_0=6"));
+                "achievement(\"T\", \"D\", 5, d(0x2222) + d(0x2224) == 6)";
+
+            // This will become:
+            //
+            //   Remember  byte(0x2223) / 8
+            //   AddSource byte(0x2222) * {recall}
+            //   Remember  byte(0x2225) / 8
+            //   AddSource byte(0x2224) * {recall}
+            //             0            = 6
+            //
+            // Since Remember has a higher precedence than AddSource, line 3 will
+            // remember the division added to line 2, which is not what was inteded.
+            // The intended result is impossible with the current toolkit, so generate an error.
+
+            Evaluate(input,
+                "2:1 achievement call failed\r\n" +
+                "- 2:26 Cannot combine multiple expressions with unique Remembered requirements\r\n" +
+                "- 2:38 Cannot combine multiple expressions with unique Remembered requirements");
         }
     }
 }


### PR DESCRIPTION
Addresses https://discord.com/channels/310192285306454017/936655398725902356/1395832001218478161

Correctly reports when multiple unique Remembers exist in a single AddSource chain and eliminates redundant Remember when current Remembered value matches new Remembered value.