### PR TITLE
Fix OR'd never() inside repeated() condition becoming multiple ResetNextIfs

### DIFF
--- a/Source/Parser/Expressions/Trigger/BehavioralRequirementExpression.cs
+++ b/Source/Parser/Expressions/Trigger/BehavioralRequirementExpression.cs
@@ -250,9 +250,9 @@ namespace RATools.Parser.Expressions.Trigger
                     goto default;
 
                 case RequirementType.ResetIf:
-                case RequirementType.ResetNextIf:
                 case RequirementType.PauseIf:
-                    if (reqClause != null && reqClause.Operation == ConditionalOperation.Or)
+                    if (reqClause != null && reqClause.Operation == ConditionalOperation.Or &&
+                        reqClause is not RequirementClauseExpression.OrNextRequirementClauseExpression)
                     {
                         // never(A || B) -> never(A) && never(B)
                         // unless(A || B) -> unless(A) && unless(B)

--- a/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
@@ -745,6 +745,23 @@ namespace RATools.Parser.Expressions.Trigger
 
                 if (resetRequirements.Count > 0)
                 {
+                    if (resetRequirements.Count > 1)
+                    {
+                        // cannot have multiple ResetNextIfs - combine into an OrNext chain into a single ReseNextIf
+                        var clause = new RequirementClauseExpression() { Operation = ConditionalOperation.Or };
+                        foreach (var behavioral in resetRequirements.OfType<BehavioralRequirementExpression>())
+                            clause.AddCondition(behavioral.Condition);
+                        clause.DeriveLocation();
+
+                        resetRequirements.Clear();
+                        resetRequirements.Add(new BehavioralRequirementExpression
+                        {
+                            Behavior = RequirementType.ResetNextIf,
+                            Condition = clause,
+                            Location = clause.Location,
+                        });
+                    }
+
                     error = BuildTrigger(achievementContext, resetRequirements, RequirementType.None);
                     if (error != null)
                         return error;

--- a/Tests/Parser/Expressions/Trigger/BehavioralRequirementExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/BehavioralRequirementExpression_Tests.cs
@@ -26,6 +26,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("never(repeated(3, always_true()))", "R:1=1.3.")]
         [TestCase("never(byte(1) == 56 || byte(2) == 3)", "R:0xH000001=56_R:0xH000002=3")] // or clauses can be separated
         [TestCase("never(byte(1) == 56 && byte(2) == 3)", "N:0xH000001=56_R:0xH000002=3")] // and clauses cannot be separated
+        [TestCase("never(__ornext(byte(1) == 56 || byte(2) == 3))", "O:0xH000001=56_R:0xH000002=3")] // don't separate clauses if __ornext used
         [TestCase("never(once(byte(1) == 56))", "R:0xH000001=56")] // hitcount of 1 is redundant on a ResetIf
         [TestCase("never(once(byte(1) == 56 && never(byte(2) == 12)))",
             "N:0xH000001=56_R:0xH000002!=12")] // hittarget of 1 can never accumulate hits so ResetNextIf can be inverted and made into a normal subclause
@@ -35,6 +36,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("unless(repeated(6, byte(1) == 56))", "P:0xH000001=56.6.")]
         [TestCase("unless(byte(1) == 56 || byte(2) == 3)", "P:0xH000001=56_P:0xH000002=3")] // or clauses can be separated
         [TestCase("unless(byte(1) == 56 && byte(2) == 3)", "N:0xH000001=56_P:0xH000002=3")] // and clauses cannot be separated
+        [TestCase("unless(__ornext(byte(1) == 56 || byte(2) == 3))", "O:0xH000001=56_P:0xH000002=3")] // don't separate clauses if __ornext used
         [TestCase("trigger_when(byte(0x001234) == 3)", "T:0xH001234=3")]
         [TestCase("trigger_when(repeated(6, byte(1) == 56))", "T:0xH000001=56.6.")]
         [TestCase("trigger_when(byte(1) == 56 && byte(2) == 3)", "T:0xH000001=56_T:0xH000002=3")] // and clauses can be separated

--- a/Tests/Parser/Internal/RequirementsOptimizerTests.cs
+++ b/Tests/Parser/Internal/RequirementsOptimizerTests.cs
@@ -514,5 +514,44 @@ namespace RATools.Parser.Tests.Internal
             Assert.That(achievement.SerializeRequirements(new SerializationContext()),
                 Is.EqualTo("0xH001234=1SM:0xH002345=6.3.ST:0=1"));
         }
+
+        [Test]
+        public void TestResetNextIfMultiple()
+        {
+            var achievement = CreateAchievement("once(byte(0x1234) == 1) && " +
+                "tally(2," +
+                "  byte(0x2345) == 2 &&" +
+                "  never(byte(0x3456) == 1) && never(byte(0x3456) == 2)" +
+                ")");
+            achievement.Optimize();
+            Assert.That(achievement.SerializeRequirements(new SerializationContext()),
+                Is.EqualTo("0xH001234=1.1._O:0xH003456=1_Z:0xH003456=2_0xH002345=2.2."));
+        }
+
+        [Test]
+        public void TestResetNextIfOr()
+        {
+            var achievement = CreateAchievement("once(byte(0x1234) == 1) && " +
+                "tally(2," +
+                "  byte(0x2345) == 2 &&" +
+                "  never(byte(0x3456) == 1 || byte(0x3456) == 2)" +
+                ")");
+            achievement.Optimize();
+            Assert.That(achievement.SerializeRequirements(new SerializationContext()),
+                Is.EqualTo("0xH001234=1.1._O:0xH003456=1_Z:0xH003456=2_0xH002345=2.2."));
+        }
+
+        [Test]
+        public void TestResetNextIfOrNext()
+        {
+            var achievement = CreateAchievement("once(byte(0x1234) == 1) && " +
+                "tally(2," +
+                "  byte(0x2345) == 2 &&" +
+                "  never(__ornext(byte(0x3456) == 1 || byte(0x3456) == 2))" +
+                ")");
+            achievement.Optimize();
+            Assert.That(achievement.SerializeRequirements(new SerializationContext()),
+                Is.EqualTo("0xH001234=1.1._O:0xH003456=1_Z:0xH003456=2_0xH002345=2.2."));
+        }
     }
 }


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/936655398725902356/1407591993596575867

> The original case is just turning the nested `never`s into ResetNextIfs instead of ResetIfs. When using `||` (even with the explicit `__onext`), the `never(A || B)` is being split into `never(A) && never(B)` and then hitting the same problem as the original case.

This fix includes three changes:
1) `__ornext` will be honored inside a never.
2) `never(A) && never(B)` will be converted to `never(A || B)` when found inside a `repeated` clause.
3) `never(A || B)` inside a `repeated` clause will not be split into `never(A) && never(B)`.
