### PR TITLE
Get progression times from server

### DIFF
--- a/Source/Services/RAWebCache.cs
+++ b/Source/Services/RAWebCache.cs
@@ -55,6 +55,13 @@ namespace RATools.Services
                 String.Format("raGame{0}.json", gameId));
         }
 
+        public JsonObject GetGameProgressionJson(int gameId)
+        {
+            return CallJsonAPI("API_GetGameProgression",
+                String.Format("i={0}&h=1", gameId),
+                String.Format("raGameProgression{0}.json", gameId));
+        }
+
         public const int AchievementUnlocksPerPage = 500;
 
         public JsonObject GetAchievementUnlocksJson(int achievementId, int pageIndex)

--- a/Source/ViewModels/GameProgressionViewModel.cs
+++ b/Source/ViewModels/GameProgressionViewModel.cs
@@ -3,7 +3,6 @@ using Jamiras.Components;
 using Jamiras.Services;
 using Jamiras.ViewModels;
 using Jamiras.ViewModels.Fields;
-using RATools.Data;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -34,7 +33,6 @@ namespace RATools.ViewModels
 
             public TimeSpan Distance { get; set; }
 
-            public TimeSpan TotalDistance { get; set; }
             public int TotalDistanceCount { get; set; }
 
             public string FormattedDistance

--- a/Source/ViewModels/GameProgressionViewModel.cs
+++ b/Source/ViewModels/GameProgressionViewModel.cs
@@ -1,8 +1,10 @@
 ﻿using Jamiras.Commands;
 using Jamiras.Components;
+using Jamiras.DataModels;
 using Jamiras.Services;
 using Jamiras.ViewModels;
 using Jamiras.ViewModels.Fields;
+using RATools.Services;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -12,15 +14,76 @@ namespace RATools.ViewModels
 {
     public class GameProgressionViewModel : DialogViewModelBase
     {
-        public GameProgressionViewModel(List<AchievementInfo> progressionStats)
+        public GameProgressionViewModel()
+            : this(ServiceRepository.Instance.FindService<IBackgroundWorkerService>())
+        {
+
+        }
+
+        public GameProgressionViewModel(IBackgroundWorkerService backgroundWorkerService)
         { 
+            _backgroundWorkerService = backgroundWorkerService;
+
             Progress = new ProgressFieldViewModel { Label = String.Empty };
             DialogTitle = "Game Progression";
             CanClose = true;
 
-            Achievements = progressionStats;
+            SearchCommand = new DelegateCommand(Search);
 
             ShowAchievementCommand = new DelegateCommand<AchievementInfo>(ShowAchievement);
+        }
+
+        private readonly IBackgroundWorkerService _backgroundWorkerService;
+
+        public static readonly ModelProperty GameIdProperty = ModelProperty.Register(typeof(GameStatsViewModel), "GameId", typeof(int), 0);
+
+        public int GameId
+        {
+            get { return (int)GetValue(GameIdProperty); }
+            set { SetValue(GameIdProperty, value); }
+        }
+
+        public CommandBase SearchCommand { get; private set; }
+        private void Search()
+        {
+            Progress.Label = "Fetching progression data";
+            Progress.Reset(1);
+            Progress.IsEnabled = true;
+
+            _backgroundWorkerService.RunAsync(() =>
+            {
+                var progressionJson = RAWebCache.Instance.GetGameProgressionJson(this.GameId);
+                Progress.Current++;
+
+                DialogTitle = "Game Progression - " + progressionJson.GetField("Title").StringValue;
+
+                var achievements = new List<AchievementInfo>();
+                foreach (var achievement in progressionJson.GetField("Achievements").ObjectArrayValue)
+                {
+                    achievements.Add(new AchievementInfo
+                    {
+                        Id = achievement.GetField("ID").IntegerValue.GetValueOrDefault(),
+                        Title = achievement.GetField("Title").StringValue,
+                        Distance = TimeSpan.FromSeconds(achievement.GetField("MedianTimeToUnlockHardcore").IntegerValue.GetValueOrDefault()),
+                        TotalDistanceCount = achievement.GetField("TimesUsedInHardcoreUnlockMedian").IntegerValue.GetValueOrDefault(),
+                    });
+                }
+
+                achievements.Sort((l, r) =>
+                {
+                    // can't just return the difference between two distances, as it's entirely
+                    // possible that a value could be a few milliseconds or several years, so
+                    // there's no easy way to convert the different into a 32-bit integer.
+                    if (l.Distance == r.Distance)
+                        return 0;
+                    return (l.Distance > r.Distance) ? 1 : -1;
+                });
+
+                Achievements = achievements;
+                OnPropertyChanged(() => Achievements);
+
+                Progress.Label = String.Empty;
+            });
         }
 
         public ProgressFieldViewModel Progress { get; private set; }

--- a/Source/ViewModels/GameStatsViewModel.cs
+++ b/Source/ViewModels/GameStatsViewModel.cs
@@ -46,8 +46,6 @@ namespace RATools.ViewModels
         private readonly IFileSystemService _fileSystem;
         private readonly ISettings _settings;
 
-        private List<GameProgressionViewModel.AchievementInfo> _progressionStats;
-
         public ProgressFieldViewModel Progress { get; private set; }
 
         public static readonly ModelProperty GameIdProperty = ModelProperty.Register(typeof(GameStatsViewModel), "GameId", typeof(int), 0);
@@ -135,7 +133,7 @@ namespace RATools.ViewModels
                 return String.Compare(x.User, y.User);
             }
 
-            public void UpdateGameTime(Func<int, int> getAchievementPointsFunc, List<GameProgressionViewModel.AchievementInfo> progressionStats)
+            public void UpdateGameTime(Func<int, int> getAchievementPointsFunc)
             {
                 PointsEarned = 0;
 
@@ -184,30 +182,6 @@ namespace RATools.ViewModels
                 // after gettin the last achievement of the session.
                 double perSessionAdjustment = GameTime.TotalSeconds / Achievements.Count;
                 GameTime += TimeSpan.FromSeconds(Sessions * perSessionAdjustment);
-
-                if (progressionStats != null)
-                {
-                    var sessionOffsets = new List<int>();
-                    sessionOffsets.Add((int)perSessionAdjustment);
-                    for (int i = 1; i < sessionStartIndices.Count - 1; i++)
-                    {
-                        var sessionLength = (times[sessionStartIndices[i] - 1] - times[sessionStartIndices[i - 1]]).TotalSeconds + perSessionAdjustment;
-                        sessionOffsets.Add((int)(sessionOffsets[i - 1] + sessionLength));
-                    }
-
-                    // calculate the distance for each earned achievement from the start of the user's playtime
-                    foreach (var achievement in achievementSessions)
-                    {
-                        var info = progressionStats.FirstOrDefault(a => a.Id == achievement.Key);
-                        if (info != null)
-                        {
-                            var sessionStart = times[sessionStartIndices[achievement.Value]];
-                            var elapsed = (Achievements[achievement.Key] - sessionStart).TotalSeconds + sessionOffsets[achievement.Value];
-                            info.TotalDistance += TimeSpan.FromSeconds(elapsed);
-                            info.TotalDistanceCount++;
-                        }
-                    }
-                }
             }
         }
 
@@ -592,17 +566,6 @@ namespace RATools.ViewModels
         {
             Progress.Label = "Analyzing data";
 
-            // initialize the progression stats
-            _progressionStats = new List<GameProgressionViewModel.AchievementInfo>();
-            foreach (var achievement in achievementStats)
-            {
-                _progressionStats.Add(new GameProgressionViewModel.AchievementInfo
-                {
-                    Id = achievement.Id,
-                    Title = achievement.Title,
-                });
-            }
-
             // estimate the time spent for each user
             foreach (var user in userStats)
             {
@@ -610,7 +573,7 @@ namespace RATools.ViewModels
                 {
                     var achievement = achievementStats.FirstOrDefault(a => a.Id == id);
                     return (achievement != null) ? achievement.Points : 0;
-                }, _progressionStats);
+                });
             }
 
             // sort the results by the most points earned, then the quickest
@@ -621,25 +584,6 @@ namespace RATools.ViewModels
                     diff = (int)((l.GameTime - r.GameTime).TotalSeconds);
 
                 return diff;
-            });
-
-            // finalize the progression stats
-            foreach (var info in _progressionStats)
-            {
-                if (info.TotalDistanceCount > 0)
-                    info.Distance = TimeSpan.FromSeconds(info.TotalDistance.TotalSeconds / info.TotalDistanceCount);
-                else
-                    info.Distance = TimeSpan.MaxValue;
-            }
-
-            _progressionStats.Sort((l, r) =>
-            {
-                // can't just return the difference between two distances, as it's entirely
-                // possible that a value could be a few milliseconds or several years, so
-                // there's no easy way to convert the different into a 32-bit integer.
-                if (l.Distance == r.Distance)
-                    return 0;
-                return (l.Distance > r.Distance) ? 1 : -1;
             });
 
             // determine how many players mastered the set and how many sessions/days it took them
@@ -669,15 +613,6 @@ namespace RATools.ViewModels
             int sessionCount = sessions.Count;
             if (sessionCount > 0)
             {
-                // sessionCount is only the number of reliable estimates. Find the median index of those, and use
-                // that record's time as the median time
-                var medianIndex = reliableEstimateIndices[sessionCount / 2];
-                var timeToMaster = userStats[medianIndex].Summary;
-                var space = timeToMaster.IndexOf(' ');
-                if (space > 0)
-                    timeToMaster = timeToMaster.Substring(0, space);
-                MedianTimeToMaster = timeToMaster;
-
                 sessions.Sort();
                 MedianSessionsToMaster = sessions[sessionCount / 2].ToString();
 
@@ -798,9 +733,44 @@ namespace RATools.ViewModels
 
         private void ShowDetailedProgress()
         {
-            var vm = new GameProgressionViewModel(_progressionStats);
-            vm.DialogTitle += " - " + _gameName;
-            vm.ShowDialog();
+            Progress.Label = "Fetching progression";
+            Progress.Reset(1);
+            Progress.IsEnabled = true;
+
+            _backgroundWorkerService.RunAsync(() =>
+            {
+                var progressionJson = RAWebCache.Instance.GetGameProgressionJson(this.GameId);
+                Progress.Current++;
+
+                var progressionStats = new List<GameProgressionViewModel.AchievementInfo>();
+                foreach (var achievement in progressionJson.GetField("Achievements").ObjectArrayValue)
+                {
+                    progressionStats.Add(new GameProgressionViewModel.AchievementInfo
+                    {
+                        Id = achievement.GetField("ID").IntegerValue.GetValueOrDefault(),
+                        Title = achievement.GetField("Title").StringValue,
+                        Distance = TimeSpan.FromSeconds(achievement.GetField("MedianTimeToUnlockHardcore").IntegerValue.GetValueOrDefault()),
+                        TotalDistanceCount = achievement.GetField("TimesUsedInHardcoreUnlockMedian").IntegerValue.GetValueOrDefault(),
+                    });
+                }
+
+                progressionStats.Sort((l, r) =>
+                {
+                    // can't just return the difference between two distances, as it's entirely
+                    // possible that a value could be a few milliseconds or several years, so
+                    // there's no easy way to convert the different into a 32-bit integer.
+                    if (l.Distance == r.Distance)
+                        return 0;
+                    return (l.Distance > r.Distance) ? 1 : -1;
+                });
+
+                Progress.Label = String.Empty;
+
+                var vm = new GameProgressionViewModel(progressionStats);
+                vm.DialogTitle += " - " + _gameName;
+
+                _backgroundWorkerService.InvokeOnUiThread(() => vm.ShowDialog());
+            });
         }
     }
 }

--- a/Source/ViewModels/MainWindowViewModel.cs
+++ b/Source/ViewModels/MainWindowViewModel.cs
@@ -31,6 +31,7 @@ namespace RATools.ViewModels
             ViewAchievementsCommand = DisabledCommand.Instance;
 
             GameStatsCommand = new DelegateCommand(GameStats);
+            GameProgressionCommand = new DelegateCommand(GameProgression);
             OpenTicketsCommand = new DelegateCommand(OpenTickets);
             ConditionsAnalyzerCommand = new DelegateCommand(ConditionsAnalyzer);
             MasteryCommand = new DelegateCommand(MasteryStats);
@@ -539,6 +540,16 @@ namespace RATools.ViewModels
                 return;
 
             var vm = new GameStatsViewModel();
+            vm.ShowDialog();
+        }
+
+        public CommandBase GameProgressionCommand { get; private set; }
+        private void GameProgression()
+        {
+            if (!ValidateForApi())
+                return;
+
+            var vm = new GameProgressionViewModel();
             vm.ShowDialog();
         }
 

--- a/Source/ViewModels/UserMasteriesViewModel.cs
+++ b/Source/ViewModels/UserMasteriesViewModel.cs
@@ -193,7 +193,7 @@ namespace RATools.ViewModels
                     {
                         var achievement = gameStats.Achievements.FirstOrDefault(a => a.Id == id);
                         return (achievement != null) ? achievement.Points : 0;
-                    }, null);
+                    });
 
                     if (user.PointsEarned == gameStats.TotalPoints)
                     {

--- a/Source/Views/GameProgressionDialog.xaml
+++ b/Source/Views/GameProgressionDialog.xaml
@@ -16,7 +16,17 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid Margin="4">
-        <ListView ItemsSource="{Binding Achievements}" jamiras:GridViewSort.IsEnabled="True">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+            <TextBlock Text="Game ID" Margin="0,2,0,0" />
+            <TextBox Text="{Binding GameId}" Width="80" Margin="4,0,4,0" TextAlignment="Right" />
+            <Button Command="{Binding SearchCommand}" Content="Search" Padding="6,0,6,2" />
+        </StackPanel>
+
+        <ListView Grid.Row="1" ItemsSource="{Binding Achievements}" jamiras:GridViewSort.IsEnabled="True">
             <ListView.Resources>
                 <Style TargetType="ListViewItem">
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -54,6 +64,6 @@
             </ListView.View>
         </ListView>
 
-        <ContentPresenter Grid.RowSpan="3" Grid.ColumnSpan="4" Margin="-4" Content="{Binding Progress}" />
+        <ContentPresenter Grid.RowSpan="2" Margin="-4" Content="{Binding Progress}" />
     </Grid>
 </UserControl>

--- a/Source/Views/GameStatsDialog.xaml
+++ b/Source/Views/GameStatsDialog.xaml
@@ -71,17 +71,6 @@
             <TextBlock Text="Game ID" />
             <TextBox Text="{Binding GameId}" />
             <Button Command="{Binding SearchCommand}" Content="Search" Margin="64,4,0,4" />
-            <Button Command="{Binding DetailedProgressCommand}" Content="Progression" Margin="64,24,0,4">
-                <Button.Style>
-                    <Style TargetType="{x:Type Button}">
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding NumberOfPlayers}" Value="0">
-                                <Setter Property="IsEnabled" Value="False" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Button.Style>
-            </Button>
         </StackPanel>
         
         <TextBlock Grid.Row="7" VerticalAlignment="Bottom" Text="Top Hardcore Users" />

--- a/Source/Views/MainWindow.xaml
+++ b/Source/Views/MainWindow.xaml
@@ -63,6 +63,7 @@
             <MenuItem Header="_Analysis">
                 <MenuItem Header="Open _Tickets" Command="{Binding OpenTicketsCommand}" />
                 <MenuItem Header="Game _Stats" Command="{Binding GameStatsCommand}" />
+                <MenuItem Header="Game _Progression" Command="{Binding GameProgressionCommand}" />
                 <MenuItem Header="Unlock _Distance" Command="{Binding UnlockDistanceCommand}" />
                 <MenuItem Header="_User Masteries" Command="{Binding UserMasteriesCommand}" />
                 <MenuItem Header="_Conditions" Command="{Binding ConditionsAnalyzerCommand}"


### PR DESCRIPTION
Updates the Game Progression dialog to use the API_GetGameProgression API instead of generating the data from the scraped unlock times.

As it's no longer dependent on the scraped unlock times, the dialog has been moved out of the Game Stats dialog into its own menu item.