### PR TITLE
don't output Array() accessor for unused array note

### DIFF
--- a/Source/ViewModels/NewScriptDialogViewModel.cs
+++ b/Source/ViewModels/NewScriptDialogViewModel.cs
@@ -301,7 +301,15 @@ namespace RATools.ViewModels
         {
             foreach (var note in _game.Notes.Values)
             {
-                var size = (note.Size == FieldSize.None) ? FieldSize.Byte : note.Size;
+                var size = note.Size;
+                switch (size)
+                {
+                    case FieldSize.None:
+                    case FieldSize.Array:
+                        // these sizes don't have accessor functions, fallback to byte()
+                        size = FieldSize.Byte;
+                        break;
+                }
                 AddMemoryAddress(new Field { Size = size, Type = FieldType.MemoryAddress, Value = note.Address });
             }
         }


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/936655398725902356/1419691489524449340

When an accessor is generated for a note that's not used by logic, the size is inferred from the note itself. The `Array` size doesn't have an accessor method, so the generated code is invalid.

Solution: Treat `Array` size like `Unknown` size and default to using the `byte()` accessor.