### PR TITLE
output pointer chain on both sides of AddSource condition

### DIFF
--- a/Source/Parser/ScriptBuilderContext.cs
+++ b/Source/Parser/ScriptBuilderContext.cs
@@ -767,7 +767,18 @@ namespace RATools.Parser
                     builder.Append('(');
 
                 AppendField(builder, requirement.Left, addAddressString);
-                AppendFieldModifier(builder, requirement);
+
+                if (requirement.Operator != RequirementOperator.None && requirement.Right.IsMemoryReference)
+                {
+                    // make sure to include the AddAddress logic on the right side too.
+                    _addAddress.Append(addAddressString);
+                    AppendFieldModifier(builder, requirement);
+                    _addAddress.Clear();
+                }
+                else
+                {
+                    AppendFieldModifier(builder, requirement);
+                }
 
                 if (!ReferenceEquals(_addAddress, builder))
                     builder.Append(')');

--- a/Tests/Parser/Internal/ScriptBuilderContextTests.cs
+++ b/Tests/Parser/Internal/ScriptBuilderContextTests.cs
@@ -66,6 +66,8 @@ namespace RATools.Parser.Tests.Internal
         [TestCase("K:0xH001234*2_I:0xX002345+{recall}_0xH000000={recall}", "byte(dword(0x002345) + (byte(0x001234) * 2)) == (byte(0x001234) * 2)")]
         [TestCase("Z:0x 000001=1_N:0x 000002=2.1._O:0x 000003=3_0x 000004=4",
             "((once(word(0x000002) == 2) && word(0x000003) == 3) || word(0x000004) == 4) && never(word(0x000001) == 1)")]
+        [TestCase("I:0xX001234_A:0xH000001/0xH000001_0=1",
+            "((byte(dword(0x001234) + 0x000001) / byte(dword(0x001234) + 0x000001))) == 1")]
         public void TestAppendRequirements(string input, string expected)
         {
             var trigger = Trigger.Deserialize(input);


### PR DESCRIPTION
```
AddAddress dword 0x1234
AddSource  byte 0x0001 / byte 0x0002
ResetIf    0 = 1
```

Would be dumped as: `byte(dword(0x1234) + 1) / byte(0x0002) == 1`
It should be: `byte(dword(0x1234) + 1) / byte(dword(0x1234) + 2) == 1`