### PR TITLE
don't implicitly convert condition to unbounded tally value

### DIFF
--- a/Source/Parser/ValueBuilder.cs
+++ b/Source/Parser/ValueBuilder.cs
@@ -30,11 +30,17 @@ namespace RATools.Parser
 
         internal static bool IsConvertible(ExpressionBase expression)
         {
-            return (expression is ITriggerExpression || expression is IntegerConstantExpression);
+            if (expression is ITriggerExpression)
+                return expression is not RequirementConditionExpression;
+
+            return expression is IntegerConstantExpression;
         }
 
         internal static ErrorExpression InconvertibleError(ExpressionBase expression)
         {
+            if (expression is RequirementConditionExpression)
+                return new ErrorExpression("Cannot create value from condition", expression);
+
             return new ErrorExpression("Cannot create value from " + expression.Type.ToLowerString(), expression);
         }
 

--- a/Tests/Parser/Expressions/MathematicExpressionTests.cs
+++ b/Tests/Parser/Expressions/MathematicExpressionTests.cs
@@ -4,6 +4,7 @@ using RATools.Data;
 using RATools.Parser.Expressions;
 using RATools.Parser.Functions;
 using RATools.Parser.Internal;
+using RATools.Parser.Tests.Expressions.Trigger;
 using System.Text;
 
 namespace RATools.Parser.Tests.Expressions
@@ -424,6 +425,16 @@ namespace RATools.Parser.Tests.Expressions
             var builder = new StringBuilder();
             result.AppendString(builder);
             Assert.That(builder.ToString(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void TestXorChain()
+        {
+            var input = "byte(dword(4) + 2) ^ byte(dword(4) + 4) ^ byte(dword(4) + 6) == 3";
+            var expected = "remembered(remembered(byte(dword(0x000004) + 0x000002)) ^ byte(dword(0x000004) + 0x000004)) ^ byte(dword(0x000004) + 0x000006)";
+
+            var expr = TriggerExpressionTests.Parse<ComparisonExpression>(input);
+            //TriggerExpressionTests.AssertSerialize(expr, expected);
         }
 
         [Test]

--- a/Tests/Parser/Functions/RichPresenceLookupFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceLookupFunctionTests.cs
@@ -19,6 +19,8 @@ namespace RATools.Parser.Tests.Functions
 
             public InterpreterScope Scope { get; private set; }
 
+            public ErrorExpression Error { get; private set; }
+
             public RichPresenceBuilder Evaluate(string input)
             {
                 input = "rich_presence_display(\"{0}\", " + input + ")";
@@ -28,7 +30,7 @@ namespace RATools.Parser.Tests.Functions
 
                 var context = new AchievementScriptContext { RichPresence = new RichPresenceBuilder() };
                 Scope.Context = context;
-                funcCall.Execute(Scope);
+                Error = funcCall.Execute(Scope);
 
                 return context.RichPresence;
             }
@@ -129,6 +131,24 @@ namespace RATools.Parser.Tests.Functions
 
             var builder = rp.Evaluate("rich_presence_lookup(\"Name\", 2, lookup, \"Fallback\")");
             Assert.That(builder.ToString(), Is.EqualTo("Display:\r\nFallback\r\n"));
+        }
+
+        [Test]
+        public void TestValueComparison()
+        {
+            var rp = new RichPresenceLookupFunctionHarness();
+            var builder = rp.Evaluate("rich_presence_lookup(\"Name\", byte(0x1234) == 1, {})");
+
+            ExpressionTests.AssertError(rp.Error, "Cannot create value from condition");
+        }
+
+        [Test]
+        public void TestValueUnboundedTally()
+        {
+            var rp = new RichPresenceLookupFunctionHarness();
+
+            var builder = rp.Evaluate("rich_presence_lookup(\"Name\", tally(0, byte(0x1234) == 1), {})");
+            Assert.That(builder.ToString(), Is.EqualTo("Lookup:Name\r\n\r\nDisplay:\r\n@Name(M:0xH001234=1)\r\n"));
         }
     }
 }

--- a/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
+++ b/Tests/Parser/Functions/RichPresenceValueFunctionTests.cs
@@ -117,6 +117,29 @@ namespace RATools.Parser.Tests.Functions
         }
 
         [Test]
+        public void TestValueComparison()
+        {
+            var input = "rich_presence_display(\"{0}\", rich_presence_value(\"Name\", byte(0x1234) == 1))";
+            var expression = ExpressionBase.Parse(new PositionalTokenizer(Tokenizer.CreateTokenizer(input)));
+            Assert.That(expression, Is.InstanceOf<FunctionCallExpression>());
+            var funcCall = (FunctionCallExpression)expression;
+
+            var context = new AchievementScriptContext { RichPresence = new RichPresenceBuilder() };
+            var scope = new InterpreterScope(AchievementScriptInterpreter.GetGlobalScope());
+            scope.Context = context;
+            var error = funcCall.Execute(scope);
+
+            ExpressionTests.AssertError(error, "Cannot create value from condition");
+        }
+
+        [Test]
+        public void TestValueUnboundedTally()
+        {
+            var rp = Evaluate("rich_presence_value(\"Name\", tally(0, byte(0x1234) == 1))");
+            Assert.That(rp.ToString(), Is.EqualTo("Format:Name\r\nFormatType=VALUE\r\n\r\nDisplay:\r\n@Name(M:0xH001234=1)\r\n"));
+        }
+
+        [Test]
         [TestCase("VALUE", "VALUE")]
         [TestCase("SECS", "SECS")]
         [TestCase("TIMESECS", "SECS")]


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/962817919698501702/1425218574372442132

`rich_presence_value("v", byte(0x0001) == 1)` will now generate an error. 

If the intent was to count the number of times the condition was true, it should be wrapped in a `tally(0, ...)`:

`rich_presence_value("v", tally(0, byte(0x0001) == 1))`