### PR TITLE
add MemoryAccessorAlias

### DIFF
--- a/Source/Data/RichPresence.cs
+++ b/Source/Data/RichPresence.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿using Jamiras.Components;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace RATools.Data
 {
@@ -39,9 +42,193 @@ namespace RATools.Data
                 value = value.Trim();
 
                 _script = value;
+                _macros = null;
+                _displayStrings = null;
                 Description = string.Format("{0}/{1} characters", _script.Length, ScriptMaxLength);
             }
         }
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private string _script;
+
+        public class MacroDefinition
+        {
+            public MacroDefinition(string name, ValueFormat formatType)
+                : this(name, formatType, null)
+            {
+            }
+
+            public MacroDefinition(string name, ValueFormat formatType, Dictionary<string, string> lookupEntries)
+            {
+                Name = name;
+                FormatType = formatType;
+                LookupEntries = lookupEntries;
+            }
+
+            public string Name { get; private set; }
+            public ValueFormat FormatType { get; private set; }
+            public Dictionary<string, string> LookupEntries { get; private set; }
+
+            public override string ToString()
+            {
+                if (LookupEntries != null)
+                    return String.Format("\"{0}\" ({1} Entries)", Name, LookupEntries.Count);
+
+                return String.Format("\"{0}\" ({1})", Name, FormatType);
+            }
+        }
+
+        public IEnumerable<MacroDefinition> Macros
+        {
+            get
+            {
+                if (_macros == null)
+                    Parse();
+
+                return _macros;
+            }
+        }
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private List<MacroDefinition> _macros;
+
+        [DebuggerDisplay("{Text}")]
+        public class DisplayString
+        {
+            public DisplayString(Trigger condition, string text, IEnumerable<Macro> macros)
+            {
+                Condition = condition;
+                Text = text;
+                Macros = macros;
+            }
+
+            public Trigger Condition { get; private set; }
+            public string Text { get; private set; }
+
+            [DebuggerDisplay("@{Name,nq}({Value})")]
+            public class Macro
+            {
+                public Macro(string name, Value value)
+                {
+                    Name = name;
+                    Value = value;
+                }
+                public string Name { get; private set; }
+                public Value Value { get; private set; }
+            }
+
+            public IEnumerable<Macro> Macros { get; private set; }
+        }
+
+        public IEnumerable<DisplayString> DisplayStrings
+        {
+            get
+            {
+                if (_macros == null)
+                    Parse();
+
+                return _displayStrings;
+            }
+        }
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private List<DisplayString> _displayStrings;
+
+        private enum Part
+        {
+            None,
+            Format,
+            Lookup,
+            Display,
+        }
+
+        private void Parse()
+        {
+            _macros = new List<MacroDefinition>();
+            _displayStrings = new List<DisplayString>();
+
+            string macroName = null;
+            Part part = Part.None;
+            Dictionary<string, string> lookups = null;
+
+            var tokenizer = Tokenizer.CreateTokenizer(_script);
+            while (tokenizer.NextChar != '\0')
+            {
+                var line = tokenizer.ReadTo('\n');
+                tokenizer.Advance();
+                if (line.StartsWith("//"))
+                    continue;
+
+                if (line.EndsWith("\r"))
+                    line = line.SubToken(0, line.Length - 1);
+
+                if (line.Length == 0)
+                    continue;
+
+                if (line.StartsWith("Format:"))
+                {
+                    macroName = line.Substring(7);
+                    part = Part.Format;
+                }
+                else if (line.StartsWith("FormatType="))
+                {
+                    if (part == Part.Format)
+                    {
+                        var formatType = Leaderboard.ParseFormat(line.Substring(11));
+                        _macros.Add(new MacroDefinition(macroName, formatType));
+                    }
+                    part = Part.None;
+                }
+                else if (line.StartsWith("Lookup:"))
+                {
+                    macroName = line.Substring(7);
+                    lookups = new Dictionary<string, string>();
+                    _macros.Add(new MacroDefinition(macroName, ValueFormat.None, lookups));
+                    part = Part.Lookup;
+                }
+                else if (line.StartsWith("Display:"))
+                {
+                    part = Part.Display;
+                }
+                else if (part == Part.Lookup)
+                {
+                    var index = line.IndexOf('=');
+                    if (index > 0)
+                        lookups.Add(line.Substring(0, index), line.Substring(index + 1));
+                }
+                else if (part == Part.Display)
+                {
+                    Trigger condition = null;
+                    int index = 0;
+
+                    if (line.StartsWith("?"))
+                    {
+                        index = line.IndexOf('?', 1);
+                        if (index != -1)
+                            condition = Trigger.Deserialize(line.Substring(1, index - 1));
+
+                        ++index;
+                    }
+
+                    var macros = new List<DisplayString.Macro>();
+                    var text = line.Substring(index);
+                    while ((index = line.IndexOf('@', index)) != -1)
+                    {
+                        var leftParen = line.IndexOf('(', index + 1);
+                        if (leftParen == -1)
+                            break;
+
+                        var rightParen = line.IndexOf(')', leftParen + 1);
+                        if (rightParen == -1)
+                            break;
+
+                        macroName = line.Substring(index + 1, leftParen - index - 1);
+                        var value = Value.Deserialize(line.Substring(leftParen + 1, rightParen - leftParen - 1));
+                        macros.Add(new DisplayString.Macro(macroName, value));
+
+                        index = rightParen + 1;
+                    }
+
+                    _displayStrings.Add(new DisplayString(condition, text, macros.ToArray()));
+                }
+            }
+        }
     }
 }

--- a/Source/Data/Trigger.cs
+++ b/Source/Data/Trigger.cs
@@ -48,6 +48,19 @@ namespace RATools.Data
         /// </summary>
         public IEnumerable<RequirementGroup> Alts { get; private set; }
 
+
+        public IEnumerable<RequirementGroup> Groups
+        {
+            get
+            {
+                if (Core != null)
+                    yield return Core;
+
+                foreach (var group in Alts)
+                    yield return group;
+            }
+        }
+
         public override bool Equals(object obj)
         {
             var that = obj as Trigger;

--- a/Source/Parser/MemoryAccessorAlias.cs
+++ b/Source/Parser/MemoryAccessorAlias.cs
@@ -1,0 +1,535 @@
+﻿using RATools.Data;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace RATools.Parser
+{
+    [DebuggerDisplay("{Address,h}: {Alias}")]
+    public class MemoryAccessorAlias : IComparer<MemoryAccessorAlias>
+    {
+        public MemoryAccessorAlias(uint address)
+        {
+            Address = address;
+        }
+
+        public MemoryAccessorAlias(uint address, CodeNote note)
+            : this(address)
+        {
+            SetNote(note);
+        }
+
+        private void SetNote(CodeNote note)
+        {
+            Note = note;
+
+            if (note != null)
+            {
+                PrimarySize = note.Size;
+
+                // if note doesn't specify a size, assume 8-bit
+                if (PrimarySize == FieldSize.None)
+                    PrimarySize = FieldSize.Byte;
+            }
+        }
+
+        public CodeNote Note { get; private set; }
+        private string _aliasFromNote = String.Empty;
+        private string _subtextFromNote = null;
+
+        public uint Address { get; private set; }
+
+        public string Alias
+        {
+            get { return _alias ?? _aliasFromNote; }
+            set
+            {
+                if (value == _aliasFromNote)
+                    _alias = null;
+                else
+                    _alias = value;
+            }
+        }
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private string _alias;
+        private NameStyle _aliasStyle = NameStyle.None;
+        private Dictionary<FieldSize, string> _aliases;
+
+        public IEnumerable<MemoryAccessorAlias> Children
+        {
+            get
+            {
+                return _children ?? Enumerable.Empty<MemoryAccessorAlias>();
+            }
+        }
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private List<MemoryAccessorAlias> _children;
+
+        [Flags]
+        private enum ReferencedSizeMask
+        {
+            None = 0,
+            Bit0 = 1 << FieldSize.Bit0,
+            Bit1 = 1 << FieldSize.Bit1,
+            Bit2 = 1 << FieldSize.Bit2,
+            Bit3 = 1 << FieldSize.Bit3,
+            Bit4 = 1 << FieldSize.Bit4,
+            Bit5 = 1 << FieldSize.Bit5,
+            Bit6 = 1 << FieldSize.Bit6,
+            Bit7 = 1 << FieldSize.Bit7,
+            LowNibble = 1 << FieldSize.LowNibble,
+            HighNibble = 1 << FieldSize.HighNibble,
+            Byte = 1 << FieldSize.Byte,
+            Word = 1 << FieldSize.Word,
+            TByte = 1 << FieldSize.TByte,
+            DWord = 1 << FieldSize.DWord,
+            BitCount = 1 << FieldSize.BitCount,
+            BigEndianWord = 1 << FieldSize.BigEndianWord,
+            BigEndianTByte = 1 << FieldSize.BigEndianTByte,
+            BigEndianDWord = 1 << FieldSize.BigEndianDWord,
+            Float = 1 << FieldSize.Float,
+            MBF32 = 1 << FieldSize.MBF32,
+            LittleEndianMBF32 = 1 << FieldSize.LittleEndianMBF32,
+            BigEndianFloat = 1 << FieldSize.BigEndianFloat,
+            Double32 = 1 << FieldSize.Double32,
+            BigEndianDouble32 = 1 << FieldSize.BigEndianDouble32,
+        }
+
+        private ReferencedSizeMask _referencedSizes = ReferencedSizeMask.None;
+
+        public FieldSize PrimarySize { get; private set; }
+
+        public void ReferenceSize(FieldSize size)
+        {
+            _referencedSizes |= (ReferencedSizeMask)(1 << (int)size);
+
+            if (PrimarySize == FieldSize.None)
+            {
+                if (Field.GetMaxValue(size) < 255)
+                    PrimarySize = FieldSize.Byte;
+                else
+                    PrimarySize = size;
+            }
+        }
+
+        public IEnumerable<FieldSize> ReferencedSizes
+        {
+            get
+            {
+                var referencedSizes = (int)_referencedSizes >> 1;
+                var size = 1;
+                while (referencedSizes != 0)
+                {
+                    if ((referencedSizes & 1) == 1)
+                        yield return (FieldSize)size;
+
+                    ++size;
+                    referencedSizes >>= 1;
+                }
+            }
+        }
+
+        public bool HasMultipleReferencedSizes
+        {
+            get
+            {
+                // masking with n-1 removes the rightmost non-zero bit.
+                // if any bits remain, there are multiple sizes.
+                var n = (int)_referencedSizes;
+                return (n & (n - 1)) != 0;
+            }
+        }
+
+        public bool HasReferencedSize(FieldSize size)
+        {
+            return ((int)_referencedSizes & (1 << (int)size)) != 0;
+        }
+
+        public bool IsOnlyReferencedSize(FieldSize size)
+        {
+            return ((int)_referencedSizes ^ (1 << (int)size)) == 0;
+        }
+
+        public string GetAlias(FieldSize size)
+        {
+            if (!HasReferencedSize(size))
+                return null;
+
+            if (size == PrimarySize)
+                return Alias;
+
+            _aliases ??= new Dictionary<FieldSize, string>();
+
+            string alias;
+            if (!_aliases.TryGetValue(size, out alias))
+            {
+                alias = Alias;
+
+                var subNote = Note?.GetSubNote(size);
+                if (subNote == null)
+                {
+                    // if size is the only referenced size, make it the primary size.
+                    if (IsOnlyReferencedSize(size))
+                    {
+                        PrimarySize = size;
+                        return alias;
+                    }
+
+                    // multiple sizes are referenced. we can't generate a unique name without a note alias
+                    if (String.IsNullOrEmpty(alias))
+                    {
+                        _aliases[size] = null;
+                        return null;
+                    }
+
+                    // if the primary size isn't referenced (note didn't specify size or all
+                    // sizes are smaller than a byte), and the size is byte or larger, make
+                    // it the primary size.
+                    if (!HasReferencedSize(PrimarySize) && Field.GetMaxValue(size) >= 255)
+                    {
+                        PrimarySize = size;
+                        return alias;
+                    }
+
+                    // append the size to the note alias to differentiate it from the primary size accessor
+                    subNote = Field.GetSizeFunction(size);
+                }
+
+                if (String.IsNullOrEmpty(alias))
+                {
+                    alias = _aliasStyle.BuildName(subNote);
+                }
+                else
+                {
+                    var suffix = _aliasStyle.BuildName("x " + subNote);
+                    alias = String.Concat(Alias, suffix.AsSpan(1));
+                }
+
+                _aliases[size] = alias;
+            }
+
+            return alias;
+        }
+
+        public void UpdateAliasFromNote(NameStyle style)
+        {
+            _aliases = null;
+            _aliasStyle = style;
+
+            if (style == NameStyle.None || Note == null)
+            {
+                _aliasFromNote = String.Empty;
+
+                if (_children != null)
+                {
+                    foreach (var child in _children)
+                        child.UpdateAliasFromNote(style);
+                }
+
+                return;
+            }
+
+            var text = Note.Summary;
+
+            if (text == "Unlabelled")
+            {
+                text = null;
+
+                var enumerator = Note.Values.GetEnumerator();
+                if (enumerator.MoveNext())
+                {
+                    var firstValue = enumerator.Current.Value;
+                    if (!enumerator.MoveNext())
+                        text = firstValue.ToString();
+                }
+            }
+
+            if (!HasReferencedSize(PrimarySize) && !HasMultipleReferencedSizes && _referencedSizes != ReferencedSizeMask.None)
+            {
+                PrimarySize = ReferencedSizes.First();
+
+                var subNote = Note.GetSubNote(PrimarySize);
+                if (subNote != null && subNote != text)
+                {
+                    if (String.IsNullOrEmpty(text))
+                        text = subNote;
+                    else
+                        text = text + " - " + subNote;
+                }
+            }
+
+            if (!String.IsNullOrEmpty(text))
+            {
+                // remove subtext: "score (bcd)" => "score"
+                int leftParen = -1;
+                if (text[text.Length - 1] == ')')
+                    leftParen = text.LastIndexOf('(');
+                else if (text[text.Length - 1] == ']')
+                    leftParen = text.LastIndexOf('[');
+                if (leftParen > 4)
+                {
+                    var subtext = text.Substring(leftParen + 1, text.Length - leftParen - 2);
+                    if (!KeepSubtext(subtext))
+                    {
+                        _subtextFromNote = subtext;
+                        text = text.Substring(0, leftParen).TrimEnd();
+                    }
+                }
+
+                // if string starts with numbers, potentially treat it as subtext
+                if (_subtextFromNote == null && text.Length > 1 && Char.IsDigit(text[0]))
+                {
+                    int index = 1;
+                    while (index < text.Length && !Char.IsLetter(text[index]))
+                        ++index;
+
+                    if (text.Length - index >= 4 && !Char.IsDigit(text[index - 1]))
+                    {
+                        _subtextFromNote = text.Substring(0, index).Trim();
+                        text = text.Substring(index);
+                    }
+                }
+            }
+
+            // build the function name
+            var functionName = style.BuildName(text);
+            if (!String.IsNullOrEmpty(functionName))
+            {
+                if (AchievementScriptInterpreter.IsReservedFunctionName(functionName))
+                    functionName += '_';
+
+                _aliasFromNote = functionName.ToString();
+            }
+
+            if (_children != null)
+            {
+                foreach (var child in _children)
+                    child.UpdateAliasFromNote(style);
+            }
+        }
+
+        private static bool KeepSubtext(string text)
+        {
+            // keep regional indicators as part of note. [purposefully requires uppercase]
+            switch (text.Length)
+            {
+                case 1:
+                    return (text == "E" || text == "U" || text == "J");
+                case 2:
+                    return (text == "EU" || text == "US" || text == "JP");
+                default:
+                    return false;
+            }
+        }
+
+        public static void ResolveConflictingAliases(IEnumerable<MemoryAccessorAlias> memoryAccessors)
+        {
+            var aliasMap = new Dictionary<string, List<MemoryAccessorAlias>>();
+            foreach (var memoryAccessor in memoryAccessors)
+                CaptureAliases(aliasMap, memoryAccessor);
+
+            // have to put new keys in separate dictionary to avoid modified iterator error
+            var newAliases = new Dictionary<string, List<MemoryAccessorAlias>>();
+            foreach (var kvp in aliasMap)
+            {
+                if (kvp.Value.Count == 1)
+                    continue;
+
+                for (int i = kvp.Value.Count - 1; i >= 0; i--)
+                {
+                    var memoryAccessor = kvp.Value[i];
+                    if (!String.IsNullOrEmpty(memoryAccessor._subtextFromNote))
+                    {
+                        var suffix = memoryAccessor._aliasStyle.BuildName("x " + memoryAccessor._subtextFromNote);
+                        var newAlias = String.Concat(memoryAccessor._aliasFromNote, suffix.AsSpan(1));
+                        memoryAccessor._aliasFromNote = newAlias;
+
+                        kvp.Value.RemoveAt(i);
+
+                        List<MemoryAccessorAlias> list;
+                        if (!aliasMap.TryGetValue(newAlias, out list) &&
+                            !newAliases.TryGetValue(newAlias, out list))
+                        {
+                            list = new List<MemoryAccessorAlias>();
+                            newAliases[newAlias] = list;
+                        }
+
+                        list.Add(memoryAccessor);
+                    }
+                }
+            }
+
+            foreach (var kvp in newAliases)
+            {
+                if (kvp.Value.Count > 1)
+                    aliasMap[kvp.Key] = kvp.Value;
+            }
+
+            foreach (var kvp in aliasMap)
+            {
+                if (kvp.Value.Count < 2)
+                    continue;
+
+                kvp.Value.Sort(new MemoryAccessorAlias(0));
+
+                int suffix = 1;
+                foreach (var memoryAccessor in kvp.Value)
+                {
+                    if (suffix > 1)
+                        memoryAccessor.Alias = memoryAccessor.Alias + '_' + suffix;
+
+                    suffix++;
+                }
+            }
+        }
+
+        private static void CaptureAliases(Dictionary<string, List<MemoryAccessorAlias>> aliasMap, MemoryAccessorAlias memoryAccessor)
+        {
+            var alias = memoryAccessor.Alias;
+            if (!String.IsNullOrEmpty(alias))
+            {
+                List<MemoryAccessorAlias> list;
+                if (!aliasMap.TryGetValue(alias, out list))
+                {
+                    list = new List<MemoryAccessorAlias>();
+                    list.Add(memoryAccessor);
+                    aliasMap.Add(alias, list);
+                }
+                else
+                {
+                    list.Add(memoryAccessor);
+                }
+            }
+
+            foreach (var child in memoryAccessor.Children)
+                CaptureAliases(aliasMap, child);
+        }
+
+
+        public static void AddMemoryAccessors(List<MemoryAccessorAlias> memoryAccessors, Achievement achievement, Dictionary<uint, CodeNote> codeNotes)
+        {
+            MemoryAccessorAlias root = new MemoryAccessorAlias(0);
+            root._children = memoryAccessors;
+
+            AddMemoryAccessors(root, achievement.Trigger.Groups, codeNotes);
+        }
+
+        public static void AddMemoryAccessors(List<MemoryAccessorAlias> memoryAccessors, Leaderboard leaderboard, Dictionary<uint, CodeNote> codeNotes)
+        {
+            MemoryAccessorAlias root = new MemoryAccessorAlias(0);
+            root._children = memoryAccessors;
+
+            AddMemoryAccessors(root, leaderboard.Start.Groups, codeNotes);
+            AddMemoryAccessors(root, leaderboard.Cancel.Groups, codeNotes);
+            AddMemoryAccessors(root, leaderboard.Submit.Groups, codeNotes);
+            AddMemoryAccessors(root, leaderboard.Value.Values, codeNotes);
+        }
+
+        public static void AddMemoryAccessors(List<MemoryAccessorAlias> memoryAccessors, RichPresence richPresence, Dictionary<uint, CodeNote> codeNotes)
+        {
+            MemoryAccessorAlias root = new MemoryAccessorAlias(0);
+            root._children = memoryAccessors;
+
+            foreach (var displayString in richPresence.DisplayStrings)
+            {
+                if (displayString.Condition != null)
+                    AddMemoryAccessors(root, displayString.Condition.Groups, codeNotes);
+
+                foreach (var macro in displayString.Macros)
+                    AddMemoryAccessors(root, macro.Value.Values, codeNotes);
+            }
+        }
+
+        public static void AddMemoryAccessors(List<MemoryAccessorAlias> memoryAccessors, Trigger trigger, Dictionary<uint, CodeNote> codeNotes)
+        {
+            MemoryAccessorAlias root = new MemoryAccessorAlias(0);
+            root._children = memoryAccessors;
+
+            AddMemoryAccessors(root, trigger.Groups, codeNotes);
+        }
+
+        public static void AddMemoryAccessors(List<MemoryAccessorAlias> memoryAccessors, Value value, Dictionary<uint, CodeNote> codeNotes)
+        {
+            MemoryAccessorAlias root = new MemoryAccessorAlias(0);
+            root._children = memoryAccessors;
+
+            AddMemoryAccessors(root, value.Values, codeNotes);
+        }
+
+        private static void AddMemoryAccessors(MemoryAccessorAlias root, IEnumerable<RequirementGroup> groups, Dictionary<uint, CodeNote> codeNotes)
+        {
+            foreach (var group in groups)
+            {
+                CodeNote parentNote = null;
+                MemoryAccessorAlias parentMemoryAccessor = root;
+
+                foreach (var requirement in group.Requirements)
+                {
+                    MemoryAccessorAlias leftMemoryAccessor = requirement.Left.IsMemoryReference ? 
+                        GetMemoryAccessor(parentMemoryAccessor, requirement.Left, codeNotes, parentNote) : null;
+                    MemoryAccessorAlias rightMemoryAccessor = requirement.Right.IsMemoryReference ?
+                        GetMemoryAccessor(parentMemoryAccessor, requirement.Right, codeNotes, parentNote) : null;
+
+                    if (requirement.Type != RequirementType.AddAddress)
+                    {
+                        // not an AddAddress. reset to root
+                        parentMemoryAccessor = root;
+                        parentNote = null;
+                    }
+                    else if (requirement.Operator.IsModifier() && requirement.Operator != RequirementOperator.BitwiseAnd)
+                    {
+                        // scaled value - assume indexing - keep current parent
+                    }
+                    else if (leftMemoryAccessor != null)
+                    {
+                        // chaining off left accessor
+                        parentMemoryAccessor = leftMemoryAccessor;
+                        parentNote = leftMemoryAccessor.Note;
+                    }
+                    else if (rightMemoryAccessor != null)
+                    {
+                        // chaining off right accessor
+                        parentMemoryAccessor = rightMemoryAccessor;
+                        parentNote = rightMemoryAccessor.Note;
+                    }
+                }
+            }
+        }
+
+        int IComparer<MemoryAccessorAlias>.Compare(MemoryAccessorAlias x, MemoryAccessorAlias y)
+        {
+            return (int)x.Address - (int)y.Address;
+        }
+
+        private static MemoryAccessorAlias GetMemoryAccessor(MemoryAccessorAlias parentMemoryAccessor,
+            Field field, Dictionary<uint, CodeNote> codeNotes, CodeNote parentNote)
+        {
+            parentMemoryAccessor._children ??= new List<MemoryAccessorAlias>();
+
+            var memoryAccessor = new MemoryAccessorAlias(field.Value);
+            var index = parentMemoryAccessor._children.BinarySearch(memoryAccessor, memoryAccessor);
+
+            if (index < 0)
+            {
+                CodeNote note = null;
+                if (parentNote == null)
+                    codeNotes.TryGetValue(field.Value, out note);
+                else
+                    note = parentNote.OffsetNotes.FirstOrDefault(n => n.Address == field.Value);
+
+                if (note != null)
+                    memoryAccessor.SetNote(note);
+
+                parentMemoryAccessor._children.Insert(~index, memoryAccessor);
+            }
+            else
+            {
+                memoryAccessor = parentMemoryAccessor._children[index];
+            }
+
+            memoryAccessor.ReferenceSize(field.Size);
+            return memoryAccessor;
+        }
+    }
+}

--- a/Source/Parser/NameStyle.cs
+++ b/Source/Parser/NameStyle.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Text;
+
+namespace RATools.Parser
+{
+    public enum NameStyle
+    {
+        None = 0,
+        SnakeCase,  // lower_with_underscore
+        PascalCase, // UpperEachFirst
+        CamelCase,  // upperInMiddle
+    }
+
+    public static class NameStyleExtension
+    {
+        public static string BuildName(this NameStyle style, string fromText)
+        {
+            if (fromText == null)
+                return null;
+
+            if (fromText.Length == 0)
+                return String.Empty;
+
+            var name = new StringBuilder();
+            var valid = false;
+            var newWord = true;
+
+            foreach (var c in fromText)
+            {
+                if (!Char.IsLetterOrDigit(c))
+                {
+                    // allow dashes and apostrophes as mid-word characters (don't -> dont)
+                    if (c != '-' && c != '\'')
+                        newWord = true;
+                    else if (!newWord && name.Length > 0 && Char.IsDigit(name[name.Length - 1]))
+                        newWord = true;
+
+                    continue;
+                }
+
+                if (newWord)
+                {
+                    newWord = false;
+
+                    if (!valid && Char.IsDigit(c))
+                        name.Append('_');
+
+                    valid = true;
+
+                    switch (style)
+                    {
+                        case NameStyle.PascalCase:
+                            if (Char.IsDigit(c) && Char.IsDigit(name[name.Length - 1]))
+                                name.Append('_');
+
+                            name.Append(Char.ToUpper(c));
+                            continue;
+
+                        case NameStyle.CamelCase:
+                            if (name.Length != 0)
+                            {
+                                if (Char.IsDigit(c) && Char.IsDigit(name[name.Length - 1]))
+                                    name.Append('_');
+
+                                name.Append(Char.ToUpper(c));
+                                continue;
+                            }
+                            break;
+
+                        case NameStyle.SnakeCase:
+                            if (name.Length != 0 && name[name.Length - 1] != '_')
+                                name.Append('_');
+                            break;
+
+                        default:
+                            break;
+                    }
+                }
+
+                name.Append(Char.ToLower(c));
+            }
+
+            return valid ? name.ToString() : string.Empty;
+        }
+    }
+}

--- a/Source/Views/NewScriptDialog.xaml
+++ b/Source/Views/NewScriptDialog.xaml
@@ -148,7 +148,7 @@
             </StackPanel>
             <StackPanel Orientation="Horizontal" Grid.Column="2" Margin="4,0,4,0" ToolTip="Specifies how to format generated function names">
                 <TextBlock Text="Function Names:" FontSize="11" VerticalAlignment="Center" Margin="0,1,4,0"  />
-                <ComboBox Width="90" Height="21" SelectedValue="{Binding SelectedFunctionNameStyle}" ItemsSource="{Binding FunctionNameStyles}" SelectedValuePath="Id">
+                <ComboBox Width="90" Height="21" SelectedValue="{Binding SelectedNameStyle}" ItemsSource="{Binding NameStyles}" SelectedValuePath="Id">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding Label}" FontSize="12" Margin="0,-1,0,0" />

--- a/Tests/Data/CodeNoteTests.cs
+++ b/Tests/Data/CodeNoteTests.cs
@@ -45,6 +45,7 @@ namespace RATools.Data.Tests
         [TestCase("[16-bit-BE] Test", 2, FieldSize.BigEndianWord)]
         [TestCase("[8-bit BE] Test", 1, FieldSize.Byte)]
         [TestCase("[4-bit BE] Test", 1, FieldSize.Byte)]
+        [TestCase("[US] Test [32-bit BE]", 4, FieldSize.BigEndianDWord)]
 
         [TestCase("8 BYTE Test", 8, FieldSize.Array)]
         [TestCase("Test 8 BYTE", 8, FieldSize.Array)]
@@ -337,6 +338,38 @@ namespace RATools.Data.Tests
             Assert.That(n.GetSubNote(FieldSize.Bit7), Is.Null);
             Assert.That(n.GetSubNote(FieldSize.HighNibble), Is.Null);
             Assert.That(n.GetSubNote(FieldSize.LowNibble), Is.Null);
+        }
+
+        [Test]
+        public void TestUnlabelledEnum()
+        {
+            var n = new CodeNote(4,
+                "01=easy\r\n" +
+                "02=normal");
+
+            Assert.That(n.Summary, Is.EqualTo("Unlabelled"));
+            Assert.That(n.Size, Is.EqualTo(FieldSize.None));
+            Assert.That(n.Values.Count(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestUnlabelledEnumCSV()
+        {
+            var n = new CodeNote(4,"01=easy,02=normal");
+
+            Assert.That(n.Summary, Is.EqualTo("Unlabelled"));
+            Assert.That(n.Size, Is.EqualTo(FieldSize.None));
+            Assert.That(n.Values.Count(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestPossibleButNotEnum()
+        {
+            var n = new CodeNote(4, "Tuesday: timer");
+
+            Assert.That(n.Summary, Is.EqualTo("Tuesday: timer"));
+            Assert.That(n.Size, Is.EqualTo(FieldSize.None));
+            Assert.That(n.Values.Count(), Is.EqualTo(0));
         }
     }
 }

--- a/Tests/Parser/MemoryAccessorAliasTests.cs
+++ b/Tests/Parser/MemoryAccessorAliasTests.cs
@@ -1,0 +1,324 @@
+﻿using Jamiras.Components;
+using Jamiras.Core.Tests;
+using Jamiras.Services;
+using Moq;
+using NUnit.Framework;
+using RATools.Data;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace RATools.Parser.Tests
+{
+    [TestFixture]
+    class MemoryAccessorAliasTests
+    {
+        [Test]
+        public void TestInitialize()
+        {
+            var alias = new MemoryAccessorAlias(0x1234);
+            Assert.That(alias.Alias, Is.EqualTo(""));
+            Assert.That(alias.Address, Is.EqualTo(0x1234));
+            Assert.That(alias.Children, Is.Empty);
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.Note, Is.Null);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.None));
+        }
+
+        [Test]
+        public void TestInitializeFromNote()
+        {
+            var note = new CodeNote(0x1230, "[32-bit] This is a note.");
+            var alias = new MemoryAccessorAlias(0x1234, note);
+            Assert.That(alias.Alias, Is.EqualTo(""));
+            Assert.That(alias.Address, Is.EqualTo(0x1234));
+            Assert.That(alias.Children, Is.Empty);
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.Note, Is.SameAs(note));
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.DWord));
+        }
+
+        [Test]
+        public void TestReferenceSize()
+        {
+            var alias = new MemoryAccessorAlias(0x1234);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.None));
+            Assert.That(alias.ReferencedSizes, Is.Empty);
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.None), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.None), Is.False);
+
+            alias.ReferenceSize(FieldSize.Byte);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.ReferencedSizes.Count(), Is.EqualTo(1));
+            Assert.That(alias.ReferencedSizes.First(), Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.Byte), Is.True);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Byte), Is.True);
+
+            alias.ReferenceSize(FieldSize.Byte);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.ReferencedSizes.Count(), Is.EqualTo(1));
+            Assert.That(alias.ReferencedSizes.First(), Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.Byte), Is.True);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Byte), Is.True);
+
+            alias.ReferenceSize(FieldSize.Word);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.ReferencedSizes.Count(), Is.EqualTo(2));
+            Assert.That(alias.ReferencedSizes.First(), Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.ReferencedSizes.Last(), Is.EqualTo(FieldSize.Word));
+            Assert.That(alias.HasMultipleReferencedSizes, Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.Byte), Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.Word), Is.True);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Byte), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Word), Is.False);
+        }
+
+        [Test]
+        public void TestReferenceSizeBits()
+        {
+            var alias = new MemoryAccessorAlias(0x1234);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.None));
+            Assert.That(alias.ReferencedSizes, Is.Empty);
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.None), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.None), Is.False);
+
+            alias.ReferenceSize(FieldSize.Bit5);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.ReferencedSizes.Count(), Is.EqualTo(1));
+            Assert.That(alias.ReferencedSizes.First(), Is.EqualTo(FieldSize.Bit5));
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.Byte), Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.Bit5), Is.True);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Byte), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Bit5), Is.True);
+
+            alias.ReferenceSize(FieldSize.Bit2);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.ReferencedSizes.Count(), Is.EqualTo(2));
+            Assert.That(alias.ReferencedSizes.First(), Is.EqualTo(FieldSize.Bit2));
+            Assert.That(alias.ReferencedSizes.Last(), Is.EqualTo(FieldSize.Bit5));
+            Assert.That(alias.HasMultipleReferencedSizes, Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.Byte), Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.Bit2), Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.Bit5), Is.True);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Byte), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Bit2), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Bit5), Is.False);
+
+            alias.ReferenceSize(FieldSize.Word);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.ReferencedSizes.Count(), Is.EqualTo(3));
+            Assert.That(alias.HasMultipleReferencedSizes, Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.Byte), Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.Bit2), Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.Bit5), Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.Word), Is.True);
+        }
+
+        [Test]
+        public void TestReferenceSizeBitCount()
+        {
+            var alias = new MemoryAccessorAlias(0x1234);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.None));
+            Assert.That(alias.ReferencedSizes, Is.Empty);
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.None), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.None), Is.False);
+
+            alias.ReferenceSize(FieldSize.BitCount);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.ReferencedSizes.Count(), Is.EqualTo(1));
+            Assert.That(alias.ReferencedSizes.First(), Is.EqualTo(FieldSize.BitCount));
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.Byte), Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.BitCount), Is.True);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Byte), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.BitCount), Is.True);
+
+            alias.ReferenceSize(FieldSize.Bit2);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Byte));
+            Assert.That(alias.ReferencedSizes.Count(), Is.EqualTo(2));
+            Assert.That(alias.ReferencedSizes.First(), Is.EqualTo(FieldSize.Bit2));
+            Assert.That(alias.ReferencedSizes.Last(), Is.EqualTo(FieldSize.BitCount));
+            Assert.That(alias.HasMultipleReferencedSizes, Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.Byte), Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.Bit2), Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.BitCount), Is.True);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Byte), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Bit2), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.BitCount), Is.False);
+        }
+
+
+        [Test]
+        public void TestReferenceSizeEndianness()
+        {
+            var alias = new MemoryAccessorAlias(0x1234);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.None));
+            Assert.That(alias.ReferencedSizes, Is.Empty);
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.None), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.None), Is.False);
+
+            alias.ReferenceSize(FieldSize.Word);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Word));
+            Assert.That(alias.ReferencedSizes.Count(), Is.EqualTo(1));
+            Assert.That(alias.ReferencedSizes.First(), Is.EqualTo(FieldSize.Word));
+            Assert.That(alias.HasMultipleReferencedSizes, Is.False);
+            Assert.That(alias.HasReferencedSize(FieldSize.Word), Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.BigEndianWord), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Word), Is.True);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.BigEndianWord), Is.False);
+
+            alias.ReferenceSize(FieldSize.BigEndianWord);
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Word));
+            Assert.That(alias.ReferencedSizes.Count(), Is.EqualTo(2));
+            Assert.That(alias.ReferencedSizes.First(), Is.EqualTo(FieldSize.Word));
+            Assert.That(alias.ReferencedSizes.Last(), Is.EqualTo(FieldSize.BigEndianWord));
+            Assert.That(alias.HasMultipleReferencedSizes, Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.Word), Is.True);
+            Assert.That(alias.HasReferencedSize(FieldSize.BigEndianWord), Is.True);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.Word), Is.False);
+            Assert.That(alias.IsOnlyReferencedSize(FieldSize.BigEndianWord), Is.False);
+        }
+
+        [Test]
+        [TestCase("Test", "test")]
+        [TestCase("Stage/Level", "stage_level")]
+        [TestCase("[16-bit] Score", "score")] // size stripped by code note processing
+        [TestCase("Mario's Lives", "marios_lives")] // apostrophe doesn't separate words
+        [TestCase("Score (BCD)", "score")] // "BCD" stored in subtext for conflict resolution
+        [TestCase("Score (US)", "score_us")] // regional markers are kept
+        [TestCase("Score (EU)", "score_eu")] // regional markers are kept
+        [TestCase("Score (JP)", "score_jp")] // regional markers are kept
+        [TestCase("Stage (1=First, 2=Second)", "stage")] // value clause will be stripped by code note processing
+        [TestCase("Stage (1=First, 2=Second) - monday", "stage")] // "- monday" consumed by code note processing
+        [TestCase("Stage - 1=First, 2=Second - monday", "stage")] // assume "- monday" is part of 2=
+        [TestCase("1-1 Time Attack", "time_attack")] // "1-1" stored in subtext for conflict resolution
+        [TestCase("Bit7=Villager 1 exists", "villager_1_exists")] // use bit description if single entry and no header
+        [TestCase("01=Happy", "happy")] // use enum value if single entry and no header
+        public void TestUpdateAliasFromNote(string note, string expected)
+        {
+            var codeNote = new CodeNote(0x1234, note);
+            var alias = new MemoryAccessorAlias(0x1234, codeNote);
+            alias.ReferenceSize(FieldSize.Byte);
+            alias.UpdateAliasFromNote(NameStyle.SnakeCase);
+
+            Assert.That(alias.Alias, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void TestUpdateAliasFromNoteBitSubset()
+        {
+            var codeNote = new CodeNote(0x1234, "Header\r\nupper4=hi\r\nlower4=lo");
+            var alias = new MemoryAccessorAlias(0x1234, codeNote);
+            alias.ReferenceSize(FieldSize.HighNibble);
+            alias.UpdateAliasFromNote(NameStyle.SnakeCase);
+
+            Assert.That(alias.Alias, Is.EqualTo("header_hi"));
+        }
+
+        [Test]
+        public void TestUpdateAliasFromNoteNibbleSubset()
+        {
+            var codeNote = new CodeNote(0x1234, "Header\r\nupper4=hi\r\nlower4=lo");
+            var alias = new MemoryAccessorAlias(0x1234, codeNote);
+            alias.ReferenceSize(FieldSize.HighNibble);
+            alias.UpdateAliasFromNote(NameStyle.SnakeCase);
+
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.HighNibble));
+            Assert.That(alias.Alias, Is.EqualTo("header_hi"));
+        }
+
+        [Test]
+        public void TestGetAliasLargeSizes()
+        {
+            var codeNote = new CodeNote(0x1234, "[16-bit] Header");
+            var alias = new MemoryAccessorAlias(0x1234, codeNote);
+            alias.ReferenceSize(FieldSize.Word);
+            alias.ReferenceSize(FieldSize.DWord);
+            alias.ReferenceSize(FieldSize.Byte);
+            alias.UpdateAliasFromNote(NameStyle.SnakeCase);
+
+            Assert.That(alias.PrimarySize, Is.EqualTo(FieldSize.Word));
+            Assert.That(alias.Alias, Is.EqualTo("header"));
+            Assert.That(alias.GetAlias(FieldSize.Word), Is.EqualTo("header"));
+            Assert.That(alias.GetAlias(FieldSize.DWord), Is.EqualTo("header_dword"));
+            Assert.That(alias.GetAlias(FieldSize.Byte), Is.EqualTo("header_byte"));
+            Assert.That(alias.GetAlias(FieldSize.BigEndianWord), Is.Null);
+        }
+
+        [Test]
+        public void TestResolveConflictingAliases()
+        {
+            var list = new List<MemoryAccessorAlias>();
+            list.Add(new MemoryAccessorAlias(0x1234, new CodeNote(0x1234, "Score")));
+            list.Add(new MemoryAccessorAlias(0x1235, new CodeNote(0x1235, "Score")));
+            list.Add(new MemoryAccessorAlias(0x1236, new CodeNote(0x1236, "Score")));
+            list.Add(new MemoryAccessorAlias(0x1240, new CodeNote(0x1240, "Lives")));
+            list.Add(new MemoryAccessorAlias(0x1248, new CodeNote(0x1248, "Level")));
+            list.Add(new MemoryAccessorAlias(0x124C, new CodeNote(0x1248, "Sub-level")));
+            list.Add(new MemoryAccessorAlias(0x1280, new CodeNote(0x1280, "Level (New Game+)")));
+            list.Add(new MemoryAccessorAlias(0x12C0, new CodeNote(0x12C0, "Character (New Game+)")));
+
+            foreach (var alias in list)
+                alias.UpdateAliasFromNote(NameStyle.CamelCase);
+
+            Assert.That(list[0].Alias, Is.EqualTo("score"));
+            Assert.That(list[1].Alias, Is.EqualTo("score"));
+            Assert.That(list[2].Alias, Is.EqualTo("score"));
+            Assert.That(list[3].Alias, Is.EqualTo("lives"));
+            Assert.That(list[4].Alias, Is.EqualTo("level"));
+            Assert.That(list[5].Alias, Is.EqualTo("sublevel"));
+            Assert.That(list[6].Alias, Is.EqualTo("level"));
+            Assert.That(list[7].Alias, Is.EqualTo("character"));
+
+            MemoryAccessorAlias.ResolveConflictingAliases(list);
+
+            Assert.That(list[0].Alias, Is.EqualTo("score"));
+            Assert.That(list[1].Alias, Is.EqualTo("score_2"));
+            Assert.That(list[2].Alias, Is.EqualTo("score_3"));
+            Assert.That(list[3].Alias, Is.EqualTo("lives"));
+            Assert.That(list[4].Alias, Is.EqualTo("level"));
+            Assert.That(list[5].Alias, Is.EqualTo("sublevel"));
+            Assert.That(list[6].Alias, Is.EqualTo("levelNewGame"));
+            Assert.That(list[7].Alias, Is.EqualTo("character"));
+        }
+
+        [Test]
+        public void TestAddMemoryAccessorsAchievement()
+        {
+            var definition = "A:0xX1234_R:d0xH1111=67S0x 2000!=d0x 2000S0xH2000=0xH1337";
+            var builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer(definition));
+            var achievement = builder.ToAchievement();
+
+            var codeNotes = new Dictionary<uint, CodeNote>();
+            codeNotes[0x2000] = new CodeNote(0x2000, "[8-bit] Column");
+            codeNotes[0x1111] = new CodeNote(0x1111, "[8-bit] Row");
+
+            var list = new List<MemoryAccessorAlias>();
+            MemoryAccessorAlias.AddMemoryAccessors(list, achievement, codeNotes);
+
+            Assert.That(list.Count, Is.EqualTo(4));
+            Assert.That(list[0].Address, Is.EqualTo(0x1111));
+            Assert.That(list[0].HasReferencedSize(FieldSize.Byte), Is.True);
+            Assert.That(list[0].Note, Is.SameAs(codeNotes[0x1111]));
+            Assert.That(list[1].Address, Is.EqualTo(0x1234));
+            Assert.That(list[1].HasReferencedSize(FieldSize.DWord), Is.True);
+            Assert.That(list[1].Note, Is.Null);
+            Assert.That(list[2].Address, Is.EqualTo(0x1337));
+            Assert.That(list[2].HasReferencedSize(FieldSize.Byte), Is.True);
+            Assert.That(list[2].Note, Is.Null);
+            Assert.That(list[3].Address, Is.EqualTo(0x2000));
+            Assert.That(list[3].HasReferencedSize(FieldSize.Word), Is.True);
+            Assert.That(list[3].HasReferencedSize(FieldSize.Byte), Is.True);
+            Assert.That(list[3].Note, Is.SameAs(codeNotes[0x2000]));
+        }
+    }
+}

--- a/Tests/Parser/NameStyleTests.cs
+++ b/Tests/Parser/NameStyleTests.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+
+namespace RATools.Parser.Tests
+{
+    [TestFixture]
+    class NameStyleTests
+    {
+        [TestCase("a", NameStyle.SnakeCase, "a")]
+        [TestCase("a", NameStyle.PascalCase, "A")]
+        [TestCase("a", NameStyle.CamelCase, "a")]
+        [TestCase("a", NameStyle.None, "a")]
+        [TestCase("big ball", NameStyle.SnakeCase, "big_ball")]
+        [TestCase("big ball", NameStyle.PascalCase, "BigBall")]
+        [TestCase("big ball", NameStyle.CamelCase, "bigBall")]
+        [TestCase("big ball", NameStyle.None, "bigball")]
+        [TestCase("ONE TWO 3", NameStyle.SnakeCase, "one_two_3")]
+        [TestCase("ONE TWO 3", NameStyle.PascalCase, "OneTwo3")]
+        [TestCase("ONE TWO 3", NameStyle.CamelCase, "oneTwo3")]
+        [TestCase("ONE TWO 3", NameStyle.None, "onetwo3")]
+        [TestCase("12.3", NameStyle.SnakeCase, "_12_3")]
+        [TestCase("12.3", NameStyle.PascalCase, "_12_3")]
+        [TestCase("12.3", NameStyle.CamelCase, "_12_3")]
+        [TestCase("12.3", NameStyle.None, "_123")]
+        [TestCase("Bob's one-off", NameStyle.SnakeCase, "bobs_oneoff")]
+        [TestCase("Bob's one-off", NameStyle.PascalCase, "BobsOneoff")]
+        [TestCase("Bob's one-off", NameStyle.CamelCase, "bobsOneoff")]
+        [TestCase("Bob's one-off", NameStyle.None, "bobsoneoff")]
+        [TestCase("_italic fun_", NameStyle.SnakeCase, "italic_fun")]
+        [TestCase("_italic fun_", NameStyle.PascalCase, "ItalicFun")]
+        [TestCase("_italic fun_", NameStyle.CamelCase, "italicFun")]
+        [TestCase("_italic fun_", NameStyle.None, "italicfun")]
+        [TestCase("1-2 Time Attack", NameStyle.SnakeCase, "_1_2_time_attack")]
+        [TestCase("1-2 Time Attack", NameStyle.PascalCase, "_1_2TimeAttack")]
+        [TestCase("1-2 Time Attack", NameStyle.CamelCase, "_1_2TimeAttack")]
+        [TestCase("1-2 Time Attack", NameStyle.None, "_12timeattack")]
+        public void TestBuildName(string input, NameStyle nameStyle, string expected)
+        {
+            var output = nameStyle.BuildName(input);
+            Assert.That(output, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Tests/Regression/DumpTests.cs
+++ b/Tests/Regression/DumpTests.cs
@@ -2,6 +2,7 @@
 using Jamiras.Services;
 using Moq;
 using NUnit.Framework;
+using RATools.Parser;
 using RATools.Services;
 using RATools.ViewModels;
 using System.Collections.Generic;
@@ -69,22 +70,21 @@ namespace RATools.Tests.Regression
 
             var mockDialogService = new Mock<IDialogService>();
 
-            var mockLogger = new Mock<ILogger>();
-
             var mockFileSystem = new Mock<IFileSystemService>();
             mockFileSystem.Setup(s => s.FileExists(It.IsAny<string>())).Returns((string p) => File.Exists(p));
             mockFileSystem.Setup(s => s.OpenFile(It.IsAny<string>(), OpenFileMode.Read)).
                 Returns((string p, OpenFileMode m) => File.Open(p, FileMode.Open, FileAccess.Read, FileShare.Read));
 
             var vmNewScript = new NewScriptDialogViewModel(mockSettings.Object, 
-                mockDialogService.Object, mockLogger.Object, mockFileSystem.Object);
+                mockDialogService.Object, mockFileSystem.Object);
             vmNewScript.GameId.Value = int.Parse(patchDataFileName);
             vmNewScript.SearchCommand.Execute();
 
             vmNewScript.SelectedCodeNotesFilter = CodeNoteFilter.ForSelectedAssets;
-            vmNewScript.SelectedFunctionNameStyle = FunctionNameStyle.SnakeCase;
             vmNewScript.SelectedNoteDump = NoteDump.OnlyForDefinedMethods;
+
             vmNewScript.CheckAllCommand.Execute();
+            vmNewScript.SelectedNameStyle = NameStyle.SnakeCase; // name style must be changed after selecting all
 
             var expectedFileName = Path.Combine(baseDir, vmNewScript.GameId.Value + ".rascript");
             var outputFileName = Path.ChangeExtension(expectedFileName, ".updated.rascript");


### PR DESCRIPTION
Moves much of the memory reference mapping code out of `NewScriptViewModel` into helper classes which can be more easily unit tested.

Improves the function name generation to better address duplicates and sub-notes.

Uses `PublishedAssets` directly instead of loading stuff through the `GameViewModel` (which obfuscates access to the raw data objects through child view models).