### PR TITLE
ignore closed/resolved tickets when creating new script

### DIFF
--- a/Source/ViewModels/NewScriptDialogViewModel.cs
+++ b/Source/ViewModels/NewScriptDialogViewModel.cs
@@ -439,6 +439,10 @@ namespace RATools.ViewModels
 
             foreach (var ticket in ticketsJson.GetField("Tickets").ObjectArrayValue)
             {
+                var state = ticket.GetField("ReportState").IntegerValue.GetValueOrDefault();
+                if (state != 1 && state != 3) // 1=open 3=request
+                    continue;
+
                 var ticketId = ticket.GetField("ID").IntegerValue.GetValueOrDefault();
                 _ticketNotes[ticketId] = ticket.GetField("ReportNotes").StringValue;
 


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/936655398725902356/1443254886170103879

It looks like the Tickets API was changed last summer to return all tickets instead of just open tickets. As a result, the non-open tickets have to be filtered out when building the list.