### PR TITLE
ResetNextIf has to be distributed over each element of an AddHits chain

### DIFF
--- a/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementClauseExpression.cs
@@ -762,9 +762,28 @@ namespace RATools.Parser.Expressions.Trigger
                         });
                     }
 
-                    error = BuildTrigger(achievementContext, resetRequirements, RequirementType.None);
-                    if (error != null)
-                        return error;
+                    bool hasAddHitsChain = conditions.OfType<TalliedRequirementExpression>().Any(c => c.Conditions.Count() > 1);
+                    if (hasAddHitsChain)
+                    {
+                        // if there's an AddHits chain, the ResetNextIf has to be attached to each subclause
+                        for (int i = 0; i < conditions.Count; i++)
+                        {
+                            var talliedCondition = conditions[i] as TalliedRequirementExpression;
+                            if (talliedCondition != null)
+                            {
+                                var clone = talliedCondition.Clone();
+                                clone.ResetCondition = resetRequirements.First();
+                                conditions[i] = clone;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // no add hits chain, just put it in front of everything.
+                        error = BuildTrigger(achievementContext, resetRequirements, RequirementType.None);
+                        if (error != null)
+                            return error;
+                    }
                 }
 
                 if (this.Operation == ConditionalOperation.And)

--- a/Tests/Parser/Functions/MeasuredFunctionTests.cs
+++ b/Tests/Parser/Functions/MeasuredFunctionTests.cs
@@ -78,6 +78,8 @@ namespace RATools.Parser.Tests.Functions
         [TestCase("measured(repeated(0, byte(0x1234) == 5))", "M:0xH001234=5")]
         [TestCase("measured(tally(0, byte(0x1234) == 20, byte(0x1234) == 67))", "C:0xH001234=20_M:0xH001234=67")]
         [TestCase("measured(tally(0, byte(0x1234) == 20 && byte(0x2345) == 67))", "N:0xH001234=20_M:0xH002345=67")]
+        [TestCase("measured(100, when = tally(1, byte(0x1234) == 1, byte(0x1234) == 2) && never(byte(0x2345) == 1))",
+            "M:100_Z:0xH002345=1_C:0xH001234=1_Z:0xH002345=1_Q:0xH001234=2.1.")]
         public void TestBuildValue(string input, string expected)
         {
             var clause = TriggerExpressionTests.Parse<MeasuredRequirementExpression>(input);


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/310195377993416714/1492671079615828059

Ensures the ResetNextIf is distributed over each subclause of an AddHits chain. Does not attempt to optimize the ResetNextIfs into a ResetIf if no other hit counts exist.