### PR TITLE
add indicator for generation failed

### DIFF
--- a/Source/Data/AssetBase.cs
+++ b/Source/Data/AssetBase.cs
@@ -43,6 +43,11 @@ namespace RATools.Data
         }
 
         /// <summary>
+        /// Gets whether or not the asset failed to generate.
+        /// </summary>
+        public bool IsInvalid { get; set; }
+
+        /// <summary>
         /// Gets the first unique identifier reserved for locally generated assets.
         /// </summary>
         public static readonly int FirstLocalId = 111000001;

--- a/Source/Parser/AchievementBuilder.cs
+++ b/Source/Parser/AchievementBuilder.cs
@@ -85,7 +85,9 @@ namespace RATools.Parser
 
         public static SoftwareVersion GetMinimumVersion(Achievement achievement)
         {
-            var minimumVersion = achievement.Trigger.MinimumVersion();
+            var minimumVersion = Data.Version.MinimumVersion;
+            if (achievement.Trigger != null)
+                minimumVersion = minimumVersion.OrNewer(achievement.Trigger.MinimumVersion());
 
             if (achievement.Type != AchievementType.Standard)
                 minimumVersion = minimumVersion.OrNewer(Data.Version._1_3);

--- a/Source/Parser/Expressions/FunctionCallExpression.cs
+++ b/Source/Parser/Expressions/FunctionCallExpression.cs
@@ -450,7 +450,13 @@ namespace RATools.Parser.Expressions
                     var value = GetParameter(parameterScope, initializationScope, assignedParameter);
                     error = value as ErrorExpression;
                     if (error != null)
-                        return null;
+                    {
+                        if (!function.DelayError(assignedParameter.Variable.Name))
+                            return null;
+
+                        parameterScope.ReturnValue ??= error;
+                        error = null;
+                    }
 
                     var variableDefinition = new VariableDefinitionExpression(assignedParameter.Variable);
                     parameter.CopyLocation(variableDefinition);
@@ -477,7 +483,13 @@ namespace RATools.Parser.Expressions
                     var value = GetParameter(parameterScope, initializationScope, assignedParameter);
                     error = value as ErrorExpression;
                     if (error != null)
-                        return null;
+                    {
+                        if (!function.DelayError(assignedParameter.Variable.Name))
+                            return null;
+
+                        parameterScope.ReturnValue ??= error;
+                        error = null;
+                    }
 
                     if (index < parameterCount)
                     {

--- a/Source/Parser/Expressions/FunctionDefinitionExpression.cs
+++ b/Source/Parser/Expressions/FunctionDefinitionExpression.cs
@@ -618,6 +618,17 @@ namespace RATools.Parser.Expressions
             scope.AddFunction(this);
             return null;
         }
+
+        /// <summary>
+        /// If this returns <c>true</c>, the error will be loaded into the function parameters
+        /// <see cref="InterpreterScope" /> as ReturnValue. The <see cref="Invoke"/> and
+        /// <see cref="Evaluate"/> functions should do whatever processing is still valid, then
+        /// return the captured error as the result.
+        /// </summary>
+        public virtual bool DelayError(string parameterName)
+        {
+            return false;
+        }
     }
 
     internal class UserFunctionDefinitionExpression : FunctionDefinitionExpression, IValueExpression

--- a/Source/Parser/Functions/AchievementFunction.cs
+++ b/Source/Parser/Functions/AchievementFunction.cs
@@ -33,39 +33,46 @@ namespace RATools.Parser.Functions
             DefaultParameters["set"] = new IntegerConstantExpression(0);
         }
 
+        public override bool DelayError(string parameterName)
+        {
+            return true;
+        }
+
         public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
             var achievement = new ScriptInterpreterAchievementBuilder();
 
             var stringExpression = GetStringParameter(scope, "title", out result);
-            if (stringExpression == null)
-                return false;
-            achievement.Title = stringExpression.Value;
+            if (stringExpression != null)
+                achievement.Title = stringExpression.Value;
+            else
+                scope.ReturnValue ??= result;
 
             stringExpression = GetStringParameter(scope, "description", out result);
-            if (stringExpression == null)
-                return false;
-            achievement.Description = stringExpression.Value;
+            if (stringExpression != null)
+                achievement.Description = stringExpression.Value;
+            else
+                scope.ReturnValue ??= result;
 
             stringExpression = GetStringParameter(scope, "badge", out result);
-            if (stringExpression == null)
-                return false;
-            achievement.BadgeName = stringExpression.Value;
+            if (stringExpression != null)
+                achievement.BadgeName = stringExpression.Value;
+            else
+                scope.ReturnValue ??= result;
 
             var integerExpression = GetIntegerParameter(scope, "points", out result);
             if (integerExpression == null)
-                return false;
-            if (!Achievement.ValidPointValues.Contains(integerExpression.Value))
-            {
-                result = new ErrorExpression(integerExpression.Value + " is not a supported value for points", integerExpression);
-                return false;
-            }
-            achievement.Points = integerExpression.Value;
+                scope.ReturnValue ??= result;
+            else if (!Achievement.ValidPointValues.Contains(integerExpression.Value))
+                scope.ReturnValue ??= new ErrorExpression(integerExpression.Value + " is not a supported value for points", integerExpression);
+            else
+                achievement.Points = integerExpression.Value;
 
             integerExpression = GetIntegerParameter(scope, "id", out result);
-            if (integerExpression == null)
-                return false;
-            achievement.Id = integerExpression.Value;
+            if (integerExpression != null)
+                achievement.Id = integerExpression.Value;
+            else
+                scope.ReturnValue ??= result;
 
             stringExpression = GetStringParameter(scope, "published", out result);
             if (stringExpression != null && !string.IsNullOrEmpty(stringExpression.Value))
@@ -73,44 +80,48 @@ namespace RATools.Parser.Functions
 
             stringExpression = GetStringParameter(scope, "type", out result);
             if (stringExpression == null)
-                return false;
-            achievement.Type = Achievement.ParseType(stringExpression.Value);
-            if (achievement.Type == AchievementType.None)
             {
-                result = new ErrorExpression(stringExpression.Value + " is not a supported achievement type", stringExpression);
-                return false;
+                scope.ReturnValue ??= result;
             }
-
-            integerExpression = GetIntegerParameter(scope, "set", out result);
-            if (integerExpression == null)
-                return false;
+            else
+            {
+                achievement.Type = Achievement.ParseType(stringExpression.Value);
+                if (achievement.Type == AchievementType.None)
+                    scope.ReturnValue ??= new ErrorExpression(stringExpression.Value + " is not a supported achievement type", stringExpression);
+            }
 
             var context = scope.GetContext<AchievementScriptContext>();
             Debug.Assert(context != null);
             AchievementSet set = null;
-            if (integerExpression.Value != 0)
+
+            integerExpression = GetIntegerParameter(scope, "set", out result);
+            if (integerExpression == null)
+            {
+                scope.ReturnValue ??= result;
+            }
+            else if (integerExpression.Value != 0)
             {
                 set = context.GetSet(integerExpression.Value);
                 if (set == null)
-                {
-                    result = new ErrorExpression("Unknown set id: " + integerExpression.Value, integerExpression);
-                    return false;
-                }
+                    scope.ReturnValue ??= new ErrorExpression("Unknown set id: " + integerExpression.Value, integerExpression);
             }
 
             var trigger = GetRequirementParameter(scope, "trigger", out result);
             if (trigger == null)
-                return false;
-
-            if (!TriggerBuilderContext.ProcessAchievementConditions(achievement, trigger, scope, out result))
+            {
+                scope.ReturnValue ??= result;
+            }
+            else if (!TriggerBuilderContext.ProcessAchievementConditions(achievement, trigger, scope, out result))
             {
                 if (result.Location.Start != trigger.Location.Start || result.Location.End != trigger.Location.End)
                 {
                     var error = (ErrorExpression)result;
-                    result = new ErrorExpression(error.Message, trigger) { InnerError = error };
+                    scope.ReturnValue ??= new ErrorExpression(error.Message, trigger) { InnerError = error };
                 }
-
-                return false;
+                else
+                {
+                    scope.ReturnValue ??= result;
+                }
             }
 
             var newAchievement = achievement.ToAchievement();
@@ -123,6 +134,14 @@ namespace RATools.Parser.Functions
                 sourceLine = functionCall.Location.Start.Line;
 
             context.Achievements[newAchievement] = sourceLine;
+
+            result = scope.ReturnValue;
+            if (result != null)
+            {
+                newAchievement.IsInvalid = true;
+                return false;
+            }
+
             return true;
         }
     }

--- a/Source/Parser/Functions/LeaderboardFunction.cs
+++ b/Source/Parser/Functions/LeaderboardFunction.cs
@@ -30,74 +30,82 @@ namespace RATools.Parser.Functions
             DefaultParameters["set"] = new IntegerConstantExpression(0);
         }
 
+        public override bool DelayError(string parameterName)
+        {
+            return true;
+        }
+
         public override bool Evaluate(InterpreterScope scope, out ExpressionBase result)
         {
             var leaderboard = new Leaderboard();
 
             var stringExpression = GetStringParameter(scope, "title", out result);
-            if (stringExpression == null)
-                return false;
-            leaderboard.Title = stringExpression.Value;
+            if (stringExpression != null)
+                leaderboard.Title = stringExpression.Value;
+            else
+                scope.ReturnValue ??= result;
 
             stringExpression = GetStringParameter(scope, "description", out result);
-            if (stringExpression == null)
-                return false;
-            leaderboard.Description = stringExpression.Value;
+            if (stringExpression != null)
+                leaderboard.Description = stringExpression.Value;
+            else
+                scope.ReturnValue ??= result;
 
+            AchievementSet set = null;
             var context = scope.GetContext<AchievementScriptContext>();
             Debug.Assert(context != null);
             var serializationContext = context.SerializationContext;
 
             leaderboard.Start = ProcessTrigger(scope, "start", serializationContext, out result);
             if (leaderboard.Start == null)
-                return false;
+                scope.ReturnValue ??= result;
 
             leaderboard.Cancel = ProcessTrigger(scope, "cancel", serializationContext, out result);
             if (leaderboard.Cancel == null)
-                return false;
+                scope.ReturnValue ??= result;
 
             leaderboard.Submit = ProcessTrigger(scope, "submit", serializationContext, out result);
             if (leaderboard.Submit == null)
-                return false;
+                scope.ReturnValue ??= result;
 
             leaderboard.Value = ProcessValue(scope, "value", serializationContext, out result);
             if (leaderboard.Value == null)
-                return false;
+                scope.ReturnValue ??= result;
 
             var format = GetStringParameter(scope, "format", out result);
             if (format == null)
-                return false;
-
-            leaderboard.Format = Leaderboard.ParseFormat(format.Value);
-            if (leaderboard.Format == ValueFormat.None)
             {
-                result = new ErrorExpression(format.Value + " is not a supported leaderboard format", format);
-                return false;
+                scope.ReturnValue ??= result;
+            }
+            else
+            {
+                leaderboard.Format = Leaderboard.ParseFormat(format.Value);
+                if (leaderboard.Format == ValueFormat.None)
+                    scope.ReturnValue ??= new ErrorExpression(format.Value + " is not a supported leaderboard format", format);
             }
 
             var lowerIsBetter = GetBooleanParameter(scope, "lower_is_better", out result);
-            if (lowerIsBetter == null)
-                return false;
-            leaderboard.LowerIsBetter = lowerIsBetter.Value;
+            if (lowerIsBetter != null)
+                leaderboard.LowerIsBetter = lowerIsBetter.Value;
+            else
+                scope.ReturnValue ??= result;
 
             var integerExpression = GetIntegerParameter(scope, "id", out result);
-            if (integerExpression == null)
-                return false;
-            leaderboard.Id = integerExpression.Value;
+            if (integerExpression != null)
+                leaderboard.Id = integerExpression.Value;
+            else
+                scope.ReturnValue ??= result;
 
             integerExpression = GetIntegerParameter(scope, "set", out result);
             if (integerExpression == null)
-                return false;
-
-            AchievementSet set = null;
-            if (integerExpression.Value != 0)
+            {
+                scope.ReturnValue ??= result;
+            }
+            else if (integerExpression.Value != 0)
             {
                 set = context.GetSet(integerExpression.Value);
                 if (set == null)
-                {
-                    result = new ErrorExpression("Unknown set id: " + integerExpression.Value, integerExpression);
-                    return false;
-                }
+                    scope.ReturnValue ??= new ErrorExpression("Unknown set id: " + integerExpression.Value, integerExpression);
             }
 
             if (leaderboard.Submit == leaderboard.Start)
@@ -119,6 +127,14 @@ namespace RATools.Parser.Functions
                 sourceLine = functionCall.Location.Start.Line;
 
             context.Leaderboards[leaderboard] = sourceLine;
+
+            result = scope.ReturnValue;
+            if (result != null)
+            {
+                leaderboard.IsInvalid = true;
+                return false;
+            }
+
             return true;
         }
 

--- a/Source/Parser/LeaderboardBuilder.cs
+++ b/Source/Parser/LeaderboardBuilder.cs
@@ -89,20 +89,29 @@ namespace RATools.Parser
         {
             var minimumVersion = GetMinimumVersion(leaderboard.Format);
 
-            minimumVersion = minimumVersion.OrNewer(leaderboard.Start.MinimumVersion());
-            minimumVersion = minimumVersion.OrNewer(leaderboard.Cancel.MinimumVersion());
-            minimumVersion = minimumVersion.OrNewer(leaderboard.Submit.MinimumVersion());
-            minimumVersion = minimumVersion.OrNewer(leaderboard.Value.MinimumVersion());
+            if (leaderboard.Start != null)
+                minimumVersion = minimumVersion.OrNewer(leaderboard.Start.MinimumVersion());
+            if (leaderboard.Cancel != null)
+                minimumVersion = minimumVersion.OrNewer(leaderboard.Cancel.MinimumVersion());
+            if (leaderboard.Submit != null)
+                minimumVersion = minimumVersion.OrNewer(leaderboard.Submit.MinimumVersion());
+            if (leaderboard.Value != null)
+                minimumVersion = minimumVersion.OrNewer(leaderboard.Value.MinimumVersion());
 
             return minimumVersion;
         }
 
         public static uint GetMaximumAddress(Leaderboard leaderboard)
         {
-            var maximumAddress = leaderboard.Start.MaximumAddress();
-            maximumAddress = Math.Max(maximumAddress, leaderboard.Cancel.MaximumAddress());
-            maximumAddress = Math.Max(maximumAddress, leaderboard.Submit.MaximumAddress());
-            maximumAddress = Math.Max(maximumAddress, leaderboard.Value.MaximumAddress());
+            uint maximumAddress = 0;
+            if (leaderboard.Start != null)
+                maximumAddress = Math.Max(maximumAddress, leaderboard.Start.MaximumAddress());
+            if (leaderboard.Cancel != null)
+                maximumAddress = Math.Max(maximumAddress, leaderboard.Cancel.MaximumAddress());
+            if (leaderboard.Submit != null)
+                maximumAddress = Math.Max(maximumAddress, leaderboard.Submit.MaximumAddress());
+            if (leaderboard.Value != null)
+                maximumAddress = Math.Max(maximumAddress, leaderboard.Value.MaximumAddress());
 
             return maximumAddress;
         }

--- a/Source/ViewModels/AssetViewModelBase.cs
+++ b/Source/ViewModels/AssetViewModelBase.cs
@@ -180,7 +180,7 @@ namespace RATools.ViewModels
         {
             var coreAsset = Published.Asset;
 
-            if (!IsGenerated)
+            if (!IsGenerated || Generated.Asset.IsInvalid)
             {
                 CanUpdate = false;
 
@@ -188,22 +188,33 @@ namespace RATools.ViewModels
                 IsTitleModified = false;
                 IsDescriptionModified = false;
                 IsPointsModified = false;
-                CompareState = GeneratedCompareState.None;
-                ModificationMessage = "Not generated";
+
+                if (!IsGenerated)
+                {
+                    CompareState = GeneratedCompareState.None;
+                    ModificationMessage = "Not generated";
+                }
+                else
+                {
+                    CompareState = GeneratedCompareState.Invalid;
+                    ModificationMessage = "Generation failed";
+                }
 
                 if (coreAsset != null)
                 {
                     Triggers = Published.TriggerList;
                     if (coreAsset.IsUnofficial)
-                        TriggerSource = "Unpublished (Not Generated)";
+                        TriggerSource = String.Format("Unpublished ({0})", ModificationMessage);
                     else
-                        TriggerSource = "Core (Not Generated)";
+                        TriggerSource = String.Format("Core ({0})", ModificationMessage);
                 }
                 else if (Local.Asset != null)
                 {
                     Triggers = Local.TriggerList;
-                    TriggerSource = "Local (Not Generated)";
-                    CompareState = GeneratedCompareState.NotGenerated;
+                    TriggerSource = String.Format("Local ({0})", ModificationMessage);
+
+                    if (!IsGenerated)
+                        CompareState = GeneratedCompareState.NotGenerated;
                 }
             }
             else if (IsModified(Local, true))

--- a/Source/ViewModels/Navigation/NavigationListViewModel.cs
+++ b/Source/ViewModels/Navigation/NavigationListViewModel.cs
@@ -241,7 +241,7 @@ namespace RATools.ViewModels.Navigation
                             editor = assetEditors.FirstOrDefault(e => e.Published.Asset == null
                                                                    && e.Generated.Asset == null
                                                                    && e.Local.Asset == null
-                                                                   && e.Title == achievement.Title);
+                                                                   && e.Title == leaderboard.Title);
                         }
 
                         if (editor == null)

--- a/Source/ViewModels/Navigation/NavigationViewModelBase.cs
+++ b/Source/ViewModels/Navigation/NavigationViewModelBase.cs
@@ -78,6 +78,8 @@ namespace RATools.ViewModels.Navigation
                     return "Generated asset differs from published";
                 case GeneratedCompareState.NotGenerated: // ◖
                     return "Local asset is not generated";
+                case GeneratedCompareState.Invalid: // △
+                    return "Generation failed";
                 default:
                     return null;
             }

--- a/Source/ViewModels/ViewerViewModelBase.cs
+++ b/Source/ViewModels/ViewerViewModelBase.cs
@@ -122,5 +122,10 @@ namespace RATools.ViewModels
         /// ● generated differs from local (published may or may not exist). fully filled circle icon
         /// </summary>
         LocalDiffers,
+
+        /// <summary>
+        /// △ generation failed. hollow triangle icon
+        /// </summary>
+        Invalid,
     }
 }

--- a/Source/Views/GameViewer.xaml
+++ b/Source/Views/GameViewer.xaml
@@ -60,6 +60,9 @@
                             <DataTrigger Binding="{Binding CompareState}" Value="PublishedDiffers">
                                 <Setter Property="Text" Value="&#x25D0;" />
                             </DataTrigger>
+                            <DataTrigger Binding="{Binding CompareState}" Value="Invalid">
+                                <Setter Property="Text" Value="&#x25B3;" />
+                            </DataTrigger>
                         </Style.Triggers>
                     </Style>
                 </TextBlock.Style>

--- a/Tests/Parser/AchievementScriptInterpreterTests.cs
+++ b/Tests/Parser/AchievementScriptInterpreterTests.cs
@@ -575,8 +575,11 @@ namespace RATools.Parser.Tests
         [Test]
         public void TestMeasuredMultipleDiffering()
         {
-            var parser = AchievementScriptTests.Parse("achievement(\"T\", \"D\", 5, measured(byte(0x1234) == 10) && measured(byte(0x2345) == 1))", false);
-            Assert.That(AchievementScriptTests.GetInnerErrorMessage(parser), Is.EqualTo("1:26 Multiple measured() conditions must have the same target."));
+            AchievementScriptTests.Evaluate(
+                "achievement(\"T\", \"D\", 5, measured(byte(0x1234) == 10) && measured(byte(0x2345) == 1))\n",
+
+                "1:1 achievement call failed\r\n" +
+                "- 1:26 Multiple measured() conditions must have the same target.");
         }
 
         [Test]
@@ -1154,7 +1157,8 @@ namespace RATools.Parser.Tests
                 "function f() => byte(0x1234) == 2\n" +
                 "achievement(\"T\", \"D\", 5, f() == 1)\n",
 
-                "2:26 Invalid value for parameter: trigger\r\n" +
+                "2:1 achievement call failed\r\n" +
+                "- 2:26 Invalid value for parameter: trigger\r\n" +
                 "- 2:26 Cannot chain comparisons");
         }
 

--- a/Tests/Parser/Expressions/ExpressionGroupCollectionTests.cs
+++ b/Tests/Parser/Expressions/ExpressionGroupCollectionTests.cs
@@ -277,7 +277,7 @@ namespace RATools.Parser.Tests.Expressions
             interpreter.Run(group, null);
 
             Assert.That(group.HasEvaluationErrors, Is.True);
-            Assert.That(group.Errors.First().Location.Start.Line, Is.EqualTo(3));
+            Assert.That(group.Errors.First().Location.Start.Line, Is.EqualTo(2));
 
             var updatedInput = "a = 3\n" +
                                "\n" +
@@ -289,14 +289,14 @@ namespace RATools.Parser.Tests.Expressions
 
             Assert.That(group.HasEvaluationErrors, Is.True);
             var error = group.Errors.First();
-            Assert.That(error.Location.Start.Line, Is.EqualTo(5));
+            Assert.That(error.Location.Start.Line, Is.EqualTo(4));
             Assert.That(error.InnermostError.Location.Start.Line, Is.EqualTo(5));
 
             group.Update(Tokenizer.CreateTokenizer(input), new int[] { 2, 3 });
 
             Assert.That(group.HasEvaluationErrors, Is.True);
             error = group.Errors.First();
-            Assert.That(error.Location.Start.Line, Is.EqualTo(3));
+            Assert.That(error.Location.Start.Line, Is.EqualTo(2));
             Assert.That(error.InnermostError.Location.Start.Line, Is.EqualTo(3));
         }
     }

--- a/Tests/Parser/Functions/AchievementFunctionTests.cs
+++ b/Tests/Parser/Functions/AchievementFunctionTests.cs
@@ -124,8 +124,13 @@ namespace RATools.Parser.Tests.Functions
             var parser = new AchievementScriptInterpreter();
             Assert.That(parser.Run(tokenizer), Is.False);
             Assert.That(parser.ErrorMessage, Is.EqualTo(
-                "2:26 Invalid value for parameter: trigger\r\n" +
+                "2:1 achievement call failed\r\n" +
+                "- 2:26 Invalid value for parameter: trigger\r\n" +
                 "- 2:26 Cannot compare function reference and integer"));
+
+            // achievement should still be generated, but marked invalid
+            Assert.That(parser.Achievements.Count, Is.EqualTo(1));
+            Assert.That(parser.Achievements.First().IsInvalid, Is.True);
         }
 
         [Test]
@@ -139,7 +144,8 @@ namespace RATools.Parser.Tests.Functions
             var parser = new AchievementScriptInterpreter();
             Assert.That(parser.Run(tokenizer), Is.False);
             Assert.That(parser.ErrorMessage, Is.EqualTo(
-                "3:26 Invalid value for parameter: trigger\r\n" +
+                "3:1 achievement call failed\r\n" +
+                "- 3:26 Invalid value for parameter: trigger\r\n" +
                 "- 3:26 b call failed\r\n" +
                 "- 2:17 Cannot compare function reference and integer"));
         }

--- a/Tests/Parser/Functions/LeaderboardFunctionTests.cs
+++ b/Tests/Parser/Functions/LeaderboardFunctionTests.cs
@@ -112,9 +112,16 @@ namespace RATools.Parser.Tests.Functions
         [Test]
         public void TestFormatUnknown()
         {
-            Evaluate("leaderboard(\"T\", \"D\", " +
+            var leaderboard = Evaluate(
+                "leaderboard(\"T\", \"D\", " +
                 "byte(0x1234) == 1, byte(0x1234) == 2, byte(0x1234) == 3, byte(0x4567), \"banana\")",
-                "1:1 leaderboard call failed\r\n- 1:94 banana is not a supported leaderboard format");
+
+                "1:1 leaderboard call failed\r\n" +
+                "- 1:94 banana is not a supported leaderboard format");
+
+            // leaderboard should still be generated, but marked invalid
+            Assert.That(leaderboard != null);
+            Assert.That(leaderboard.IsInvalid, Is.True);
         }
 
         [Test]
@@ -172,7 +179,8 @@ namespace RATools.Parser.Tests.Functions
                 "byte(0x1234) == 1, byte(0x1234) == 2, byte(0x1234) == 3, " +
                 "max_of())",
 
-                "1:80 Invalid value for parameter: value\r\n" +
+                "1:1 leaderboard call failed\r\n" +
+                "- 1:80 Invalid value for parameter: value\r\n" +
                 "- 1:80 max_of call failed\r\n" +
                 "- 1:80 At least one expression is required");
         }

--- a/Tests/ViewModels/AssetViewModelBaseTests.cs
+++ b/Tests/ViewModels/AssetViewModelBaseTests.cs
@@ -137,7 +137,7 @@ namespace RATools.Tests.ViewModels
             Assert.That(vmAsset.Triggers.Count(), Is.EqualTo(1));
             Assert.That(vmAsset.Triggers.ElementAt(0), Is.Not.InstanceOf<TriggerComparisonViewModel>());
             Assert.That(vmAsset.Triggers.ElementAt(0).Label, Is.EqualTo("Trigger1234"));
-            Assert.That(vmAsset.TriggerSource, Is.EqualTo("Core (Not Generated)"));
+            Assert.That(vmAsset.TriggerSource, Is.EqualTo("Core (Not generated)"));
         }
 
         [Test]
@@ -166,7 +166,7 @@ namespace RATools.Tests.ViewModels
             Assert.That(vmAsset.Triggers.Count(), Is.EqualTo(1));
             Assert.That(vmAsset.Triggers.ElementAt(0), Is.Not.InstanceOf<TriggerComparisonViewModel>());
             Assert.That(vmAsset.Triggers.ElementAt(0).Label, Is.EqualTo("Trigger1234"));
-            Assert.That(vmAsset.TriggerSource, Is.EqualTo("Unpublished (Not Generated)"));
+            Assert.That(vmAsset.TriggerSource, Is.EqualTo("Unpublished (Not generated)"));
         }
 
         [Test]
@@ -194,7 +194,7 @@ namespace RATools.Tests.ViewModels
             Assert.That(vmAsset.Triggers.Count(), Is.EqualTo(1));
             Assert.That(vmAsset.Triggers.ElementAt(0), Is.Not.InstanceOf<TriggerComparisonViewModel>());
             Assert.That(vmAsset.Triggers.ElementAt(0).Label, Is.EqualTo("Trigger1234"));
-            Assert.That(vmAsset.TriggerSource, Is.EqualTo("Local (Not Generated)"));
+            Assert.That(vmAsset.TriggerSource, Is.EqualTo("Local (Not generated)"));
         }
 
         [Test]
@@ -268,6 +268,76 @@ namespace RATools.Tests.ViewModels
             Assert.That(vmAsset.Triggers.ElementAt(0), Is.InstanceOf<TriggerComparisonViewModel>());
             Assert.That(vmAsset.Triggers.ElementAt(0).Label, Is.EqualTo("Trigger1235"));
             Assert.That(vmAsset.TriggerSource, Is.EqualTo("Generated (Same as Unpublished)"));
+        }
+
+        [Test]
+        public void TestRefreshGenerationFailedWithCore()
+        {
+            var vmAsset = new AssetViewModelBaseHarness();
+            vmAsset.Published.Asset = new TestAchievement(1235, "TitleC", "DescriptionC")
+            {
+                BadgeName = "BadgeC"
+            };
+            vmAsset.Local.Asset = new TestAchievement(1234, "TitleL", "DescriptionL")
+            {
+                BadgeName = "BadgeL"
+            };
+            vmAsset.Generated.Asset = new TestAchievement(1235, "TitleG", "DescriptionG")
+            {
+                BadgeName = "BadgeG",
+                IsInvalid = true,
+            };
+
+            vmAsset.Refresh();
+
+            Assert.That(vmAsset.Id, Is.EqualTo(1235));
+            Assert.That(vmAsset.Title, Is.EqualTo("TitleG"));
+            Assert.That(vmAsset.Description, Is.EqualTo("DescriptionG"));
+            Assert.That(vmAsset.IsTitleModified, Is.False);
+            Assert.That(vmAsset.IsDescriptionModified, Is.False);
+            Assert.That(vmAsset.BadgeName, Is.EqualTo("BadgeG"));
+            Assert.That(vmAsset.CompareState, Is.EqualTo(GeneratedCompareState.Invalid));
+            Assert.That(vmAsset.ModificationMessage, Is.EqualTo("Generation failed"));
+            Assert.That(vmAsset.IsGenerated, Is.True);
+            Assert.That(vmAsset.CanUpdate, Is.False);
+            Assert.That(vmAsset.Other, Is.Null);
+            Assert.That(vmAsset.Triggers.Count(), Is.EqualTo(1));
+            Assert.That(vmAsset.Triggers.ElementAt(0), Is.InstanceOf<TriggerViewModel>());
+            Assert.That(vmAsset.Triggers.ElementAt(0).Label, Is.EqualTo("Trigger1234"));
+            Assert.That(vmAsset.TriggerSource, Is.EqualTo("Core (Generation failed)"));
+        }
+
+        [Test]
+        public void TestRefreshGenerationFailedWithLocal()
+        {
+            var vmAsset = new AssetViewModelBaseHarness();
+            vmAsset.Local.Asset = new TestAchievement(1234, "TitleL", "DescriptionL")
+            {
+                BadgeName = "BadgeL"
+            };
+            vmAsset.Generated.Asset = new TestAchievement(1235, "TitleG", "DescriptionG")
+            {
+                BadgeName = "BadgeG",
+                IsInvalid = true,
+            };
+
+            vmAsset.Refresh();
+
+            Assert.That(vmAsset.Id, Is.EqualTo(1235));
+            Assert.That(vmAsset.Title, Is.EqualTo("TitleG"));
+            Assert.That(vmAsset.Description, Is.EqualTo("DescriptionG"));
+            Assert.That(vmAsset.IsTitleModified, Is.False);
+            Assert.That(vmAsset.IsDescriptionModified, Is.False);
+            Assert.That(vmAsset.BadgeName, Is.EqualTo("BadgeG"));
+            Assert.That(vmAsset.CompareState, Is.EqualTo(GeneratedCompareState.Invalid));
+            Assert.That(vmAsset.ModificationMessage, Is.EqualTo("Generation failed"));
+            Assert.That(vmAsset.IsGenerated, Is.True);
+            Assert.That(vmAsset.CanUpdate, Is.False);
+            Assert.That(vmAsset.Other, Is.Null);
+            Assert.That(vmAsset.Triggers.Count(), Is.EqualTo(1));
+            Assert.That(vmAsset.Triggers.ElementAt(0), Is.InstanceOf<TriggerViewModel>());
+            Assert.That(vmAsset.Triggers.ElementAt(0).Label, Is.EqualTo("Trigger1235"));
+            Assert.That(vmAsset.TriggerSource, Is.EqualTo("Local (Generation failed)"));
         }
 
         [Test]

--- a/Tests/ViewModels/Nagivation/NavigationViewModelBaseTests.cs
+++ b/Tests/ViewModels/Nagivation/NavigationViewModelBaseTests.cs
@@ -88,6 +88,10 @@ namespace RATools.Tests.ViewModels.Nagivation
             Assert.That(harness.CompareState, Is.EqualTo(GeneratedCompareState.LocalDiffers));
             Assert.That(harness.ModificationMessage, Is.EqualTo("Generated asset differs from unpublished"));
 
+            harness.SetCompareState(GeneratedCompareState.Invalid);
+            Assert.That(harness.CompareState, Is.EqualTo(GeneratedCompareState.Invalid));
+            Assert.That(harness.ModificationMessage, Is.EqualTo("Generation failed"));
+
             changedProperties.Clear();
             harness.SetCompareState(GeneratedCompareState.Same);
             Assert.That(harness.CompareState, Is.EqualTo(GeneratedCompareState.Same));


### PR DESCRIPTION
When an `achievement()` or `leaderboard()` call fails, the current behavior is to mark the associated achievement/leaderboard as "not generated", which moves it to the bottom of the list. This is slightly confusing.

This PR allows the `achievement()` and `leaderboard()` calls to still create the generated record as well as they can, then mark it as invalid:
<img width="267" height="63" alt="image" src="https://github.com/user-attachments/assets/5b5f6b0c-0afc-42b8-acea-4408650c1f82" />

In addition to a better indicator, and not moving the item from its position in the list, this also allows the user to get back to the failing code by maintaining the "Go to source" link.