### PR TITLE
show pointer offset notes in the requirements view

### DIFF
--- a/Source/Data/CodeNote.cs
+++ b/Source/Data/CodeNote.cs
@@ -894,5 +894,14 @@ namespace RATools.Data
 
             return false;
         }
+
+        public static CodeNote ResolveNote(uint address, IDictionary<uint, CodeNote> notes, CodeNote parentNote)
+        {
+            if (parentNote != null)
+                return parentNote.OffsetNotes.FirstOrDefault(n => n.Address == address);
+
+            notes.TryGetValue(address, out CodeNote note);
+            return note;
+        }
     }
 }

--- a/Source/ViewModels/RequirementComparisonViewModel.cs
+++ b/Source/ViewModels/RequirementComparisonViewModel.cs
@@ -7,8 +7,8 @@ namespace RATools.ViewModels
 {
     public class RequirementComparisonViewModel : RequirementViewModel
     {
-        public RequirementComparisonViewModel(Requirement requirement, Requirement compareRequirement, NumberFormat numberFormat, IDictionary<uint, CodeNote> notes)
-            : base(requirement, numberFormat, notes)
+        public RequirementComparisonViewModel(Requirement requirement, Requirement compareRequirement, NumberFormat numberFormat, IDictionary<uint, CodeNote> notes, CodeNote parentNote)
+            : base(requirement, numberFormat, notes, parentNote)
         {
             if (compareRequirement == null)
             {

--- a/Source/ViewModels/RequirementGroupViewModel.cs
+++ b/Source/ViewModels/RequirementGroupViewModel.cs
@@ -20,8 +20,12 @@ namespace RATools.ViewModels
             Label = label;
 
             var list = new List<RequirementViewModel>();
+            CodeNote parentNote = null;
             foreach (var requirement in requirements)
-                list.Add(new RequirementViewModel(requirement, numberFormat, notes));
+            {
+                list.Add(new RequirementViewModel(requirement, numberFormat, notes, parentNote));
+                parentNote = UpdateParentNote(requirement, parentNote, notes);
+            }
 
             UpdateDependencies(list);
             Requirements = list;
@@ -200,22 +204,44 @@ namespace RATools.ViewModels
             }
         }
 
+        private static CodeNote UpdateParentNote(Requirement requirement, CodeNote parentNote, IDictionary<uint, CodeNote> notes)
+        {
+            if (requirement.Type == RequirementType.AddAddress && requirement.Left.IsMemoryReference)
+            {
+                var leftNote = CodeNote.ResolveNote(requirement.Left.Value, notes, parentNote);
+                return (leftNote != null && leftNote.IsPointer) ? leftNote : null;
+            }
+            else if (requirement.Type != RequirementType.AddAddress)
+            {
+                return null;
+            }
+            return parentNote;
+        }
+
         private static void AppendRequirements(List<RequirementViewModel> list, RequirementEx left, RequirementEx right, NumberFormat numberFormat, IDictionary<uint, CodeNote> notes)
         {
             if (right == null)
             {
+                CodeNote parentNote = null;
                 foreach (var requirement in left.Requirements)
-                    list.Add(new RequirementComparisonViewModel(requirement, null, numberFormat, notes));
+                {
+                    list.Add(new RequirementComparisonViewModel(requirement, null, numberFormat, notes, parentNote));
+                    parentNote = UpdateParentNote(requirement, parentNote, notes);
+                }
             }
             else if (left == null)
             {
                 foreach (var requirement in right.Requirements)
-                    list.Add(new RequirementComparisonViewModel(null, requirement, numberFormat, notes));
+                    list.Add(new RequirementComparisonViewModel(null, requirement, numberFormat, notes, null));
             }
             else if (left.Requirements.Count == right.Requirements.Count)
             {
+                CodeNote parentNote = null;
                 for (int i = 0; i < left.Requirements.Count; ++i)
-                    list.Add(new RequirementComparisonViewModel(left.Requirements[i], right.Requirements[i], numberFormat, notes));
+                {
+                    list.Add(new RequirementComparisonViewModel(left.Requirements[i], right.Requirements[i], numberFormat, notes, parentNote));
+                    parentNote = UpdateParentNote(left.Requirements[i], parentNote, notes);
+                }
             }
             else
             {
@@ -272,6 +298,7 @@ namespace RATools.ViewModels
                 }
 
                 var rightIndex = 0;
+                CodeNote parentNote = null;
 
                 foreach (var requirement in left.Requirements)
                 {
@@ -283,17 +310,18 @@ namespace RATools.ViewModels
                         {
                             var rightRequirement = right.Requirements[rightIndex++];
                             if (unmatchedCompareRequirements.Remove(rightRequirement))
-                                list.Add(new RequirementComparisonViewModel(null, rightRequirement, numberFormat, notes));
+                                list.Add(new RequirementComparisonViewModel(null, rightRequirement, numberFormat, notes, null));
                         }
 
                         rightIndex++;
                     }
 
-                    list.Add(new RequirementComparisonViewModel(requirement, match, numberFormat, notes));
+                    list.Add(new RequirementComparisonViewModel(requirement, match, numberFormat, notes, parentNote));
+                    parentNote = UpdateParentNote(requirement, parentNote, notes);
                 }
 
                 foreach (var requirement in unmatchedCompareRequirements)
-                    list.Add(new RequirementComparisonViewModel(null, requirement, numberFormat, notes));
+                    list.Add(new RequirementComparisonViewModel(null, requirement, numberFormat, notes, null));
             }
         }
 
@@ -450,7 +478,7 @@ namespace RATools.ViewModels
             while (GetBestMerge(list, out leftIndex, out rightIndex))
             {
                 list[leftIndex] = new RequirementComparisonViewModel(list[leftIndex].Requirement, 
-                    ((RequirementComparisonViewModel)list[rightIndex]).CompareRequirement, numberFormat, notes);
+                    ((RequirementComparisonViewModel)list[rightIndex]).CompareRequirement, numberFormat, notes, null);
                 list.RemoveAt(rightIndex);
             }
 

--- a/Source/ViewModels/RequirementViewModel.cs
+++ b/Source/ViewModels/RequirementViewModel.cs
@@ -14,7 +14,7 @@ namespace RATools.ViewModels
     [DebuggerDisplay("{Requirement}")]
     public class RequirementViewModel : ViewModelBase
     {
-        public RequirementViewModel(Requirement requirement, NumberFormat numberFormat, IDictionary<uint, CodeNote> notes)
+        public RequirementViewModel(Requirement requirement, NumberFormat numberFormat, IDictionary<uint, CodeNote> notes, CodeNote parentNote)
         {
             Requirement = requirement;
 
@@ -28,14 +28,15 @@ namespace RATools.ViewModels
                     {
                         var builder = new StringBuilder();
 
-                        CodeNote note;
-                        if (notes.TryGetValue(requirement.Left.Value, out note))
+                        var note = CodeNote.ResolveNote(requirement.Left.Value, notes, parentNote);
+                        if (note != null)
                         {
                             var subNote = note.GetSubNote(requirement.Left.Size);
                             builder.AppendFormat("0x{0:x6}:{1}", requirement.Left.Value, subNote ?? note.Summary);
                         }
 
-                        if (notes.TryGetValue(requirement.Right.Value, out note))
+                        note = CodeNote.ResolveNote(requirement.Right.Value, notes, parentNote);
+                        if (note != null)
                         {
                             if (builder.Length > 0)
                                 builder.AppendLine();
@@ -48,8 +49,8 @@ namespace RATools.ViewModels
                     }
                     else
                     {
-                        CodeNote note;
-                        if (notes.TryGetValue(requirement.Left.Value, out note))
+                        var note = CodeNote.ResolveNote(requirement.Left.Value, notes, parentNote);
+                        if (note != null)
                         {
                             Notes = note.Note;
                             var subNote = note.GetSubNote(requirement.Left.Size);
@@ -63,8 +64,8 @@ namespace RATools.ViewModels
                 }
                 else if (requirement.Right.IsMemoryReference)
                 {
-                    CodeNote note;
-                    if (notes.TryGetValue(requirement.Right.Value, out note))
+                    var note = CodeNote.ResolveNote(requirement.Right.Value, notes, parentNote);
+                    if (note != null)
                     {
                         Notes = note.Note;
                         var subNote = note.GetSubNote(requirement.Left.Size);

--- a/Tests/ViewModels/RequirementComparisonViewModelTests.cs
+++ b/Tests/ViewModels/RequirementComparisonViewModelTests.cs
@@ -36,7 +36,7 @@ namespace RATools.Tests.ViewModels
             builder.ParseRequirements(Tokenizer.CreateTokenizer(rightSerialized));
             var compareRequirement = builder.ToAchievement().CoreRequirements.First();
 
-            var vmRequirement = new RequirementComparisonViewModel(requirement, compareRequirement, NumberFormat.Decimal, notes);
+            var vmRequirement = new RequirementComparisonViewModel(requirement, compareRequirement, NumberFormat.Decimal, notes, null);
 
             Assert.That(vmRequirement.Definition, Is.EqualTo(expectedDefinition));
             Assert.That(vmRequirement.OtherDefinition, Is.EqualTo(expectedOtherDefinition));
@@ -52,7 +52,7 @@ namespace RATools.Tests.ViewModels
             builder.ParseRequirements(Tokenizer.CreateTokenizer("0xH1234=7"));
             var requirement = builder.ToAchievement().CoreRequirements.First();
 
-            var vmRequirement = new RequirementComparisonViewModel(requirement, null, NumberFormat.Decimal, notes);
+            var vmRequirement = new RequirementComparisonViewModel(requirement, null, NumberFormat.Decimal, notes, null);
 
             Assert.That(vmRequirement.Definition, Is.EqualTo("byte(0x001234) == 7"));
             Assert.That(vmRequirement.OtherDefinition, Is.EqualTo(""));
@@ -68,7 +68,7 @@ namespace RATools.Tests.ViewModels
             builder.ParseRequirements(Tokenizer.CreateTokenizer("0xH1234=7"));
             var requirement = builder.ToAchievement().CoreRequirements.First();
 
-            var vmRequirement = new RequirementComparisonViewModel(null, requirement, NumberFormat.Decimal, notes);
+            var vmRequirement = new RequirementComparisonViewModel(null, requirement, NumberFormat.Decimal, notes, null);
 
             Assert.That(vmRequirement.Definition, Is.EqualTo(""));
             Assert.That(vmRequirement.OtherDefinition, Is.EqualTo("byte(0x001234) == 7"));

--- a/Tests/ViewModels/RequirementGroupViewModelTests.cs
+++ b/Tests/ViewModels/RequirementGroupViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿using Jamiras.Components;
+using Jamiras.Components;
 using Moq;
 using NUnit.Framework;
 using RATools.Data;
@@ -6,6 +6,7 @@ using RATools.Parser;
 using RATools.Services;
 using RATools.ViewModels;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace RATools.Tests.ViewModels
@@ -105,6 +106,38 @@ namespace RATools.Tests.ViewModels
             ServiceRepository.Reset();
 
             Assert.That(strBuilder.ToString(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase("I:0xX1000_I:0xX0068_0xH0004=1",  // nested pointer
+            new[] { "[32-bit pointer] root\n+0x68 | [32-bit pointer] nested\n++0x4 | [8-bit] value" },
+            new[] { "[32-bit pointer] root\n+0x68 | [32-bit pointer] nested\n++0x4 | [8-bit] value", "[32-bit pointer] nested\n+0x4 | [8-bit] value", "[8-bit] value" })]
+        [TestCase("I:0xX1000_0xH0004=1_0xH2000=2",  // resets after pointer chain
+            new[] { "[32-bit pointer] root\n+0x4 | [8-bit] hp", "unrelated" },
+            new[] { "[32-bit pointer] root\n+0x4 | [8-bit] hp", "[8-bit] hp", "unrelated" })]
+        public void TestNotes(string serialized, string[] notes, string[] expectedNotes)
+        {
+            var mockSettings = new Mock<ISettings>();
+            mockSettings.Setup(s => s.HexValues).Returns(false);
+            ServiceRepository.Reset();
+            ServiceRepository.Instance.RegisterInstance(mockSettings.Object);
+
+            var builder = new AchievementBuilder();
+            builder.ParseRequirements(Tokenizer.CreateTokenizer(serialized));
+            var requirements = builder.ToAchievement().CoreRequirements;
+
+            // notes are for 0x1000, 0x2000, ...
+            var notesDict = new Dictionary<uint, CodeNote>();
+            for (int i = 0; i < notes.Length; i++)
+            {
+                uint address = (uint)(0x1000 * (i + 1));
+                notesDict[address] = new CodeNote(address, notes[i]);
+            }
+
+            var vmRequirementGroup = new RequirementGroupViewModel("Group", requirements, NumberFormat.Decimal, notesDict);
+
+            for (int i = 0; i < expectedNotes.Length; i++)
+                Assert.That(vmRequirementGroup.Requirements.ElementAt(i).Notes, Is.EqualTo(expectedNotes[i]));
         }
     }
 }

--- a/Tests/ViewModels/RequirementViewModelTests.cs
+++ b/Tests/ViewModels/RequirementViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿using Jamiras.Components;
+using Jamiras.Components;
 using Moq;
 using NUnit.Framework;
 using RATools.Data;
@@ -33,7 +33,7 @@ namespace RATools.Tests.ViewModels
 
             var requirement = builder.ToAchievement().CoreRequirements.First();
             var notes = new Dictionary<uint, CodeNote>();
-            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes);
+            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes, null);
 
             Assert.That(vmRequirement.Definition, Is.EqualTo(expected));
         }
@@ -64,7 +64,7 @@ namespace RATools.Tests.ViewModels
             var builder = new AchievementBuilder();
             builder.ParseRequirements(Tokenizer.CreateTokenizer(serialized));
             var requirement = builder.ToAchievement().CoreRequirements.First();
-            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes);
+            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes, null);
 
             Assert.That(vmRequirement.Notes, Is.EqualTo(expectedNote));
 
@@ -92,7 +92,7 @@ namespace RATools.Tests.ViewModels
             var builder = new AchievementBuilder();
             builder.ParseRequirements(Tokenizer.CreateTokenizer(serialized));
             var requirement = builder.ToAchievement().CoreRequirements.First();
-            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes);
+            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes, null);
 
             Assert.That(vmRequirement.NotesShort, Is.EqualTo(expected));
 
@@ -118,7 +118,7 @@ namespace RATools.Tests.ViewModels
             };
 
             var notes = new Dictionary<uint, CodeNote>();
-            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes);
+            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes, null);
 
             Assert.That(vmRequirement.Definition, Is.EqualTo("always_false()"));
 
@@ -145,7 +145,7 @@ namespace RATools.Tests.ViewModels
             };
 
             var notes = new Dictionary<uint, CodeNote>();
-            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes);
+            var vmRequirement = new RequirementViewModel(requirement, NumberFormat.Decimal, notes, null);
 
             Assert.That(vmRequirement.Definition, Is.EqualTo("repeated(10, always_false())"));
 


### PR DESCRIPTION
I'm trying to use the pointer offset feature in code notes that allows to toolkit to display notes on AddAddress chains.

I usually develop everything in rascript and only create code notes at the end. During this process, I use RATools' achievement view to see which addresses are still missing notes. The view didn't support offset notes for pointers though, so it was breaking my workflow :)

RATools was already parsing offset notes, so this PR is just displaying that information on the requirements view. The idea is to keep track of a parent code note as we go through the requirements. AddAddress sets the parent note and chained conditions resolve their code notes using the parent note's offset notes.

<img width="577" height="63" alt="image" src="https://github.com/user-attachments/assets/70d90bf7-77c7-4407-ab5a-a20c2d8d2dec" />
