### PR TITLE
de-emphasize pointer notes in requirements view

### DIFF
--- a/Source/ViewModels/RequirementGroupViewModel.cs
+++ b/Source/ViewModels/RequirementGroupViewModel.cs
@@ -206,16 +206,14 @@ namespace RATools.ViewModels
 
         private static CodeNote UpdateParentNote(Requirement requirement, CodeNote parentNote, IDictionary<uint, CodeNote> notes)
         {
-            if (requirement.Type == RequirementType.AddAddress && requirement.Left.IsMemoryReference)
-            {
-                var leftNote = CodeNote.ResolveNote(requirement.Left.Value, notes, parentNote);
-                return (leftNote != null && leftNote.IsPointer) ? leftNote : null;
-            }
-            else if (requirement.Type != RequirementType.AddAddress)
-            {
+            if (requirement.Type != RequirementType.AddAddress)
                 return null;
-            }
-            return parentNote;
+
+            if (!requirement.Left.IsMemoryReference)
+                return parentNote;
+
+            var leftNote = CodeNote.ResolveNote(requirement.Left.Value, notes, parentNote);
+            return (leftNote != null && leftNote.IsPointer) ? leftNote : null;
         }
 
         private static void AppendRequirements(List<RequirementViewModel> list, RequirementEx left, RequirementEx right, NumberFormat numberFormat, IDictionary<uint, CodeNote> notes)

--- a/Source/ViewModels/RequirementViewModel.cs
+++ b/Source/ViewModels/RequirementViewModel.cs
@@ -125,7 +125,7 @@ namespace RATools.ViewModels
 
         public bool IsAddAddress
         {
-            get { return Requirement.Type == RequirementType.AddAddress; }
+            get { return Requirement?.Type == RequirementType.AddAddress; }
         }
 
         internal virtual void OnShowHexValuesChanged(ModelPropertyChangedEventArgs e)

--- a/Source/ViewModels/RequirementViewModel.cs
+++ b/Source/ViewModels/RequirementViewModel.cs
@@ -123,6 +123,11 @@ namespace RATools.ViewModels
 
         public bool IsNoteShortened { get; private set; }
 
+        public bool IsAddAddress
+        {
+            get { return Requirement.Type == RequirementType.AddAddress; }
+        }
+
         internal virtual void OnShowHexValuesChanged(ModelPropertyChangedEventArgs e)
         {
             if (Requirement != null)

--- a/Source/Views/AssetViewer.xaml
+++ b/Source/Views/AssetViewer.xaml
@@ -108,7 +108,17 @@
 
     <DataTemplate x:Key="codeNotesStackPanelTemplate">
         <StackPanel Orientation="Horizontal">
-            <TextBlock Text="{Binding NotesShort}" Style="{StaticResource themedTextBlock}" TextWrapping="Wrap" FontStyle="Italic" />
+            <TextBlock Text="{Binding NotesShort}" TextWrapping="Wrap" FontStyle="Italic">
+                <TextBlock.Style>
+                    <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource themedTextBlock}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsAddAddress}" Value="True">
+                                <Setter Property="Opacity" Value="0.6" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
             <Border BorderBrush="{Binding DataContext.Resources.ScrollBarForegroundBrush, ElementName=gameGrid}"
                     BorderThickness="2" CornerRadius="4" Margin="6,0,0,0">
                 <Border.Style>


### PR DESCRIPTION
extension of #642 

AddAddress notes will be slightly grayed out, allowing the user to focus on the leaf node notes.
<img width="612" height="80" alt="image" src="https://github.com/user-attachments/assets/329229f0-957e-4ee1-8c5f-4f996f2f1a10" />
