### PR TITLE
delay comparison optimization to BuildTrigger step

### DIFF
--- a/Source/Parser/Expressions/ComparisonExpression.cs
+++ b/Source/Parser/Expressions/ComparisonExpression.cs
@@ -163,62 +163,36 @@ namespace RATools.Parser.Expressions
                 }
             }
 
-            bool canModifyRight = true;
-            // if the right side is only a constant, check to see if we're in a measured.
-            // if we are, the right side is the measured target, and we don't want to modify that.
-            if (right.Type == ExpressionType.IntegerConstant || right.Type == ExpressionType.FloatConstant)
+            var comparisonNormalize = left as IComparisonNormalizeExpression;
+            if (comparisonNormalize != null)
             {
-                var initializationContext = scope.GetContext<ParameterInitializationContext>();
-                if (initializationContext != null &&
-                    initializationContext.Function.Name.Name == "measured")
+                var normalized = comparisonNormalize.NormalizeComparison(right, Operation, true);
+                if (normalized != null && normalized is not ComparisonExpression)
                 {
-                    // capturing measured value - don't modify comparison. the user has already
-                    // determined the limits they want to use for the progress tracker.
-                    canModifyRight = false;
+                    result = normalized;
+                    result.Location = Location;
+                    return (result is not ErrorExpression);
                 }
             }
 
             var comparison = new ComparisonExpression(left, Operation, right);
-            do
+            if (comparison.Left.Type != comparison.Right.Type)
             {
-                if (comparison.Left.Type != comparison.Right.Type)
+                // attempt to find a common type to perform the comparison
+                var converter = comparison.Left as IUpconvertibleExpression;
+                var newLeft = (converter != null) ? converter.UpconvertTo(comparison.Right.Type) : null;
+                if (newLeft != null)
                 {
-                    // attempt to find a common type to perform the comparison
-                    var converter = comparison.Left as IUpconvertibleExpression;
-                    var newLeft = (converter != null) ? converter.UpconvertTo(comparison.Right.Type) : null;
-                    if (newLeft != null)
-                    {
-                        comparison = new ComparisonExpression(newLeft, comparison.Operation, comparison.Right);
-                    }
-                    else
-                    {
-                        converter = comparison.Right as IUpconvertibleExpression;
-                        var newRight = (converter != null) ? converter.UpconvertTo(comparison.Left.Type) : null;
-                        if (newRight != null)
-                            comparison = new ComparisonExpression(comparison.Left, comparison.Operation, newRight);
-                    }
+                    comparison = new ComparisonExpression(newLeft, comparison.Operation, comparison.Right);
                 }
-
-                var comparisonNormalize = comparison.Left as IComparisonNormalizeExpression;
-                if (comparisonNormalize == null)
-                    break;
-
-                var newComparison = comparisonNormalize.NormalizeComparison(comparison.Right, comparison.Operation, canModifyRight);
-                if (newComparison == null)
+                else
                 {
-                    // could not make any further normalizations, we're done
-                    break;
+                    converter = comparison.Right as IUpconvertibleExpression;
+                    var newRight = (converter != null) ? converter.UpconvertTo(comparison.Left.Type) : null;
+                    if (newRight != null)
+                        comparison = new ComparisonExpression(comparison.Left, comparison.Operation, newRight);
                 }
-
-                comparison = newComparison as ComparisonExpression;
-                if (comparison == null)
-                {
-                    // result of normalization is error or constant, return it
-                    result = newComparison;
-                    CopyLocation(result);
-                    return (result.Type != ExpressionType.Error);
-                }
-            } while (true);
+            }
 
             // if it's a memory comparison, wrap it in a RequirementClause
             switch (comparison.Left.Type)

--- a/Source/Parser/Expressions/ComparisonExpression.cs
+++ b/Source/Parser/Expressions/ComparisonExpression.cs
@@ -198,34 +198,26 @@ namespace RATools.Parser.Expressions
             switch (comparison.Left.Type)
             {
                 case ExpressionType.MemoryAccessor:
-                    var requirement = new RequirementConditionExpression
+                    result = new RequirementConditionExpression
                     {
                         Left = comparison.Left,
                         Comparison = comparison.Operation,
                         Right = comparison.Right,
                         Location = Location
                     };
-                    result = requirement.Normalize();
-                    if (result is ErrorExpression)
-                        return false;
-                    result.Location = Location;
                     return true;
             }
 
             switch (comparison.Right.Type)
             {
                 case ExpressionType.MemoryAccessor:
-                    var requirement = new RequirementConditionExpression
+                    result = new RequirementConditionExpression
                     {
                         Left = comparison.Right,
                         Comparison = ReverseComparisonOperation(comparison.Operation),
                         Right = comparison.Left,
                         Location = Location
                     };
-                    result = requirement.Normalize();
-                    if (result is ErrorExpression)
-                        return false;
-                    result.Location = Location;
                     return true;
             }
 

--- a/Source/Parser/Expressions/Trigger/BinaryCodedDecimalExpression.cs
+++ b/Source/Parser/Expressions/Trigger/BinaryCodedDecimalExpression.cs
@@ -35,7 +35,7 @@ namespace RATools.Parser.Expressions.Trigger
             if (result == null)
             {
                 if (context.LastRequirement.Left.Type != FieldType.MemoryAddress)
-                    return new ErrorExpression("cannot apply multiple modifiers to memory accessor", this);
+                    return new ErrorExpression("Cannot apply multiple modifiers to memory accessor", this);
 
                 context.LastRequirement.Left = context.LastRequirement.Left.ChangeType(FieldType.BinaryCodedDecimal);
             }

--- a/Source/Parser/Expressions/Trigger/BinaryCodedDecimalExpression.cs
+++ b/Source/Parser/Expressions/Trigger/BinaryCodedDecimalExpression.cs
@@ -37,7 +37,8 @@ namespace RATools.Parser.Expressions.Trigger
                 if (context.LastRequirement.Left.Type != FieldType.MemoryAddress)
                     return new ErrorExpression("Cannot apply multiple modifiers to memory accessor", this);
 
-                context.LastRequirement.Left = context.LastRequirement.Left.ChangeType(FieldType.BinaryCodedDecimal);
+                if (Field.GetMaxValue(context.LastRequirement.Left.Size) >= 0x10)
+                    context.LastRequirement.Left = context.LastRequirement.Left.ChangeType(FieldType.BinaryCodedDecimal);
             }
 
             return result;

--- a/Source/Parser/Expressions/Trigger/BitwiseInvertExpression.cs
+++ b/Source/Parser/Expressions/Trigger/BitwiseInvertExpression.cs
@@ -34,7 +34,7 @@ namespace RATools.Parser.Expressions.Trigger
             if (result == null)
             {
                 if (context.LastRequirement.Left.Type != FieldType.MemoryAddress)
-                    return new ErrorExpression("cannot apply multiple modifiers to memory accessor", this);
+                    return new ErrorExpression("Cannot apply multiple modifiers to memory accessor", this);
 
                 context.LastRequirement.Left = context.LastRequirement.Left.ChangeType(FieldType.Invert);
             }

--- a/Source/Parser/Expressions/Trigger/MeasuredRequirementExpression.cs
+++ b/Source/Parser/Expressions/Trigger/MeasuredRequirementExpression.cs
@@ -75,7 +75,8 @@ namespace RATools.Parser.Expressions.Trigger
             var whenOptimized = When.Optimize(context);
             var updated = !ReferenceEquals(whenOptimized, When);
 
-            var conditionOptimized = Condition.Optimize(context);
+            var comparison = Condition as RequirementConditionExpression;
+            var conditionOptimized = (comparison != null) ? comparison.Optimize(context, false) : Condition.Optimize(context);
             updated |= !ReferenceEquals(conditionOptimized, Condition);
 
             if (updated)

--- a/Source/Parser/Expressions/Trigger/MeasuredRequirementExpression.cs
+++ b/Source/Parser/Expressions/Trigger/MeasuredRequirementExpression.cs
@@ -75,8 +75,9 @@ namespace RATools.Parser.Expressions.Trigger
             var whenOptimized = When.Optimize(context);
             var updated = !ReferenceEquals(whenOptimized, When);
 
-            var comparison = Condition as RequirementConditionExpression;
-            var conditionOptimized = (comparison != null) ? comparison.Optimize(context, false) : Condition.Optimize(context);
+            var measuredContext = context.Clone();
+            measuredContext.CanModifyComparison = false;
+            var conditionOptimized = Condition.Optimize(measuredContext);
             updated |= !ReferenceEquals(conditionOptimized, Condition);
 
             if (updated)
@@ -115,12 +116,11 @@ namespace RATools.Parser.Expressions.Trigger
             {
                 // generate the subclause using a clean set of requirements in case we need to
                 // rearrange some stuff later
-                var oldRequirements = context.Trigger;
-                context.Trigger = requirements;
+                var measuredContext = context.Clone();
+                measuredContext.Trigger = requirements;
+                measuredContext.CanModifyComparison = false;
 
-                error = Condition.BuildSubclauseTrigger(context);
-
-                context.Trigger = oldRequirements;
+                error = Condition.BuildSubclauseTrigger(measuredContext);
             }
 
             if (error != null)

--- a/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
+++ b/Source/Parser/Expressions/Trigger/ModifiedMemoryAccessorExpression.cs
@@ -858,8 +858,20 @@ namespace RATools.Parser.Expressions.Trigger
                         {
                             case ComparisonOperation.Equal:
                             case ComparisonOperation.NotEqual:
-                                // "a / 2 == 3" is true for 6 and 7 so cannot be "a == 6"
-                                return null;
+                                if (((IntegerConstantExpression)right).Value == 0)
+                                {
+                                    // "a / 2 == 0" is true for 0 and 1 so we can make it "a < 2" by changing it to "a / 2 < 1".
+                                    // similary, "a / 2 != 0" can be "a >= 2" by changing it to "a / 2 >= 1".
+                                    operation = (operation == ComparisonOperation.Equal)
+                                        ? ComparisonOperation.LessThan : ComparisonOperation.GreaterThanOrEqual;
+                                    right = new IntegerConstantExpression(1);
+                                }
+                                else
+                                {
+                                    // "a / 2 == 3" is true for 6 and 7 so cannot be "a == 6"
+                                    return null;
+                                }
+                                break;
 
                             case ComparisonOperation.GreaterThan:
                                 // "a / 2 > 3" cannot be "a > 6" because 7 would qualify
@@ -869,8 +881,8 @@ namespace RATools.Parser.Expressions.Trigger
                                 break;
 
                             case ComparisonOperation.LessThanOrEqual:
-                                // "a / 2 <= 3" cannot be "a <= 6" because 7 should quality
-                                // but we cane make it "a < 8" by changing it to "a / 2 < 4"
+                                // "a / 2 <= 3" cannot be "a <= 6" because 7 should qualify
+                                // but we can make it "a < 8" by changing it to "a / 2 < 4"
                                 operation = ComparisonOperation.LessThan;
                                 right = new IntegerConstantExpression(((IntegerConstantExpression)right).Value + 1);
                                 break;

--- a/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
@@ -70,6 +70,47 @@ namespace RATools.Parser.Expressions.Trigger
                 Right == that.Right && Left == that.Left);
         }
 
+        public override RequirementExpressionBase Optimize(TriggerBuilderContext context)
+        {
+            return Optimize(context, true);
+        }
+
+        internal RequirementExpressionBase Optimize(TriggerBuilderContext context, bool canModifyRight)
+        {
+            var comparison = new ComparisonExpression(Left, Comparison, Right);
+            var originalComparison = comparison;
+            do
+            {
+                var comparisonNormalize = comparison.Left as IComparisonNormalizeExpression;
+                if (comparisonNormalize == null)
+                    break;
+
+                var newComparison = comparisonNormalize.NormalizeComparison(comparison.Right, comparison.Operation, canModifyRight);
+                if (newComparison == null)
+                {
+                    // could not make any further normalizations, we're done
+                    break;
+                }
+
+                comparison = newComparison as ComparisonExpression;
+                if (comparison == null)
+                    return ConvertToRequirementExpression(newComparison);
+            } while (true);
+
+            if (ReferenceEquals(comparison, originalComparison))
+                return this;
+
+            var requirement = new RequirementConditionExpression
+            {
+                Left = comparison.Left,
+                Comparison = comparison.Operation,
+                Right = comparison.Right,
+                Location = Location
+            };
+            requirement.MakeReadOnly();
+            return requirement;
+        }
+
         public override ErrorExpression BuildTrigger(TriggerBuilderContext context)
         {
             ErrorExpression error;
@@ -81,7 +122,8 @@ namespace RATools.Parser.Expressions.Trigger
             var rightAccessor = MemoryAccessorExpression.Extract(right);
             if (rightAccessor != null && rightAccessor.HasPointerChain)
             {
-                if (rightAccessor.PointerChainMatches(left as MemoryAccessorExpressionBase))
+                if (left is not ModifiedMemoryAccessorExpression &&
+                    rightAccessor.PointerChainMatches(left as MemoryAccessorExpressionBase))
                 {
                     rightAccessor = rightAccessor.Clone();
                     rightAccessor.ClearPointerChain();
@@ -90,7 +132,8 @@ namespace RATools.Parser.Expressions.Trigger
                 else
                 {
                     var leftMemoryValue = left as MemoryValueExpression;
-                    if (leftMemoryValue != null && leftMemoryValue.MemoryAccessors.All(m => m.ModifyingOperator != RequirementOperator.None))
+                    if (leftMemoryValue != null &&
+                        leftMemoryValue.MemoryAccessors.All(m => m.ModifyingOperator != RequirementOperator.None))
                     {
                         // all elements on left side are modified, so we'd need a 0 placeholder for the comparison
                         // attempt to avoid that by making the right value the AddSource element.
@@ -152,6 +195,14 @@ namespace RATools.Parser.Expressions.Trigger
                 return error;
 
             var lastRequirement = context.LastRequirement;
+            if (lastRequirement.Operator.IsModifier())
+            {
+                lastRequirement.Type = RequirementType.AddSource;
+
+                lastRequirement = new Requirement();
+                lastRequirement.Left = FieldFactory.CreateField(0);
+                context.Trigger.Add(lastRequirement);
+            }
 
             if (rightAccessor != null)
             {
@@ -268,7 +319,7 @@ namespace RATools.Parser.Expressions.Trigger
                 int newValue = 0;
                 int modifier = 0;
                 int value = integerExpression.Value;
-                while (value > 0)
+                while (value != 0)
                 {
                     newValue |= value % 10 << modifier;
                     modifier += 4;
@@ -306,7 +357,19 @@ namespace RATools.Parser.Expressions.Trigger
                     return null;
                 }
 
-                rightHasBCD = ConvertToBCD(Right, out newRight);
+                newRight = Right;
+                var rightConstant = newRight as IntegerConstantExpression;
+                if (rightConstant != null)
+                {
+                    var leftMemoryValue = newLeft as MemoryValueExpression;
+                    if (leftMemoryValue != null && leftMemoryValue.HasConstant)
+                    {
+                        newRight = rightConstant.Combine(leftMemoryValue.ExtractConstant(), MathematicOperation.Subtract);
+                        newLeft = leftMemoryValue.ClearConstant();
+                    }
+                }
+
+                rightHasBCD = ConvertToBCD(newRight, out newRight);
                 if (newRight == null)
                 {
                     // right value cannot be decoded into 32-bits
@@ -356,7 +419,7 @@ namespace RATools.Parser.Expressions.Trigger
                         return new ErrorExpression("Cannot eliminate bcd from equality comparison with modifier", leftMemoryValue);
                     }
 
-                    var rightMemoryValue = newLeft as MemoryValueExpression;
+                    var rightMemoryValue = newRight as MemoryValueExpression;
                     if (rightMemoryValue != null && rightMemoryValue.HasConstant)
                     {
                         result = null;

--- a/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
@@ -73,15 +73,10 @@ namespace RATools.Parser.Expressions.Trigger
 
         public override RequirementExpressionBase Optimize(TriggerBuilderContext context)
         {
-            return Optimize(context, true);
-        }
-
-        internal RequirementExpressionBase Optimize(TriggerBuilderContext context, bool canModifyRight)
-        {
             var comparison = new ComparisonExpression(Left, Comparison, Right);
             var originalComparison = comparison;
 
-            var normalized = Normalize();
+            var normalized = Normalize(context);
             if (!ReferenceEquals(normalized, this))
             {
                 var normalizedCondition = normalized as RequirementConditionExpression;
@@ -103,7 +98,7 @@ namespace RATools.Parser.Expressions.Trigger
                 if (comparisonNormalize == null)
                     break;
 
-                var newComparison = comparisonNormalize.NormalizeComparison(comparison.Right, comparison.Operation, canModifyRight);
+                var newComparison = comparisonNormalize.NormalizeComparison(comparison.Right, comparison.Operation, context.CanModifyComparison);
                 if (newComparison == null)
                 {
                     // could not make any further normalizations, we're done
@@ -133,7 +128,7 @@ namespace RATools.Parser.Expressions.Trigger
         {
             ErrorExpression error;
 
-            var normalized = Normalize();
+            var normalized = Normalize(context);
             if (!ReferenceEquals(normalized, this))
             {
                 error = normalized as ErrorExpression;
@@ -373,7 +368,7 @@ namespace RATools.Parser.Expressions.Trigger
             return false;
         }
 
-        private ErrorExpression NormalizeBCD(out RequirementExpressionBase result)
+        private ErrorExpression NormalizeBCD(TriggerBuilderContext context, out RequirementExpressionBase result)
         {
             ExpressionBase newLeft;
             ExpressionBase newRight;
@@ -439,7 +434,7 @@ namespace RATools.Parser.Expressions.Trigger
                 }
             }
 
-            if (leftHasBCD && rightHasBCD)
+            if (leftHasBCD && rightHasBCD && context.CanModifyComparison)
             {
                 if (Comparison == ComparisonOperation.Equal || Comparison == ComparisonOperation.NotEqual)
                 {
@@ -534,7 +529,7 @@ namespace RATools.Parser.Expressions.Trigger
             }
         }
 
-        private static void NormalizeLimits(ref RequirementExpressionBase expression)
+        private static void NormalizeLimits(TriggerBuilderContext context, ref RequirementExpressionBase expression)
         {
             var condition = expression as RequirementConditionExpression;
             if (condition == null)
@@ -702,19 +697,22 @@ namespace RATools.Parser.Expressions.Trigger
                 }
             }
 
-            if (newComparison != condition.Comparison || !ReferenceEquals(rightValue, condition.Right))
+            if (context.CanModifyComparison || ReferenceEquals(rightValue, condition.Right))
             {
-                expression = new RequirementConditionExpression
+                if (newComparison != condition.Comparison || !ReferenceEquals(rightValue, condition.Right))
                 {
-                    Left = condition.Left,
-                    Comparison = newComparison,
-                    Right = rightValue,
-                    Location = condition.Location
-                };
+                    expression = new RequirementConditionExpression
+                    {
+                        Left = condition.Left,
+                        Comparison = newComparison,
+                        Right = rightValue,
+                        Location = condition.Location
+                    };
+                }
             }
         }
 
-        public ExpressionBase Normalize()
+        public ExpressionBase Normalize(TriggerBuilderContext context)
         {
             if (_isNormalized)
                 return this;
@@ -727,7 +725,7 @@ namespace RATools.Parser.Expressions.Trigger
                     Comparison = ComparisonExpression.ReverseComparisonOperation(Comparison),
                     Right = Left
                 };
-                return reversed.Normalize();
+                return reversed.Normalize(context);
             }
 
             var integerRight = Right as IntegerConstantExpression;
@@ -746,7 +744,7 @@ namespace RATools.Parser.Expressions.Trigger
                         Comparison = ComparisonExpression.ReverseComparisonOperation(Comparison),
                         Right = integerConstant
                     };
-                    return normalized.Normalize();
+                    return normalized.Normalize(context);
                 }
             }
 
@@ -759,12 +757,12 @@ namespace RATools.Parser.Expressions.Trigger
             }
 
             RequirementExpressionBase result;
-            var error = NormalizeBCD(out result);
+            var error = NormalizeBCD(context, out result);
             if (error != null)
                 return error;
 
             NormalizeInvert(ref result);
-            NormalizeLimits(ref result);
+            NormalizeLimits(context, ref result);
 
             if (!ReferenceEquals(result, this))
                 CopyLocation(result);
@@ -890,7 +888,7 @@ namespace RATools.Parser.Expressions.Trigger
             condition.Comparison = ComparisonExpression.GetOppositeComparisonOperation(condition.Comparison);
 
             RequirementExpressionBase result = condition;
-            NormalizeLimits(ref result);
+            NormalizeLimits(new TriggerBuilderContext(), ref result);
             result.Location = Location;
             return result;
         }

--- a/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
+++ b/Source/Parser/Expressions/Trigger/RequirementConditionExpression.cs
@@ -26,6 +26,7 @@ namespace RATools.Parser.Expressions.Trigger
         public ExpressionBase Left { get; set; }
         public ComparisonOperation Comparison { get; set; }
         public ExpressionBase Right { get; set; }
+        private bool _isNormalized = false;
 
         ExpressionBase ICloneableExpression.Clone()
         {
@@ -79,6 +80,23 @@ namespace RATools.Parser.Expressions.Trigger
         {
             var comparison = new ComparisonExpression(Left, Comparison, Right);
             var originalComparison = comparison;
+
+            var normalized = Normalize();
+            if (!ReferenceEquals(normalized, this))
+            {
+                var normalizedCondition = normalized as RequirementConditionExpression;
+                if (normalizedCondition != null)
+                {
+                    comparison = new ComparisonExpression(normalizedCondition.Left, normalizedCondition.Comparison, normalizedCondition.Right);
+                }
+                else
+                {
+                    var requirementExpression = normalized as RequirementExpressionBase;
+                    if (requirementExpression != null)
+                        return requirementExpression.Optimize(context);
+                }
+            }
+
             do
             {
                 var comparisonNormalize = comparison.Left as IComparisonNormalizeExpression;
@@ -114,6 +132,19 @@ namespace RATools.Parser.Expressions.Trigger
         public override ErrorExpression BuildTrigger(TriggerBuilderContext context)
         {
             ErrorExpression error;
+
+            var normalized = Normalize();
+            if (!ReferenceEquals(normalized, this))
+            {
+                error = normalized as ErrorExpression;
+                if (error != null)
+                    return error;
+
+                var trigger = normalized as ITriggerExpression;
+                if (trigger != null)
+                    return trigger.BuildTrigger(context);
+            }
+
             var comparison = Comparison;
             var left = Left;
             var right = MemoryAccessorExpressionBase.ReduceToSimpleExpression(Right);
@@ -685,6 +716,9 @@ namespace RATools.Parser.Expressions.Trigger
 
         public ExpressionBase Normalize()
         {
+            if (_isNormalized)
+                return this;
+
             if (Left is LiteralConstantExpressionBase && Right is not LiteralConstantExpressionBase)
             {
                 var reversed = new RequirementConditionExpression
@@ -734,6 +768,11 @@ namespace RATools.Parser.Expressions.Trigger
 
             if (!ReferenceEquals(result, this))
                 CopyLocation(result);
+
+            var normalizedConditionExpression = result as RequirementConditionExpression;
+            if (normalizedConditionExpression != null)
+                normalizedConditionExpression._isNormalized = true;
+
             return result;
         }
 

--- a/Source/Parser/Functions/PrevPriorFunction.cs
+++ b/Source/Parser/Functions/PrevPriorFunction.cs
@@ -252,7 +252,7 @@ namespace RATools.Parser.Functions
             {
                 if (memoryAccessor.Modifier.Type != FieldType.MemoryAddress)
                 {
-                    error = new ErrorExpression("cannot apply multiple modifiers to memory accessor", memoryAccessor);
+                    error = new ErrorExpression("Cannot apply multiple modifiers to memory accessor", memoryAccessor);
                     return false;
                 }
 

--- a/Source/Parser/Internal/RequirementsOptimizer.cs
+++ b/Source/Parser/Internal/RequirementsOptimizer.cs
@@ -153,67 +153,6 @@ namespace RATools.Parser.Internal
             return null;
         }
 
-        private static uint DecToHex(uint dec)
-        {
-            uint hex = (dec % 10);
-            dec /= 10;
-            hex |= (dec % 10) << 4;
-            dec /= 10;
-            hex |= (dec % 10) << 8;
-            dec /= 10;
-            hex |= (dec % 10) << 12;
-            dec /= 10;
-            hex |= (dec % 10) << 16;
-            dec /= 10;
-            hex |= (dec % 10) << 20;
-            dec /= 10;
-            hex |= (dec % 10) << 24;
-            dec /= 10;
-            hex |= (dec % 10) << 28;
-            return hex;
-        }
-
-        private static bool? NormalizeBCD(Requirement requirement)
-        {
-            if (requirement.Left.Type == FieldType.BinaryCodedDecimal)
-            {
-                switch (requirement.Right.Type)
-                {
-                    case FieldType.BinaryCodedDecimal:
-                        /* both sides are being BCD decoded, can skip that step */
-                        requirement.Left = new Field { Size = requirement.Left.Size, Type = FieldType.MemoryAddress, Value = requirement.Left.Value };
-                        requirement.Right = new Field { Size = requirement.Right.Size, Type = FieldType.MemoryAddress, Value = requirement.Right.Value };
-                        break;
-
-                    case FieldType.Value:
-                        /* prevent overflow calling DecToHex - limits for smaller sizes will be enforced later
-                         * because DecToHex will return a value larger than the memory accessor can generate */
-                        var result = NormalizeComparisonMax(requirement, 99999999);
-                        if (result != null)
-                            return result;
-
-                        /* BCD comparison to constant - convert constant to avoid decoding overhead */
-                        requirement.Left = new Field { Size = requirement.Left.Size, Type = FieldType.MemoryAddress, Value = requirement.Left.Value };
-                        requirement.Right = new Field { Size = requirement.Right.Size, Type = FieldType.Value, Value = DecToHex(requirement.Right.Value) };
-                        break;
-
-                    default:
-                        /* cannot normalize BCD comparison */
-                        break;
-                }
-
-                /* BCD decode of anything smaller than 4 bits has no effect */
-                if (requirement.Left.Type == FieldType.BinaryCodedDecimal && Field.GetMaxValue(requirement.Left.Size) < 16)
-                    requirement.Left = new Field { Size = requirement.Left.Size, Type = FieldType.MemoryAddress, Value = requirement.Left.Value };
-            }
-
-            /* BCD decode of anything smaller than 4 bits has no effect */
-            if (requirement.Right.Type == FieldType.BinaryCodedDecimal && Field.GetMaxValue(requirement.Right.Size) < 16)
-                requirement.Right = new Field { Size = requirement.Right.Size, Type = FieldType.MemoryAddress, Value = requirement.Right.Value };
-
-            return null;
-        }
-
         private static void NormalizeComparisons(IList<RequirementEx> requirements, bool forSubclause)
         {
             var alwaysTrue = new List<RequirementEx>();
@@ -228,9 +167,7 @@ namespace RATools.Parser.Internal
                 var requirement = requirementEx.Requirements[0];
 
                 // see if the requirement can be simplified down to an always_true() or always_false().
-                var result = NormalizeBCD(requirement);
-                if (result == null)
-                    result = requirement.Evaluate();
+                var result = requirement.Evaluate();
                 if (result == null)
                     result = NormalizeLimits(requirement, forSubclause);
 

--- a/Source/Parser/Internal/TriggerBuilderContext.cs
+++ b/Source/Parser/Internal/TriggerBuilderContext.cs
@@ -11,6 +11,11 @@ namespace RATools.Parser.Internal
 {
     internal class TriggerBuilderContext
     {
+        public TriggerBuilderContext()
+        {
+            CanModifyComparison = true;
+        }
+
         /// <summary>
         /// Gets the collection of requirements that forms the trigger.
         /// </summary>
@@ -33,6 +38,27 @@ namespace RATools.Parser.Internal
         /// Gets the last Remembered expression.
         /// </summary>
         public MemoryValueExpression RememberedValue { get; internal set; }
+
+        /// <summary>
+        /// If set to <c>false</c>, the comparison target is important and should not
+        /// be modified even if it simplies the resulting logic.
+        /// </summary>
+        public bool CanModifyComparison { get; set; }
+
+        public virtual TriggerBuilderContext Clone()
+        {
+            var clone = new TriggerBuilderContext();
+            CloneInto(clone);
+            return clone;
+        }
+
+        protected void CloneInto(TriggerBuilderContext clone)
+        {
+            clone.Trigger = this.Trigger;
+            clone.MinimumVersion = this.MinimumVersion;
+            clone.RememberedValue = this.RememberedValue;
+            clone.CanModifyComparison = this.CanModifyComparison;
+        }
 
         [DebuggerDisplay("{field} * {Multiplier}")]
         private class Term
@@ -65,7 +91,7 @@ namespace RATools.Parser.Internal
             }
         }
 
-        private static ExpressionBase WrapInMeasured(ExpressionBase expression)
+        private static FunctionCallExpression WrapInMeasured(ExpressionBase expression)
         {
             return new FunctionCallExpression("measured", new ExpressionBase[]
             {
@@ -586,6 +612,12 @@ namespace RATools.Parser.Internal
     /// </summary>
     internal class ValueBuilderContext : TriggerBuilderContext
     {
+        public override TriggerBuilderContext Clone()
+        {
+            var clone = new ValueBuilderContext();
+            CloneInto(clone);
+            return clone;
+        }
     }
 
     /// <summary>
@@ -593,5 +625,11 @@ namespace RATools.Parser.Internal
     /// </summary>
     internal class TallyBuilderContext : TriggerBuilderContext
     {
+        public override TriggerBuilderContext Clone()
+        {
+            var clone = new TallyBuilderContext();
+            CloneInto(clone);
+            return clone;
+        }
     }
 }

--- a/Tests/Parser/Expressions/ComparisonExpressionTests.cs
+++ b/Tests/Parser/Expressions/ComparisonExpressionTests.cs
@@ -31,20 +31,9 @@ namespace RATools.Parser.Tests.Expressions
         [Test]
         [TestCase("byte(1) > variable2", "byte(0x000001) > 99")] // simple variable substitution
         [TestCase("variable1 > variable2", "false")] // evaluates to a constant
-        [TestCase("byte(1) * 10 / 3 == 10", "remembered(byte(0x000001) * 10) / 3 == 10")] // integer division ignores remainder, multiple values could be result in equality
-        [TestCase("byte(1) * 10 + 10 == 100", "byte(0x000001) == 9")] // factor out multiplication and addition
-        [TestCase("byte(1) * 10 - 10 == 100", "byte(0x000001) == 11")] // factor out multiplication and subtraction
-        [TestCase("(byte(1) - 1) * 10 == 100", "byte(0x000001) == 11")] // factor out multiplication and subtraction
-        [TestCase("(byte(1) - 1) / 10 == 10", "remembered(byte(0x000001) - 1) / 10 == 10")] // integer division ignores remainder, multiple values could be result in equality
-        [TestCase("(byte(1) - 1) / 10 > 10", "byte(0x000001) >= 111")] // factor out division and subtraction
-        [TestCase("(byte(1) - 1) * 10 < 99", "byte(0x000001) <= 10")] // factor out multiplication and subtraction
-        [TestCase("byte(1) + variable1 < byte(2) + 3", "byte(0x000001) + 95 < byte(0x000002)")] // differing modifier should be merged
-        [TestCase("byte(2) + 1 == variable1", "byte(0x000002) == 97")] // differing modifier should be merged
-        [TestCase("variable1 == byte(2) + 1", "byte(0x000002) == 97")] // differing modifier should be merged, move constant to right side
-        [TestCase("0 + byte(1) + 0 == 9", "byte(0x000001) == 9")] // 0s should be removed without reordering
-        [TestCase("0 + byte(1) - 9 == 0", "byte(0x000001) == 9")] // 9 should be moved to right hand side, then 0s removed
-        [TestCase("bcd(byte(1)) == 24", "byte(0x000001) == 36")] // bcd should be factored out
-        [TestCase("byte(1) != bcd(byte(2))", "byte(0x000001) != bcd(byte(0x000002))")] // bcd cannot be factored out
+        [TestCase("byte(1) + variable1 < byte(2) + 3", "byte(0x000001) + 98 < byte(0x000002) + 3")] // differing modifier should be merged
+        [TestCase("byte(2) + 1 == variable1", "byte(0x000002) + 1 == 98")] // differing modifier should be merged
+        [TestCase("variable1 == byte(2) + 1", "byte(0x000002) + 1 == 98")] // differing modifier should be merged, move constant to right side
         public void TestReplaceVariables(string input, string expected)
         {
             var tokenizer = Tokenizer.CreateTokenizer(input);
@@ -306,6 +295,7 @@ namespace RATools.Parser.Tests.Expressions
 
             Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
             Assert.That(result, Is.InstanceOf<RequirementConditionExpression>());
+            result = ((RequirementConditionExpression)result).Optimize(new TriggerBuilderContext());
 
             var builder = new StringBuilder();
             result.AppendString(builder);
@@ -326,6 +316,7 @@ namespace RATools.Parser.Tests.Expressions
 
             Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
             Assert.That(result, Is.InstanceOf<RequirementConditionExpression>());
+            result = ((RequirementConditionExpression)result).Optimize(new TriggerBuilderContext());
 
             var builder = new StringBuilder();
             result.AppendString(builder);
@@ -343,6 +334,7 @@ namespace RATools.Parser.Tests.Expressions
 
             Assert.That(expr.ReplaceVariables(scope, out result), Is.True);
             Assert.That(result, Is.InstanceOf<RequirementConditionExpression>());
+            result = ((RequirementConditionExpression)result).Optimize(new TriggerBuilderContext());
 
             var builder = new StringBuilder();
             result.AppendString(builder);

--- a/Tests/Parser/Expressions/Trigger/MemoryAccessorExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/MemoryAccessorExpressionTests.cs
@@ -45,6 +45,13 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             "K:0x 002345&1023_A:{recall}*8_K:0xX001234_I:{recall}_0xX000004")]
         [TestCase("byte(0x3B0038 - ((dword_be(0x3180) & 0x15) / (dword_be(0x3180) & 0x15)) * 0x4C068)",
             "K:0xG003180&21_K:{recall}/{recall}_I:{recall}*4294655896_0xH3b0038")]
+        [TestCase("bcd(byte(0x1234))", "b0xH001234")]
+        [TestCase("bcd(word(0x1234))", "b0x 001234")]
+        [TestCase("bcd(dword(0x1234))", "b0xX001234")]
+        [TestCase("bcd(low4(0x1234))", "0xL001234")] // bcd redundant on low4
+        [TestCase("bcd(high4(0x1234))", "0xU001234")] // bcd redundant on high4
+        [TestCase("bcd(bit0(0x1234))", "0xM001234")] // bcd redudant on bit sizes
+        [TestCase("bcd(bit7(0x1234))", "0xT001234")] // bcd redudant on bit sizes
         public void TestBuildTrigger(string input, string expected)
         {
             var accessor = TriggerExpressionTests.Parse<MemoryAccessorExpression>(input);

--- a/Tests/Parser/Expressions/Trigger/RequirementClauseExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementClauseExpressionTests.cs
@@ -35,6 +35,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("always_true() || byte(0x001234) == 0", "1=1")] // always_true() makes everything else redundant
         [TestCase("always_true() || never(byte(0x001234) == 0)", "R:0xH001234=0")] // discard always_true() when reset is kept
         [TestCase("always_true() || unless(byte(0x001234) == 0)", "1=1")] // always_true() makes everything else redundant
+        [TestCase("(byte(1) == 1 && always_false()) || byte(2) == 2", "0xH000002=2")] // always_false() eliminates entire first clause
         public void TestBuildTrigger(string input, string expected)
         {
             var clause = TriggerExpressionTests.Parse<RequirementClauseExpression>(input);

--- a/Tests/Parser/Expressions/Trigger/RequirementClauseExpressionTests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementClauseExpressionTests.cs
@@ -36,6 +36,9 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("always_true() || never(byte(0x001234) == 0)", "R:0xH001234=0")] // discard always_true() when reset is kept
         [TestCase("always_true() || unless(byte(0x001234) == 0)", "1=1")] // always_true() makes everything else redundant
         [TestCase("(byte(1) == 1 && always_false()) || byte(2) == 2", "0xH000002=2")] // always_false() eliminates entire first clause
+        [TestCase("byte(1) > prev(byte(1)) && byte(1) - prev(byte(1)) > 0", "0xH000001>d0xH000001")] // second clause becomes first clause
+        [TestCase("byte(1) > prev(byte(1)) && byte(1) - prev(byte(1)) == 2", "0xH000001>d0xH000001_B:d0xH000001=0_0xH000001=2")] // equality will use subsource
+        [TestCase("byte(1) > prev(byte(1)) && byte(1) - prev(byte(1)) > 2", "0xH000001>d0xH000001_A:2=0_d0xH000001<0xH000001")] // inequality has to use addsource to avoid underflow
         public void TestBuildTrigger(string input, string expected)
         {
             var clause = TriggerExpressionTests.Parse<RequirementClauseExpression>(input);

--- a/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
@@ -85,6 +85,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("(byte(1) - 1) / 10 == 10", "B:1_K:0xH000001_A:{recall}/10_0=10")] // integer division ignores remainder, multiple values could be result in equality
         [TestCase("(byte(1) - 1) / 10 > 10", "0xH000001>=111")] // factor out division and subtraction
         [TestCase("(byte(1) - 1) * 10 < 99", "0xH000001<=10")] // factor out multiplication and subtraction
+        [TestCase("byte(1) / 10 <= 0", "0xH000001<10")] // a/n<=x -> a/n<x+1 -> a<n*(x+1)
         [TestCase("0 + byte(1) + 0 == 9", "0xH000001=9")] // 0s should be removed without reordering
         [TestCase("0 + byte(1) - 9 == 0", "0xH000001=9")] // 9 should be moved to right hand side, then 0s removed
         [TestCase("bcd(byte(1)) == 24", "0xH000001=36")] // bcd should be factored out

--- a/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
@@ -92,6 +92,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("byte(0x000001) + 98 < byte(0x000002) + 3", "A:95=0_0xH000001<0xH000002")] // differing modifier should be merged
         [TestCase("byte(0x000001) + 1 == 98", "0xH000001=97")] // differing modifier should be merged
         [TestCase("98 == byte(0x000001) + 1", "0xH000001=97")] // differing modifier should be merged
+        [TestCase("prev(bcd(tbyte(0x60d)) * 10) < 100000", "d0xW00060d<65536")] // optimize will eliminate the *10, then normalize will eliminate the BCD
         public void TestBuildTrigger(string input, string expected)
         {
             var clause = TriggerExpressionTests.Parse<RequirementConditionExpression>(input);
@@ -171,7 +172,6 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("prev(bcd(byte(1)) - 1) == 14", "prev(byte(0x000001)) == 21")]
         [TestCase("prev(bcd(byte(1)) - 1) == 19", "prev(byte(0x000001)) == 32")]
         [TestCase("prev(bcd(byte(1))) - 1 >= 19", "prev(byte(0x000001)) >= 32")]
-        [TestCase("bcd(byte(1)) >= prev(bcd(byte(1))) + 10", "byte(0x000001) >= prev(byte(0x000001)) + 16")]
         public void TestNormalizeBCD(string input, string expected)
         {
             var result = TriggerExpressionTests.Parse(input);
@@ -184,12 +184,10 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         }
 
         [Test]
-        // bcd adjustment cannot be applied after adjustment
-        [TestCase("prev(bcd(byte(1) - 1)) >= 19", "Cannot apply bcd() to a modified memory accessor")]
         [TestCase("bcd(byte(1)) == prev(bcd(byte(1))) + 10", "Cannot eliminate bcd from equality comparison with modifier")]
         public void TestNormalizeBCDError(string input, string expectedError)
         {
-            TriggerExpressionTests.AssertParseError(input, expectedError);
+            TriggerExpressionTests.AssertBuildTriggerError(input, expectedError);
         }
 
         [Test]
@@ -272,7 +270,9 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             // becomes "prev(byte(0x1234)) == -10", which can never be true
             // user meant "prev(byte(0x1234 + 10)) == 0"
 
-            TriggerExpressionTests.Parse<AlwaysFalseExpression>(input);
+            var clause = TriggerExpressionTests.Parse<RequirementConditionExpression>(input);
+            var normalized = clause.Normalize();
+            Assert.That(normalized, Is.InstanceOf<AlwaysFalseExpression>());
         }
 
         [Test]

--- a/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
@@ -149,7 +149,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
 
             var condition = result as RequirementConditionExpression;
             if (condition != null)
-                result = condition.Normalize();
+                result = condition.Normalize(new TriggerBuilderContext());
 
             ExpressionTests.AssertAppendString(result, expected);
         }
@@ -179,7 +179,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
 
             var condition = result as RequirementConditionExpression;
             if (condition != null)
-                result = condition.Normalize();
+                result = condition.Normalize(new TriggerBuilderContext());
 
             ExpressionTests.AssertAppendString(result, expected);
         }
@@ -213,7 +213,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
 
             var condition = result as RequirementConditionExpression;
             if (condition != null)
-                result = condition.Normalize();
+                result = condition.Normalize(new TriggerBuilderContext());
 
             ExpressionTests.AssertAppendString(result, expected);
         }
@@ -272,7 +272,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             // user meant "prev(byte(0x1234 + 10)) == 0"
 
             var clause = TriggerExpressionTests.Parse<RequirementConditionExpression>(input);
-            var normalized = clause.Normalize();
+            var normalized = clause.Normalize(new TriggerBuilderContext());
             Assert.That(normalized, Is.InstanceOf<AlwaysFalseExpression>());
         }
 

--- a/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
+++ b/Tests/Parser/Expressions/Trigger/RequirementConditionExpression_Tests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using RATools.Parser.Expressions;
 using RATools.Parser.Expressions.Trigger;
+using RATools.Parser.Internal;
 
 namespace RATools.Parser.Tests.Expressions.Trigger
 {
@@ -77,6 +78,20 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             "K:0xH001234*0xH002345_A:{recall}*0xH003456_0=99")]
         [TestCase("byte(0x1234) * byte(0x2345) * byte(0x3456) * byte(0x4567) == 99",
             "K:0xH001234*0xH002345_K:{recall}*0xH003456_A:{recall}*0xH004567_0=99")]
+        [TestCase("byte(1) * 10 / 3 == 10", "K:0xH000001*10_A:{recall}/3_0=10")] // integer division ignores remainder, multiple values could be result in equality
+        [TestCase("byte(1) * 10 + 10 == 100", "0xH000001=9")] // factor out multiplication and addition
+        [TestCase("byte(1) * 10 - 10 == 100", "0xH000001=11")] // factor out multiplication and subtraction
+        [TestCase("(byte(1) - 1) * 10 == 100", "0xH000001=11")] // factor out multiplication and subtraction
+        [TestCase("(byte(1) - 1) / 10 == 10", "B:1_K:0xH000001_A:{recall}/10_0=10")] // integer division ignores remainder, multiple values could be result in equality
+        [TestCase("(byte(1) - 1) / 10 > 10", "0xH000001>=111")] // factor out division and subtraction
+        [TestCase("(byte(1) - 1) * 10 < 99", "0xH000001<=10")] // factor out multiplication and subtraction
+        [TestCase("0 + byte(1) + 0 == 9", "0xH000001=9")] // 0s should be removed without reordering
+        [TestCase("0 + byte(1) - 9 == 0", "0xH000001=9")] // 9 should be moved to right hand side, then 0s removed
+        [TestCase("bcd(byte(1)) == 24", "0xH000001=36")] // bcd should be factored out
+        [TestCase("byte(1) != bcd(byte(2))", "0xH000001!=b0xH000002")] // bcd cannot be factored out
+        [TestCase("byte(0x000001) + 98 < byte(0x000002) + 3", "A:95=0_0xH000001<0xH000002")] // differing modifier should be merged
+        [TestCase("byte(0x000001) + 1 == 98", "0xH000001=97")] // differing modifier should be merged
+        [TestCase("98 == byte(0x000001) + 1", "0xH000001=97")] // differing modifier should be merged
         public void TestBuildTrigger(string input, string expected)
         {
             var clause = TriggerExpressionTests.Parse<RequirementConditionExpression>(input);
@@ -156,7 +171,7 @@ namespace RATools.Parser.Tests.Expressions.Trigger
         [TestCase("prev(bcd(byte(1)) - 1) == 14", "prev(byte(0x000001)) == 21")]
         [TestCase("prev(bcd(byte(1)) - 1) == 19", "prev(byte(0x000001)) == 32")]
         [TestCase("prev(bcd(byte(1))) - 1 >= 19", "prev(byte(0x000001)) >= 32")]
-        [TestCase("bcd(byte(1)) >= prev(bcd(byte(1))) + 10", "prev(byte(0x000001)) + 16 <= byte(0x000001)")]
+        [TestCase("bcd(byte(1)) >= prev(bcd(byte(1))) + 10", "byte(0x000001) >= prev(byte(0x000001)) + 16")]
         public void TestNormalizeBCD(string input, string expected)
         {
             var result = TriggerExpressionTests.Parse(input);
@@ -243,10 +258,11 @@ namespace RATools.Parser.Tests.Expressions.Trigger
             input = input.Replace("WB", "word(0x2345)");
 
             var clause = TriggerExpressionTests.Parse<RequirementConditionExpression>(input);
+            var optimized = clause.Optimize(new TriggerBuilderContext());
 
             expected = expected.Replace("WA", "word(0x001234)");
             expected = expected.Replace("WB", "word(0x002345)");
-            ExpressionTests.AssertAppendString(clause, expected);
+            ExpressionTests.AssertAppendString(optimized, expected);
         }
 
         [Test]

--- a/Tests/Parser/Functions/AchievementFunctionTests.cs
+++ b/Tests/Parser/Functions/AchievementFunctionTests.cs
@@ -330,5 +330,22 @@ namespace RATools.Parser.Tests.Functions
                 "- 1:23 15 is not a supported value for points"
             );
         }
+
+        [Test]
+        public void TestMeasuredFunc()
+        {
+            var achievement = Evaluate(
+                "counter = word(0x1234) / 64 >= 100\r\n" +
+                "achievement(\"t\", \"d\", 5, measured(counter))");
+            var builder = new AchievementBuilder(achievement);
+            Assert.That(builder.SerializeRequirements(new SerializationContext()),
+                Is.EqualTo("A:0x 001234/64_M:0>=100"));
+
+            var achievement2 = Evaluate(
+                "achievement(\"t\", \"d\", 5, measured(word(0x1234) / 64 >= 100))");
+            var builder2 = new AchievementBuilder(achievement2);
+            Assert.That(builder2.SerializeRequirements(new SerializationContext()),
+                Is.EqualTo("A:0x 001234/64_M:0>=100"));
+        }
     }
 }

--- a/Tests/Parser/Functions/MeasuredFunctionTests.cs
+++ b/Tests/Parser/Functions/MeasuredFunctionTests.cs
@@ -62,6 +62,7 @@ namespace RATools.Parser.Tests.Functions
         [TestCase("measured(byte(0x1234) - 6 >= 100, format=\"percent\")", "B:6_G:0xH001234>=100")] // measurements include adjustment so target is unchanged
         [TestCase("measured(tally(2, byte(0x1234) == 120, byte(0x1234) == 126))", "C:0xH001234=120_M:0xH001234=126.2.")]
         [TestCase("measured(bitcount(0x1234) == 8)", "M:0xK001234=8")] // should not be optimized to byte=255
+        [TestCase("measured(bcd(byte(0x1234)) == 15)", "M:b0xH001234=15")] // should not be optimized to byte=21
         [TestCase("measured(byte(0x1234) + (60 - byte(0x2345)) * 100 / 60 == 9)",
             "K:0xH002345*100_B:{recall}/60_A:100_M:0xH001234=9")]
         public void TestBuildTrigger(string input, string expected)

--- a/Tests/Parser/Functions/OnceFunctionTests.cs
+++ b/Tests/Parser/Functions/OnceFunctionTests.cs
@@ -40,6 +40,7 @@ namespace RATools.Parser.Tests.Functions
         [TestCase("once(((byte(0x1234) == 1 && byte(0x2345) == 2) || byte(0x3456) == 3) && never(byte(0x4567) == 4 && byte(0x5678) == 5))",
             "N:0xH004567=4_Z:0xH005678=5_N:0xH001234=1_O:0xH002345=2_0xH003456=3.1.")]
         [TestCase("once(bit3(0x1234) < prev(bit3(0x1234)) && never(repeated(3, bit3(0x1234) == 0)))", "Z:0xP001234=0.3._0xP001234<d0xP001234.1.")]
+        [TestCase("once((byte(1) == 1 && byte(1) == 300) || byte(2) == 2)", "0xH000002=2.1.")] // byte(1) == 300 is impossible, which eliminates the entire first clause
         public void TestBuildTrigger(string input, string expected)
         {
             var clause = TriggerExpressionTests.Parse<TalliedRequirementExpression>(input);

--- a/Tests/Parser/Functions/PrevPriorFunctionTests.cs
+++ b/Tests/Parser/Functions/PrevPriorFunctionTests.cs
@@ -88,7 +88,10 @@ namespace RATools.Parser.Tests.Functions
 
             // bcd cannot be factored out
             var parser = Parse("achievement(\"T\", \"D\", 5, prev(bcd(byte(0x1234))) != byte(0x1234))", false);
-            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:26 cannot apply multiple modifiers to memory accessor"));
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:26 Cannot apply multiple modifiers to memory accessor"));
+
+            parser = Parse("achievement(\"T\", \"D\", 5, prev(bcd(byte(1) - 1)) >= 19)", false);
+            Assert.That(GetInnerErrorMessage(parser), Is.EqualTo("1:35 Cannot apply bcd() to a modified memory accessor"));
         }
 
         [Test]

--- a/Tests/Parser/Internal/RequirementsOptimizerTests.cs
+++ b/Tests/Parser/Internal/RequirementsOptimizerTests.cs
@@ -91,8 +91,6 @@ namespace RATools.Parser.Tests.Internal
         [TestCase("bcd(dword(0x1234)) == 100000000", "always_false()")] // BCD of a dword cannot exceed 99999999
         [TestCase("bcd(byte(0x1234)) == bcd(byte(0x2345))", "byte(0x001234) == byte(0x002345)")] // BCD can be removed from both sides of the comparison
         [TestCase("bcd(byte(0x1234)) == byte(0x2345)", "bcd(byte(0x001234)) == byte(0x002345)")] // BCD cannot be removed when comparing to another memory address
-        [TestCase("bcd(low4(0x1234)) == low4(0x2345)", "low4(0x001234) == low4(0x002345)")] // BCD can be removed for memory accessors of 4 bits or less
-        [TestCase("low4(0x1234) == bcd(low4(0x2345))", "low4(0x001234) == low4(0x002345)")] // BCD can be removed for memory accessors of 4 bits or less
         [TestCase("bcd(low4(0x1234)) == 6", "low4(0x001234) == 6")] // BCD can be removed for memory accessors of 4 bits or less
         [TestCase("bcd(low4(0x1234)) == 10", "always_false()")] // BCD of a nummber cannot exceed 9
         // ==== NormalizeComparisons ===


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/936655398725902356/1508474639322452179

Comparisons were being optimized on assignment, which prevented the `measured()` function from detecting the intended measure target when the comparison was constructed in a variable.
